### PR TITLE
feat(ion identity client): improve errors for register and login

### DIFF
--- a/lib/app/features/auth/views/components/identity_key_name_input/identity_key_name_input.dart
+++ b/lib/app/features/auth/views/components/identity_key_name_input/identity_key_name_input.dart
@@ -14,10 +14,11 @@ import 'package:ice/generated/assets.gen.dart';
 class IdentityKeyNameInput extends HookWidget {
   const IdentityKeyNameInput({
     this.textInputAction = TextInputAction.done,
-    super.key,
     this.controller,
     this.scrollPadding,
     this.notShowInfoIcon = false,
+    this.errorText,
+    super.key,
   });
 
   final TextEditingController? controller;
@@ -26,6 +27,8 @@ class IdentityKeyNameInput extends HookWidget {
 
   final EdgeInsets? scrollPadding;
   final bool notShowInfoIcon;
+
+  final String? errorText;
 
   @override
   Widget build(BuildContext context) {
@@ -67,6 +70,7 @@ class IdentityKeyNameInput extends HookWidget {
       },
       textInputAction: textInputAction,
       scrollPadding: scrollPadding ?? EdgeInsets.only(bottom: 100.0.s),
+      errorText: errorText,
     );
   }
 }

--- a/lib/app/features/auth/views/pages/get_started/login_form.dart
+++ b/lib/app/features/auth/views/pages/get_started/login_form.dart
@@ -29,6 +29,7 @@ class LoginForm extends HookConsumerWidget {
       child: Column(
         children: [
           IdentityKeyNameInput(
+            errorText: loginActionState.error?.toString(),
             controller: identityKeyNameController,
             scrollPadding: EdgeInsets.only(bottom: 190.0.s),
           ),

--- a/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
+++ b/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
@@ -27,7 +27,10 @@ class SignUpPasskeyForm extends HookConsumerWidget {
       key: formKey.value,
       child: Column(
         children: [
-          IdentityKeyNameInput(controller: identityKeyNameController),
+          IdentityKeyNameInput(
+            errorText: registerActionState.error?.toString(),
+            controller: identityKeyNameController,
+          ),
           SizedBox(height: 16.0.s),
           Button(
             disabled: registerActionState.isLoading,

--- a/packages/ion_identity_client/lib/src/auth/result_types/login_user_result.dart
+++ b/packages/ion_identity_client/lib/src/auth/result_types/login_user_result.dart
@@ -12,6 +12,9 @@ sealed class LoginUserFailure extends LoginUserResult {
 
 final class PasskeyNotAvailableLoginUserFailure extends LoginUserFailure {
   const PasskeyNotAvailableLoginUserFailure();
+
+  @override
+  String toString() => 'Passkey not available';
 }
 
 final class PasskeyValidationLoginUserFailure extends LoginUserFailure {
@@ -24,7 +27,28 @@ final class PasskeyValidationLoginUserFailure extends LoginUserFailure {
   final StackTrace? stackTrace;
 
   @override
-  String toString() => 'PasskeyValidationLoginUserFailure(error: $error, stackTrace: $stackTrace)';
+  String toString() => 'Passkey validation failed: $error';
+}
+
+final class InvalidCodeLoginUserFailure extends LoginUserFailure {
+  const InvalidCodeLoginUserFailure();
+
+  @override
+  String toString() => 'Invalid code';
+}
+
+final class NoCredentialsLoginUserFailure extends LoginUserFailure {
+  const NoCredentialsLoginUserFailure();
+
+  @override
+  String toString() => 'No credentials found for this user';
+}
+
+final class AccountDeactivatedLoginUserFailure extends LoginUserFailure {
+  const AccountDeactivatedLoginUserFailure();
+
+  @override
+  String toString() => 'Account has been deactivated';
 }
 
 final class UnknownLoginUserFailure extends LoginUserFailure {

--- a/packages/ion_identity_client/lib/src/auth/result_types/register_user_result.dart
+++ b/packages/ion_identity_client/lib/src/auth/result_types/register_user_result.dart
@@ -10,10 +10,21 @@ sealed class RegisterUserFailure extends RegisterUserResult {
   const RegisterUserFailure();
 }
 
-final class UserAlreadyExistsRegisterUserFailure extends RegisterUserFailure {}
+final class UserAlreadyExistsRegisterUserFailure extends RegisterUserFailure {
+  @override
+  String toString() => 'User already exists';
+}
+
+final class RegistrationCodeExpiredRegisterUserFailure extends RegisterUserFailure {
+  @override
+  String toString() => 'Registration code expired';
+}
 
 final class PasskeyNotAvailableRegisterUserFailure extends RegisterUserFailure {
   const PasskeyNotAvailableRegisterUserFailure();
+
+  @override
+  String toString() => 'Passkey not available';
 }
 
 final class PasskeyValidationRegisterUserFailure extends RegisterUserFailure {
@@ -26,8 +37,7 @@ final class PasskeyValidationRegisterUserFailure extends RegisterUserFailure {
   final StackTrace? stackTrace;
 
   @override
-  String toString() =>
-      'PasskeyValidationRegisterUserFailure(error: $error, stackTrace: $stackTrace)';
+  String toString() => 'Passkey validation failed: $error';
 }
 
 final class UnknownRegisterUserFailure extends RegisterUserFailure {
@@ -40,5 +50,5 @@ final class UnknownRegisterUserFailure extends RegisterUserFailure {
   final StackTrace? stackTrace;
 
   @override
-  String toString() => 'UnknownRegisterUserFailure(error: $error, stackTrace: $stackTrace)';
+  String toString() => 'Unknown error: $error';
 }


### PR DESCRIPTION
### What does this PR do?
Improves error handling and displays error messages in the login and registration forms.

### Changes brought by this PR:
- **IdentityKeyNameInput**: Added `errorText` prop to show validation errors.
- **LoginForm & SignUpPasskeyForm**: Pass `errorText` to `IdentityKeyNameInput`.
- **LoginDataSource & RegisterDataSource**: Better network error handling (e.g., account deactivated, invalid code).
- **Failure types**: Added new failure cases with clearer error messages.
