### PR TITLE
feat: Integrate Photo Compression to webp

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,15 +2,37 @@ PODS:
   - camera_avfoundation (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_image_compress_common (1.0.0):
+    - Flutter
+    - Mantle
+    - SDWebImage
+    - SDWebImageWebPCoder
   - flutter_keyboard_visibility (0.0.1):
     - Flutter
   - flutter_secure_storage (6.0.0):
+    - Flutter
+  - image_compression_flutter (1.0.0):
     - Flutter
   - image_cropper (0.0.4):
     - Flutter
     - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
+  - libwebp (1.3.2):
+    - libwebp/demux (= 1.3.2)
+    - libwebp/mux (= 1.3.2)
+    - libwebp/sharpyuv (= 1.3.2)
+    - libwebp/webp (= 1.3.2)
+  - libwebp/demux (1.3.2):
+    - libwebp/webp
+  - libwebp/mux (1.3.2):
+    - libwebp/demux
+  - libwebp/sharpyuv (1.3.2)
+  - libwebp/webp (1.3.2):
+    - libwebp/sharpyuv
+  - Mantle (2.2.0):
+    - Mantle/extobjc (= 2.2.0)
+  - Mantle/extobjc (2.2.0)
   - MTBBarcodeScanner (5.0.11)
   - passkeys_ios (0.0.1):
     - Flutter
@@ -27,6 +49,12 @@ PODS:
     - MTBBarcodeScanner
   - quill_native_bridge (0.0.1):
     - Flutter
+  - SDWebImage (5.19.7):
+    - SDWebImage/Core (= 5.19.7)
+  - SDWebImage/Core (5.19.7)
+  - SDWebImageWebPCoder (0.14.6):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.17)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -47,8 +75,10 @@ PODS:
 DEPENDENCIES:
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - Flutter (from `Flutter`)
+  - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - image_compression_flutter (from `.symlinks/plugins/image_compression_flutter/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - passkeys_ios (from `.symlinks/plugins/passkeys_ios/ios`)
@@ -66,7 +96,11 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - libwebp
+    - Mantle
     - MTBBarcodeScanner
+    - SDWebImage
+    - SDWebImageWebPCoder
     - TOCropViewController
 
 EXTERNAL SOURCES:
@@ -74,10 +108,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/camera_avfoundation/ios"
   Flutter:
     :path: Flutter
+  flutter_image_compress_common:
+    :path: ".symlinks/plugins/flutter_image_compress_common/ios"
   flutter_keyboard_visibility:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  image_compression_flutter:
+    :path: ".symlinks/plugins/image_compression_flutter/ios"
   image_cropper:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
@@ -110,10 +148,14 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  image_compression_flutter: 5327fc5ee43f5ee6107d44ff0d4480a363788358
   image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
+  Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
@@ -121,6 +163,8 @@ SPEC CHECKSUMS:
   photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   quill_native_bridge: e5afa7d49c08cf68c52a5e23bc272eba6925c622
+  SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
+  SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec

--- a/lib/app/services/media_service/media_service.dart
+++ b/lib/app/services/media_service/media_service.dart
@@ -100,5 +100,5 @@ class MediaService {
 
 @riverpod
 MediaService mediaService(MediaServiceRef ref) => MediaService(
-      ref.read(photoCompressService),
+      ref.read(photoCompressServiceProvider),
     );

--- a/lib/app/services/media_service/photo_compress_service.dart
+++ b/lib/app/services/media_service/photo_compress_service.dart
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:image_compression_flutter/image_compression_flutter.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+abstract class IPhotoCompressService {
+  Future<XFile> compressImage(XFile file, {int quality});
+
+  String generateCompressedFilePath(String filePath) {
+    final fileName = filePath.split('/').last;
+    final directory = filePath.substring(0, filePath.lastIndexOf('/'));
+
+    if (fileName.contains('.')) {
+      final extension = fileName.split('.').last;
+      final nameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'));
+      return '$directory/${nameWithoutExtension}_compressed.$extension';
+    } else {
+      return '$directory/${fileName}_compressed';
+    }
+  }
+}
+
+class PhotoCompressService extends IPhotoCompressService {
+  @override
+  Future<XFile> compressImage(XFile file, {int quality = 80}) async {
+    final config = ImageFileConfiguration(
+      input: ImageFile(
+        filePath: file.path,
+        rawBytes: await file.readAsBytes(),
+      ),
+      config: Configuration(
+        quality: quality,
+      ),
+    );
+
+    final output = await compressor.compress(config);
+
+    final newPath = generateCompressedFilePath(file.path);
+
+    final compressedFile = XFile.fromData(output.rawBytes);
+
+    await compressedFile.saveTo(newPath);
+
+    return XFile(newPath);
+  }
+}
+
+@riverpod
+final photoCompressService = Provider<IPhotoCompressService>((ref) {
+  return PhotoCompressService();
+});

--- a/lib/app/services/media_service/photo_compress_service.dart
+++ b/lib/app/services/media_service/photo_compress_service.dart
@@ -3,6 +3,8 @@
 import 'package:image_compression_flutter/image_compression_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+part 'photo_compress_service.g.dart';
+
 abstract class IPhotoCompressService {
   Future<XFile> compressImage(XFile file, {int quality});
 
@@ -46,6 +48,4 @@ class PhotoCompressService extends IPhotoCompressService {
 }
 
 @riverpod
-final photoCompressService = Provider<IPhotoCompressService>((ref) {
-  return PhotoCompressService();
-});
+IPhotoCompressService photoCompressService(PhotoCompressServiceRef ref) => PhotoCompressService();

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <image_compression_flutter/image_compression_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) image_compression_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ImageCompressionFlutterPlugin");
+  image_compression_flutter_plugin_register_with_registrar(image_compression_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
+  image_compression_flutter
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import file_selector_macos
+import flutter_image_compress_macos
 import flutter_secure_storage_macos
+import image_compression_flutter
 import path_provider_foundation
 import photo_manager
 import share_plus
@@ -17,7 +19,9 @@ import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  ImageCompressionFlutterPlugin.register(with: registry.registrar(forPlugin: "ImageCompressionFlutterPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,6 +611,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  flutter_image_compress:
+    dependency: transitive
+    description:
+      name: flutter_image_compress
+      sha256: "45a3071868092a61b11044c70422b04d39d4d9f2ef536f3c5b11fb65a1e7dd90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  flutter_image_compress_common:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_common
+      sha256: "7f79bc6c8a363063620b4e372fa86bc691e1cb28e58048cd38e030692fbd99ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_macos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_macos
+      sha256: "26df6385512e92b3789dc76b613b54b55c457a7f1532e59078b04bf189782d47"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  flutter_image_compress_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_platform_interface
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_web:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_web
+      sha256: f02fe352b17f82b72f481de45add240db062a2585850bea1667e82cc4cd6c311
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4+1"
   flutter_keyboard_visibility:
     dependency: "direct main"
     description:
@@ -914,6 +962,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  image_compression:
+    dependency: transitive
+    description:
+      name: image_compression
+      sha256: "0ab2ad255fc3877c0e425a3f46796b2872806c1d7260207ec72b723975f6f3e0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  image_compression_flutter:
+    dependency: "direct main"
+    description:
+      name: image_compression_flutter
+      sha256: "0d7fc5d37bb69996285dd57342b3a37ad92fa4bb0616484af084ec924d6818b4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   image_cropper:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   go_router: ^14.2.0
   hooks_riverpod: ^2.5.1
+  image_compression_flutter: ^1.0.4
   image_cropper: ^8.0.2
   image_picker: ^1.1.2
   intl: any

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <image_compression_flutter/image_compression_flutter_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -17,6 +18,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  ImageCompressionFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ImageCompressionFlutterPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   flutter_secure_storage_windows
+  image_compression_flutter
   permission_handler_windows
   share_plus
   url_launcher_windows


### PR DESCRIPTION
### What does this PR do?
This PR contains service to compress photo to webp. It runs on native pool so we do not need to run in isolate.

Sample Test Result
> flutter: Original size: 1785250 bytes
> flutter: Compressed size: 119004 bytes
> flutter: Compressed to 6.67% of original size

### Changes brought by this PR
- Add `image_compression_flutter` package to support all platforms
- Create `PhotoCompressService` to use encode photos
