### PR TITLE
chore(auth provider): rename currentUserIdSelector -> currentIdentityKeyNameSelector

### DIFF
--- a/lib/app/features/auth/providers/auth_provider.dart
+++ b/lib/app/features/auth/providers/auth_provider.dart
@@ -41,7 +41,7 @@ class Auth extends _$Auth {
         fakeUsers.contains(savedSelectedUser) ? savedSelectedUser : authorizedUsers.lastOrNull;
 
     return AuthState(
-      authenticatedIdentityKeyNames: authorizedUsers.toList(),
+      authenticatedIdentityKeyNames: fakeUsers.toList(),
       currentIdentityKeyName: selectedUser,
     );
   }
@@ -64,9 +64,9 @@ class Auth extends _$Auth {
 }
 
 @riverpod
-String currentUserIdSelector(CurrentUserIdSelectorRef ref) {
+String? currentIdentityKeyNameSelector(CurrentIdentityKeyNameSelectorRef ref) {
   return ref.watch(
-    authProvider.select((state) => state.valueOrNull?.currentIdentityKeyName ?? ''),
+    authProvider.select((state) => state.valueOrNull?.currentIdentityKeyName),
   );
 }
 

--- a/lib/app/features/auth/views/pages/discover_creators/discover_creators.dart
+++ b/lib/app/features/auth/views/pages/discover_creators/discover_creators.dart
@@ -23,7 +23,7 @@ class DiscoverCreators extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final loginActionState = ref.watch(loginActionNotifierProvider);
-    final currentUserId = ref.watch(currentUserIdSelectorProvider);
+    final currentUserId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final followingIds = ref.watch(userFollowingProvider(currentUserId));
     final creatorIds = [
       'f5d70542664e65719b55d8d6250b7d51cbbea7711412dbb524108682cbd7f0d4',

--- a/lib/app/features/components/follow_user_button/follow_user_button.dart
+++ b/lib/app/features/components/follow_user_button/follow_user_button.dart
@@ -17,7 +17,7 @@ class FollowUserButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentUserId = ref.watch(currentUserIdSelectorProvider);
+    final currentUserId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final following = ref.watch(isCurrentUserFollowingSelectorProvider(userId));
     return Button(
       onPressed: () {

--- a/lib/app/features/feed/feed_search/providers/feed_search_filters_provider.dart
+++ b/lib/app/features/feed/feed_search/providers/feed_search_filters_provider.dart
@@ -56,7 +56,7 @@ class FeedSearchFilter extends _$FeedSearchFilter {
   }
 
   void _saveState(FeedSearchFiltersState state) {
-    final userId = ref.read(currentUserIdSelectorProvider);
+    final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
     ref.read(userPreferencesServiceProvider(userId: userId))
       ..setEnum(_feedSearchPeopleFilterKey, state.people)
       ..setValue<List<String>>(
@@ -66,7 +66,7 @@ class FeedSearchFilter extends _$FeedSearchFilter {
   }
 
   FeedSearchFiltersState _loadSavedState() {
-    final userId = ref.watch(currentUserIdSelectorProvider);
+    final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final userPreferencesService = ref.watch(userPreferencesServiceProvider(userId: userId));
 
     final people =

--- a/lib/app/features/feed/feed_search/providers/feed_search_history_provider.dart
+++ b/lib/app/features/feed/feed_search/providers/feed_search_history_provider.dart
@@ -5,8 +5,8 @@ import 'package:ice/app/features/auth/providers/auth_provider.dart';
 import 'package:ice/app/services/storage/user_preferences_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'feed_search_history_provider.g.dart';
 part 'feed_search_history_provider.freezed.dart';
+part 'feed_search_history_provider.g.dart';
 
 @Freezed(copyWith: true, equal: true)
 class FeedSearchHistoryState with _$FeedSearchHistoryState {
@@ -23,7 +23,7 @@ class FeedSearchHistory extends _$FeedSearchHistory {
 
   @override
   FeedSearchHistoryState build() {
-    final userId = ref.watch(currentUserIdSelectorProvider);
+    final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final userPreferencesService = ref.watch(userPreferencesServiceProvider(userId: userId));
 
     final storedUserIds = userPreferencesService.getValue<List<String>>(_userIdsStoreKey) ?? [];
@@ -36,7 +36,7 @@ class FeedSearchHistory extends _$FeedSearchHistory {
     if (!state.userIds.contains(userId)) {
       final newUserIds = [userId, ...state.userIds];
 
-      final currentUserId = ref.read(currentUserIdSelectorProvider);
+      final currentUserId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
       final userPreferencesService =
           ref.read(userPreferencesServiceProvider(userId: currentUserId));
       await userPreferencesService.setValue<List<String>>(_userIdsStoreKey, newUserIds);
@@ -49,7 +49,7 @@ class FeedSearchHistory extends _$FeedSearchHistory {
     if (!state.queries.contains(query)) {
       final newQueries = [query, ...state.queries];
 
-      final currentUserId = ref.read(currentUserIdSelectorProvider);
+      final currentUserId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
       final userPreferencesService =
           ref.read(userPreferencesServiceProvider(userId: currentUserId));
       await userPreferencesService.setValue<List<String>>(_queriesStoreKey, newQueries);
@@ -59,7 +59,7 @@ class FeedSearchHistory extends _$FeedSearchHistory {
   }
 
   Future<void> clear() async {
-    final currentUserId = ref.read(currentUserIdSelectorProvider);
+    final currentUserId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
     final userPreferencesService = ref.read(userPreferencesServiceProvider(userId: currentUserId));
     await Future.wait([
       userPreferencesService.remove(_userIdsStoreKey),

--- a/lib/app/features/feed/providers/feed_current_filter_provider.dart
+++ b/lib/app/features/feed/providers/feed_current_filter_provider.dart
@@ -49,14 +49,14 @@ class FeedCurrentFilter extends _$FeedCurrentFilter {
   }
 
   void _saveState(FeedFiltersState state) {
-    final userId = ref.read(currentUserIdSelectorProvider);
+    final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
     ref.read(userPreferencesServiceProvider(userId: userId))
       ..setEnum(_feedFilterCategoryKey, state.category)
       ..setEnum(_feedFilterFilterKey, state.filter);
   }
 
   FeedFiltersState _loadSavedState() {
-    final userId = ref.watch(currentUserIdSelectorProvider);
+    final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final userPreferencesService = ref.watch(userPreferencesServiceProvider(userId: userId));
 
     final category = userPreferencesService.getEnum(_feedFilterCategoryKey, FeedCategory.values);

--- a/lib/app/features/user/pages/pull_right_menu_page/components/profile_details/profile_details.dart
+++ b/lib/app/features/user/pages/pull_right_menu_page/components/profile_details/profile_details.dart
@@ -21,7 +21,7 @@ class ProfileDetails extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentUserId = ref.watch(currentUserIdSelectorProvider);
+    final currentUserId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final userMetadataValue = ref.watch(currentUserMetadataProvider).valueOrNull;
     final userFollowers = ref.watch(userFollowersProvider(currentUserId));
     final userFollowing = ref.watch(userFollowingProvider(currentUserId));

--- a/lib/app/features/user/pages/switch_account_modal/components/accounts_list/account_tile.dart
+++ b/lib/app/features/user/pages/switch_account_modal/components/accounts_list/account_tile.dart
@@ -20,7 +20,7 @@ class AccountsTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentUserId = ref.watch(currentUserIdSelectorProvider);
+    final currentUserId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
     final userMetadataValue = ref.watch(userMetadataProvider(userId)).valueOrNull;
     final isCurrentUser = userId == currentUserId;
 

--- a/lib/app/features/user/providers/user_following_provider.dart
+++ b/lib/app/features/user/providers/user_following_provider.dart
@@ -29,7 +29,7 @@ class UserFollowing extends _$UserFollowing {
 
 @riverpod
 bool isCurrentUserFollowingSelector(IsCurrentUserFollowingSelectorRef ref, String userId) {
-  final currentUserId = ref.watch(currentUserIdSelectorProvider);
+  final currentUserId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
   return ref.watch(
     userFollowingProvider(currentUserId)
         .select((state) => state.valueOrNull?.contains(userId) ?? false),

--- a/lib/app/features/user/providers/user_metadata_provider.dart
+++ b/lib/app/features/user/providers/user_metadata_provider.dart
@@ -52,7 +52,7 @@ Future<UserMetadata?> userMetadata(UserMetadataRef ref, String pubkey) async {
 
 @riverpod
 AsyncValue<UserMetadata?> currentUserMetadata(CurrentUserMetadataRef ref) {
-  final currentUserId = ref.watch(currentUserIdSelectorProvider);
+  final currentUserId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
   if (currentUserId.isEmpty) {
     return const AsyncData(null);
   }

--- a/lib/app/features/wallet/providers/wallet_user_preferences/user_preferences_selectors.dart
+++ b/lib/app/features/wallet/providers/wallet_user_preferences/user_preferences_selectors.dart
@@ -11,7 +11,7 @@ part 'user_preferences_selectors.g.dart';
 
 @riverpod
 bool isBalanceVisibleSelector(IsBalanceVisibleSelectorRef ref) {
-  final userId = ref.watch(currentUserIdSelectorProvider);
+  final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
 
   return ref.watch(
     walletUserPreferencesNotifierProvider(userId: userId).select(
@@ -22,7 +22,7 @@ bool isBalanceVisibleSelector(IsBalanceVisibleSelectorRef ref) {
 
 @riverpod
 bool isZeroValueAssetsVisibleSelector(IsZeroValueAssetsVisibleSelectorRef ref) {
-  final userId = ref.watch(currentUserIdSelectorProvider);
+  final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
 
   return ref.watch(
     walletUserPreferencesNotifierProvider(userId: userId).select(
@@ -33,7 +33,7 @@ bool isZeroValueAssetsVisibleSelector(IsZeroValueAssetsVisibleSelectorRef ref) {
 
 @riverpod
 NftLayoutType nftLayoutTypeSelector(NftLayoutTypeSelectorRef ref) {
-  final userId = ref.watch(currentUserIdSelectorProvider);
+  final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
 
   return ref.watch(
     walletUserPreferencesNotifierProvider(userId: userId).select(
@@ -44,7 +44,7 @@ NftLayoutType nftLayoutTypeSelector(NftLayoutTypeSelectorRef ref) {
 
 @riverpod
 NftSortingType nftSortingTypeSelector(NftSortingTypeSelectorRef ref) {
-  final userId = ref.watch(currentUserIdSelectorProvider);
+  final userId = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
 
   return ref.watch(
     walletUserPreferencesNotifierProvider(userId: userId).select(

--- a/lib/app/features/wallet/views/pages/nfts_sorting_modal/components/sorting_button/sorting_button.dart
+++ b/lib/app/features/wallet/views/pages/nfts_sorting_modal/components/sorting_button/sorting_button.dart
@@ -27,7 +27,7 @@ class SortingButton extends ConsumerWidget {
           color: context.theme.appColors.primaryAccent,
         ),
         onPressed: () {
-          final userId = ref.read(currentUserIdSelectorProvider);
+          final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
           ref
               .read(walletUserPreferencesNotifierProvider(userId: userId).notifier)
               .setNftSortingType(sortingType);

--- a/lib/app/features/wallet/views/pages/wallet_page/components/balance/balance.dart
+++ b/lib/app/features/wallet/views/pages/wallet_page/components/balance/balance.dart
@@ -52,7 +52,7 @@ class Balance extends ConsumerWidget {
                     ),
                   ),
                   onPressed: () {
-                    final userId = ref.read(currentUserIdSelectorProvider);
+                    final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
                     ref
                         .read(walletUserPreferencesNotifierProvider(userId: userId).notifier)
                         .switchBalanceVisibility();

--- a/lib/app/features/wallet/views/pages/wallet_page/components/nfts/nfts_header_layout_action.dart
+++ b/lib/app/features/wallet/views/pages/wallet_page/components/nfts/nfts_header_layout_action.dart
@@ -27,7 +27,7 @@ class NftHeaderLayoutAction extends ConsumerWidget {
       children: [
         TextButton(
           onPressed: () {
-            final userId = ref.read(currentUserIdSelectorProvider);
+            final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
             ref
                 .read(walletUserPreferencesNotifierProvider(userId: userId).notifier)
                 .setNftLayoutType(NftLayoutType.grid);
@@ -47,7 +47,7 @@ class NftHeaderLayoutAction extends ConsumerWidget {
         ),
         TextButton(
           onPressed: () {
-            final userId = ref.read(currentUserIdSelectorProvider);
+            final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
             ref
                 .read(walletUserPreferencesNotifierProvider(userId: userId).notifier)
                 .setNftLayoutType(NftLayoutType.list);

--- a/lib/app/features/wallet/views/pages/wallet_page/components/tabs/tabs_header_hide_action.dart
+++ b/lib/app/features/wallet/views/pages/wallet_page/components/tabs/tabs_header_hide_action.dart
@@ -28,7 +28,7 @@ class WalletTabsHeaderHideAction extends ConsumerWidget {
 
     return TextButton(
       onPressed: () {
-        final userId = ref.read(currentUserIdSelectorProvider);
+        final userId = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
         ref
             .read(walletUserPreferencesNotifierProvider(userId: userId).notifier)
             .switchZeroValueAssetsVisibility();


### PR DESCRIPTION
### What does this PR do?
This PR aligns name of the provider with the rest of the code.

### Changes brought by this PR
- Rename provider `currentUserIdSelector -> currentIdentityKeyNameSelector`
- Change it's return type to be nullable
- Update dependent code to use the new name and the return nullable value

### Additional information
Logout happens immediately

https://github.com/user-attachments/assets/44a38c6b-9f38-467c-84b3-b4fc25290fb4
