### PR TITLE
feat(auth): add refreshing tokens flow

### DIFF
--- a/lib/app/features/core/providers/app_lifecycle_provider.dart
+++ b/lib/app/features/core/providers/app_lifecycle_provider.dart
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'app_lifecycle_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class AppLifecycle extends _$AppLifecycle {
+  @override
+  AppLifecycleState build() {
+    return AppLifecycleState.resumed;
+  }
+
+  set newState(AppLifecycleState newState) {
+    state = newState;
+  }
+}

--- a/lib/app/features/core/views/components/app_lifecycle_observer.dart
+++ b/lib/app/features/core/views/components/app_lifecycle_observer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/permissions/providers/permissions_provider.dart';
+import 'package:ion/app/features/core/providers/app_lifecycle_provider.dart';
 
 class AppLifecycleObserver extends HookConsumerWidget {
   const AppLifecycleObserver({required this.child, super.key});
@@ -13,6 +14,8 @@ class AppLifecycleObserver extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useOnAppLifecycleStateChange((_, AppLifecycleState current) {
+      ref.read(appLifecycleProvider.notifier).newState = current;
+
       if (current == AppLifecycleState.resumed) {
         ref.read(permissionsProvider.notifier).checkAllPermissions();
       }

--- a/packages/ion_identity_client/example/lib/pages/login_delegated/delegated_login_page.dart
+++ b/packages/ion_identity_client/example/lib/pages/login_delegated/delegated_login_page.dart
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion_client_example/pages/login_delegated/providers/delegated_login_notifier.dart';
+
+class DelegatedLoginPage extends HookConsumerWidget {
+  const DelegatedLoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usernameController = useTextEditingController();
+
+    final delegatedLoginState = ref.watch(delegatedLoginNotifierProvider);
+    final isLoading = delegatedLoginState.isLoading;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Delegated Login'),
+      ),
+      body: Column(
+        children: [
+          TextField(
+            controller: usernameController,
+          ),
+          ElevatedButton(
+            onPressed: isLoading
+                ? null
+                : () {
+                    ref
+                        .read(delegatedLoginNotifierProvider.notifier)
+                        .delegatedLogin(username: usernameController.text);
+                  },
+            child: const Text('Login'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/ion_identity_client/example/lib/pages/login_delegated/providers/delegated_login_notifier.dart
+++ b/packages/ion_identity_client/example/lib/pages/login_delegated/providers/delegated_login_notifier.dart
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_client_example/providers/ion_client_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'delegated_login_notifier.g.dart';
+
+@riverpod
+class DelegatedLoginNotifier extends _$DelegatedLoginNotifier {
+  @override
+  FutureOr<void> build() {}
+
+  Future<void> delegatedLogin({required String username}) async {
+    state = const AsyncLoading();
+
+    try {
+      final ionClient = await ref.read(ionClientProvider.future);
+      await ionClient(username: username).auth.delegatedLogin();
+    } catch (e) {
+      state = AsyncValue.error(e, StackTrace.current);
+    }
+  }
+}

--- a/packages/ion_identity_client/example/lib/pages/user_wallets/user_wallets_page.dart
+++ b/packages/ion_identity_client/example/lib/pages/user_wallets/user_wallets_page.dart
@@ -36,7 +36,7 @@ class UserWalletsPage extends HookConsumerWidget {
 }
 
 class _CreateWalletAction extends ConsumerWidget {
-  const _CreateWalletAction({super.key});
+  const _CreateWalletAction();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/packages/ion_identity_client/example/lib/pages/users/components/users_menu.dart
+++ b/packages/ion_identity_client/example/lib/pages/users/components/users_menu.dart
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ion_client_example/pages/login/login_page.dart';
+import 'package:ion_client_example/pages/login_delegated/delegated_login_page.dart';
+import 'package:ion_client_example/pages/register/register_page.dart';
+
+class UsersMenu extends HookWidget {
+  const UsersMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final menuController = useRef(MenuController());
+
+    return IconButton(
+      onPressed: () {
+        menuController.value.open();
+      },
+      icon: MenuAnchor(
+        controller: menuController.value,
+        menuChildren: [
+          MenuItemButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const RegisterPage(),
+                ),
+              );
+            },
+            child: const Text('Register'),
+          ),
+          MenuItemButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const LoginPage(),
+                ),
+              );
+            },
+            child: const Text('Login'),
+          ),
+          MenuItemButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const DelegatedLoginPage(),
+                ),
+              );
+            },
+            child: const Text('Delegated Login'),
+          ),
+        ],
+        child: const Icon(Icons.person),
+      ),
+    );
+  }
+}

--- a/packages/ion_identity_client/example/lib/pages/users/users_page.dart
+++ b/packages/ion_identity_client/example/lib/pages/users/users_page.dart
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ion_client_example/pages/login/login_page.dart';
-import 'package:ion_client_example/pages/register/register_page.dart';
 import 'package:ion_client_example/pages/user_details/user_details_page.dart';
+import 'package:ion_client_example/pages/users/components/users_menu.dart';
 import 'package:ion_client_example/pages/users/providers/users_provider.dart';
 import 'package:ion_client_example/providers/current_username_notifier.dart';
 
@@ -17,52 +15,9 @@ class UsersPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Users'),
-        actions: const [
-          _UsersMenu(),
-        ],
+        actions: const [UsersMenu()],
       ),
       body: const _Body(),
-    );
-  }
-}
-
-class _UsersMenu extends HookWidget {
-  const _UsersMenu();
-
-  @override
-  Widget build(BuildContext context) {
-    final menuController = useRef(MenuController());
-
-    return IconButton(
-      onPressed: () {
-        menuController.value.open();
-      },
-      icon: MenuAnchor(
-        controller: menuController.value,
-        menuChildren: [
-          MenuItemButton(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const RegisterPage(),
-                ),
-              );
-            },
-            child: const Text('Register'),
-          ),
-          MenuItemButton(
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const LoginPage(),
-                ),
-              );
-            },
-            child: const Text('Login'),
-          ),
-        ],
-        child: const Icon(Icons.person),
-      ),
     );
   }
 }

--- a/packages/ion_identity_client/lib/ion_client.dart
+++ b/packages/ion_identity_client/lib/ion_client.dart
@@ -5,6 +5,7 @@ library ion_identity_client;
 export 'src/auth/ion_auth.dart';
 export 'src/auth/result_types/result_types.dart';
 export 'src/core/types/ion_exception.dart';
+export 'src/core/types/user_token.dart';
 export 'src/ion_api_client.dart';
 export 'src/ion_client_config.dart';
 export 'src/wallets/models/wallet.dart';

--- a/packages/ion_identity_client/lib/src/auth/data_sources/create_recovery_credentials_data_source.dart
+++ b/packages/ion_identity_client/lib/src/auth/data_sources/create_recovery_credentials_data_source.dart
@@ -40,7 +40,10 @@ class CreateRecoveryCredentialsDataSource {
           createCredentialInitPath,
           data: recoveryKeyBody,
           decoder: CredentialChallenge.fromJson,
-          headers: RequestHeaders.getAuthorizationHeader(token: token.token),
+          headers: RequestHeaders.getAuthorizationHeaders(
+            token: token.token,
+            username: username,
+          ),
         )
         .mapLeft(CreateCredentialInitCreateRecoveryCredentialsFailure.new);
   }

--- a/packages/ion_identity_client/lib/src/auth/data_sources/recover_user_data_source.dart
+++ b/packages/ion_identity_client/lib/src/auth/data_sources/recover_user_data_source.dart
@@ -41,7 +41,7 @@ class RecoverUserDataSource {
         .post(
           recoverUserPath,
           data: recoveryData,
-          headers: RequestHeaders.getAuthorizationHeader(token: temporaryAuthenticationToken),
+          headers: RequestHeaders.getTokenHeader(token: temporaryAuthenticationToken),
           decoder: (json) => json,
         )
         .mapLeft(RecoverUserRequestRecoverUserFailure.new);

--- a/packages/ion_identity_client/lib/src/auth/data_sources/register_data_source.dart
+++ b/packages/ion_identity_client/lib/src/auth/data_sources/register_data_source.dart
@@ -46,7 +46,7 @@ class RegisterDataSource {
           registerCompletePath,
           data: SignedChallenge(firstFactorCredential: attestation).toJson(),
           decoder: RegistrationCompleteResponse.fromJson,
-          headers: RequestHeaders.getAuthorizationHeader(token: temporaryAuthenticationToken),
+          headers: RequestHeaders.getTokenHeader(token: temporaryAuthenticationToken),
         )
         .mapLeft(
           (l) => switch (l) {

--- a/packages/ion_identity_client/lib/src/auth/dtos/authentication.dart
+++ b/packages/ion_identity_client/lib/src/auth/dtos/authentication.dart
@@ -1,22 +1,16 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'package:ion_identity_client/src/core/types/types.dart';
-import 'package:json_annotation/json_annotation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
+part 'authentication.freezed.dart';
 part 'authentication.g.dart';
 
-@JsonSerializable()
-class Authentication {
-  Authentication({
-    required this.token,
-  });
+@freezed
+class Authentication with _$Authentication {
+  factory Authentication({
+    required String token,
+    required String refreshToken,
+  }) = _Authentication;
 
-  factory Authentication.fromJson(JsonObject map) => _$AuthenticationFromJson(map);
-
-  final String token;
-
-  JsonObject toJson() => _$AuthenticationToJson(this);
-
-  @override
-  String toString() => 'Authentication(token: <redacted>)';
+  factory Authentication.fromJson(Map<String, dynamic> json) => _$AuthenticationFromJson(json);
 }

--- a/packages/ion_identity_client/lib/src/auth/dtos/authentication.freezed.dart
+++ b/packages/ion_identity_client/lib/src/auth/dtos/authentication.freezed.dart
@@ -1,0 +1,184 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'authentication.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Authentication _$AuthenticationFromJson(Map<String, dynamic> json) {
+  return _Authentication.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Authentication {
+  String get token => throw _privateConstructorUsedError;
+  String get refreshToken => throw _privateConstructorUsedError;
+
+  /// Serializes this Authentication to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Authentication
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AuthenticationCopyWith<Authentication> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AuthenticationCopyWith<$Res> {
+  factory $AuthenticationCopyWith(
+          Authentication value, $Res Function(Authentication) then) =
+      _$AuthenticationCopyWithImpl<$Res, Authentication>;
+  @useResult
+  $Res call({String token, String refreshToken});
+}
+
+/// @nodoc
+class _$AuthenticationCopyWithImpl<$Res, $Val extends Authentication>
+    implements $AuthenticationCopyWith<$Res> {
+  _$AuthenticationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Authentication
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? token = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_value.copyWith(
+      token: null == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AuthenticationImplCopyWith<$Res>
+    implements $AuthenticationCopyWith<$Res> {
+  factory _$$AuthenticationImplCopyWith(_$AuthenticationImpl value,
+          $Res Function(_$AuthenticationImpl) then) =
+      __$$AuthenticationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String token, String refreshToken});
+}
+
+/// @nodoc
+class __$$AuthenticationImplCopyWithImpl<$Res>
+    extends _$AuthenticationCopyWithImpl<$Res, _$AuthenticationImpl>
+    implements _$$AuthenticationImplCopyWith<$Res> {
+  __$$AuthenticationImplCopyWithImpl(
+      _$AuthenticationImpl _value, $Res Function(_$AuthenticationImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Authentication
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? token = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_$AuthenticationImpl(
+      token: null == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AuthenticationImpl implements _Authentication {
+  _$AuthenticationImpl({required this.token, required this.refreshToken});
+
+  factory _$AuthenticationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AuthenticationImplFromJson(json);
+
+  @override
+  final String token;
+  @override
+  final String refreshToken;
+
+  @override
+  String toString() {
+    return 'Authentication(token: $token, refreshToken: $refreshToken)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AuthenticationImpl &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.refreshToken, refreshToken) ||
+                other.refreshToken == refreshToken));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, token, refreshToken);
+
+  /// Create a copy of Authentication
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AuthenticationImplCopyWith<_$AuthenticationImpl> get copyWith =>
+      __$$AuthenticationImplCopyWithImpl<_$AuthenticationImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AuthenticationImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Authentication implements Authentication {
+  factory _Authentication(
+      {required final String token,
+      required final String refreshToken}) = _$AuthenticationImpl;
+
+  factory _Authentication.fromJson(Map<String, dynamic> json) =
+      _$AuthenticationImpl.fromJson;
+
+  @override
+  String get token;
+  @override
+  String get refreshToken;
+
+  /// Create a copy of Authentication
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AuthenticationImplCopyWith<_$AuthenticationImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/ion_identity_client/lib/src/auth/ion_auth.dart
+++ b/packages/ion_identity_client/lib/src/auth/ion_auth.dart
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'package:ion_identity_client/src/auth/result_types/create_recovery_credentials_result.dart';
-import 'package:ion_identity_client/src/auth/result_types/login_user_result.dart';
-import 'package:ion_identity_client/src/auth/result_types/recover_user_result.dart';
-import 'package:ion_identity_client/src/auth/result_types/register_user_result.dart';
+import 'package:ion_identity_client/ion_client.dart';
 import 'package:ion_identity_client/src/auth/services/create_recovery_credentials_service.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/delegated_login_service.dart';
 import 'package:ion_identity_client/src/auth/services/login_service.dart';
 import 'package:ion_identity_client/src/auth/services/recover_user_service.dart';
 import 'package:ion_identity_client/src/auth/services/register_service.dart';
@@ -27,12 +25,14 @@ class IonAuth {
     required this.tokenStorage,
     required this.createRecoveryCredentialsService,
     required this.recoverUserService,
+    required this.delegatedLoginService,
   });
 
   final RegisterService registerService;
   final LoginService loginService;
   final CreateRecoveryCredentialsService createRecoveryCredentialsService;
   final RecoverUserService recoverUserService;
+  final DelegatedLoginService delegatedLoginService;
 
   final String username;
   final TokenStorage tokenStorage;
@@ -57,4 +57,7 @@ class IonAuth {
     // TODO: implement logout request
     return tokenStorage.removeToken(username: username);
   }
+
+  Future<UserToken> delegatedLogin() async =>
+      delegatedLoginService.delegatedLogin(username: username);
 }

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/data_sources/delegated_login_data_source.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/data_sources/delegated_login_data_source.dart
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/ion_client.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/models/delegated_login_request.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/models/delegated_login_response.dart';
+import 'package:ion_identity_client/src/core/network2/network_client2.dart';
+import 'package:ion_identity_client/src/core/token_storage/token_storage.dart';
+import 'package:ion_identity_client/src/core/types/request_headers.dart';
+
+class DelegatedLoginDataSource {
+  DelegatedLoginDataSource({
+    required this.networkClient,
+    required this.tokenStorage,
+  });
+
+  final NetworkClient2 networkClient;
+  final TokenStorage tokenStorage;
+
+  static const delegatedLoginPath = '/auth/login/delegated';
+
+  Future<DelegatedLoginResponse> delegatedLogin({
+    required String username,
+  }) async {
+    final token = tokenStorage.getToken(username: username);
+    if (token == null) {
+      throw const UnauthenticatedException();
+    }
+
+    final requestData = DelegatedLoginRequest(
+      username: username,
+      refreshToken: token.refreshToken,
+    );
+    return networkClient.post(
+      delegatedLoginPath,
+      headers: RequestHeaders.getTokenHeader(token: token.token),
+      data: requestData.toJson(),
+      decoder: DelegatedLoginResponse.fromJson,
+    );
+  }
+}

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/delegated_login_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/delegated_login_service.dart
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/ion_client.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/data_sources/delegated_login_data_source.dart';
+import 'package:ion_identity_client/src/core/token_storage/token_storage.dart';
+
+class DelegatedLoginService {
+  const DelegatedLoginService({
+    required this.dataSource,
+    required this.tokenStorage,
+  });
+
+  final DelegatedLoginDataSource dataSource;
+  final TokenStorage tokenStorage;
+
+  Future<UserToken> delegatedLogin({
+    required String username,
+  }) async {
+    final tokenResponse = await dataSource.delegatedLogin(username: username);
+    await tokenStorage.setToken(username: username, newToken: tokenResponse.token);
+
+    final userToken = tokenStorage.getToken(username: username);
+    if (userToken == null) {
+      throw const UnauthenticatedException();
+    }
+    return userToken;
+  }
+}

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_request.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_request.dart
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'delegated_login_request.freezed.dart';
+part 'delegated_login_request.g.dart';
+
+@freezed
+class DelegatedLoginRequest with _$DelegatedLoginRequest {
+  const factory DelegatedLoginRequest({
+    required String username,
+    required String refreshToken,
+  }) = _DelegatedLoginRequest;
+
+  factory DelegatedLoginRequest.fromJson(Map<String, dynamic> json) =>
+      _$DelegatedLoginRequestFromJson(json);
+}

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_request.freezed.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_request.freezed.dart
@@ -1,0 +1,190 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'delegated_login_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+DelegatedLoginRequest _$DelegatedLoginRequestFromJson(
+    Map<String, dynamic> json) {
+  return _DelegatedLoginRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DelegatedLoginRequest {
+  String get username => throw _privateConstructorUsedError;
+  String get refreshToken => throw _privateConstructorUsedError;
+
+  /// Serializes this DelegatedLoginRequest to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of DelegatedLoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $DelegatedLoginRequestCopyWith<DelegatedLoginRequest> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DelegatedLoginRequestCopyWith<$Res> {
+  factory $DelegatedLoginRequestCopyWith(DelegatedLoginRequest value,
+          $Res Function(DelegatedLoginRequest) then) =
+      _$DelegatedLoginRequestCopyWithImpl<$Res, DelegatedLoginRequest>;
+  @useResult
+  $Res call({String username, String refreshToken});
+}
+
+/// @nodoc
+class _$DelegatedLoginRequestCopyWithImpl<$Res,
+        $Val extends DelegatedLoginRequest>
+    implements $DelegatedLoginRequestCopyWith<$Res> {
+  _$DelegatedLoginRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of DelegatedLoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? username = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_value.copyWith(
+      username: null == username
+          ? _value.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$DelegatedLoginRequestImplCopyWith<$Res>
+    implements $DelegatedLoginRequestCopyWith<$Res> {
+  factory _$$DelegatedLoginRequestImplCopyWith(
+          _$DelegatedLoginRequestImpl value,
+          $Res Function(_$DelegatedLoginRequestImpl) then) =
+      __$$DelegatedLoginRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String username, String refreshToken});
+}
+
+/// @nodoc
+class __$$DelegatedLoginRequestImplCopyWithImpl<$Res>
+    extends _$DelegatedLoginRequestCopyWithImpl<$Res,
+        _$DelegatedLoginRequestImpl>
+    implements _$$DelegatedLoginRequestImplCopyWith<$Res> {
+  __$$DelegatedLoginRequestImplCopyWithImpl(_$DelegatedLoginRequestImpl _value,
+      $Res Function(_$DelegatedLoginRequestImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of DelegatedLoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? username = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_$DelegatedLoginRequestImpl(
+      username: null == username
+          ? _value.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DelegatedLoginRequestImpl implements _DelegatedLoginRequest {
+  const _$DelegatedLoginRequestImpl(
+      {required this.username, required this.refreshToken});
+
+  factory _$DelegatedLoginRequestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DelegatedLoginRequestImplFromJson(json);
+
+  @override
+  final String username;
+  @override
+  final String refreshToken;
+
+  @override
+  String toString() {
+    return 'DelegatedLoginRequest(username: $username, refreshToken: $refreshToken)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DelegatedLoginRequestImpl &&
+            (identical(other.username, username) ||
+                other.username == username) &&
+            (identical(other.refreshToken, refreshToken) ||
+                other.refreshToken == refreshToken));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, username, refreshToken);
+
+  /// Create a copy of DelegatedLoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DelegatedLoginRequestImplCopyWith<_$DelegatedLoginRequestImpl>
+      get copyWith => __$$DelegatedLoginRequestImplCopyWithImpl<
+          _$DelegatedLoginRequestImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DelegatedLoginRequestImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DelegatedLoginRequest implements DelegatedLoginRequest {
+  const factory _DelegatedLoginRequest(
+      {required final String username,
+      required final String refreshToken}) = _$DelegatedLoginRequestImpl;
+
+  factory _DelegatedLoginRequest.fromJson(Map<String, dynamic> json) =
+      _$DelegatedLoginRequestImpl.fromJson;
+
+  @override
+  String get username;
+  @override
+  String get refreshToken;
+
+  /// Create a copy of DelegatedLoginRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DelegatedLoginRequestImplCopyWith<_$DelegatedLoginRequestImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_request.g.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_request.g.dart
@@ -1,20 +1,21 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'authentication.dart';
+part of 'delegated_login_request.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthenticationImpl _$$AuthenticationImplFromJson(Map<String, dynamic> json) =>
-    _$AuthenticationImpl(
-      token: json['token'] as String,
+_$DelegatedLoginRequestImpl _$$DelegatedLoginRequestImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DelegatedLoginRequestImpl(
+      username: json['username'] as String,
       refreshToken: json['refreshToken'] as String,
     );
 
-Map<String, dynamic> _$$AuthenticationImplToJson(
-        _$AuthenticationImpl instance) =>
+Map<String, dynamic> _$$DelegatedLoginRequestImplToJson(
+        _$DelegatedLoginRequestImpl instance) =>
     <String, dynamic>{
-      'token': instance.token,
+      'username': instance.username,
       'refreshToken': instance.refreshToken,
     };

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_response.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_response.dart
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'delegated_login_response.freezed.dart';
+part 'delegated_login_response.g.dart';
+
+@freezed
+class DelegatedLoginResponse with _$DelegatedLoginResponse {
+  const factory DelegatedLoginResponse({
+    required String token,
+  }) = _DelegatedLoginResponse;
+
+  factory DelegatedLoginResponse.fromJson(Map<String, dynamic> json) =>
+      _$DelegatedLoginResponseFromJson(json);
+}

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_response.freezed.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_response.freezed.dart
@@ -1,0 +1,171 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'delegated_login_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+DelegatedLoginResponse _$DelegatedLoginResponseFromJson(
+    Map<String, dynamic> json) {
+  return _DelegatedLoginResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DelegatedLoginResponse {
+  String get token => throw _privateConstructorUsedError;
+
+  /// Serializes this DelegatedLoginResponse to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of DelegatedLoginResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $DelegatedLoginResponseCopyWith<DelegatedLoginResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DelegatedLoginResponseCopyWith<$Res> {
+  factory $DelegatedLoginResponseCopyWith(DelegatedLoginResponse value,
+          $Res Function(DelegatedLoginResponse) then) =
+      _$DelegatedLoginResponseCopyWithImpl<$Res, DelegatedLoginResponse>;
+  @useResult
+  $Res call({String token});
+}
+
+/// @nodoc
+class _$DelegatedLoginResponseCopyWithImpl<$Res,
+        $Val extends DelegatedLoginResponse>
+    implements $DelegatedLoginResponseCopyWith<$Res> {
+  _$DelegatedLoginResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of DelegatedLoginResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? token = null,
+  }) {
+    return _then(_value.copyWith(
+      token: null == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$DelegatedLoginResponseImplCopyWith<$Res>
+    implements $DelegatedLoginResponseCopyWith<$Res> {
+  factory _$$DelegatedLoginResponseImplCopyWith(
+          _$DelegatedLoginResponseImpl value,
+          $Res Function(_$DelegatedLoginResponseImpl) then) =
+      __$$DelegatedLoginResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String token});
+}
+
+/// @nodoc
+class __$$DelegatedLoginResponseImplCopyWithImpl<$Res>
+    extends _$DelegatedLoginResponseCopyWithImpl<$Res,
+        _$DelegatedLoginResponseImpl>
+    implements _$$DelegatedLoginResponseImplCopyWith<$Res> {
+  __$$DelegatedLoginResponseImplCopyWithImpl(
+      _$DelegatedLoginResponseImpl _value,
+      $Res Function(_$DelegatedLoginResponseImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of DelegatedLoginResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? token = null,
+  }) {
+    return _then(_$DelegatedLoginResponseImpl(
+      token: null == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DelegatedLoginResponseImpl implements _DelegatedLoginResponse {
+  const _$DelegatedLoginResponseImpl({required this.token});
+
+  factory _$DelegatedLoginResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DelegatedLoginResponseImplFromJson(json);
+
+  @override
+  final String token;
+
+  @override
+  String toString() {
+    return 'DelegatedLoginResponse(token: $token)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DelegatedLoginResponseImpl &&
+            (identical(other.token, token) || other.token == token));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, token);
+
+  /// Create a copy of DelegatedLoginResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DelegatedLoginResponseImplCopyWith<_$DelegatedLoginResponseImpl>
+      get copyWith => __$$DelegatedLoginResponseImplCopyWithImpl<
+          _$DelegatedLoginResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DelegatedLoginResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DelegatedLoginResponse implements DelegatedLoginResponse {
+  const factory _DelegatedLoginResponse({required final String token}) =
+      _$DelegatedLoginResponseImpl;
+
+  factory _DelegatedLoginResponse.fromJson(Map<String, dynamic> json) =
+      _$DelegatedLoginResponseImpl.fromJson;
+
+  @override
+  String get token;
+
+  /// Create a copy of DelegatedLoginResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DelegatedLoginResponseImplCopyWith<_$DelegatedLoginResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_response.g.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/delegated_login/models/delegated_login_response.g.dart
@@ -1,20 +1,19 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'authentication.dart';
+part of 'delegated_login_response.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthenticationImpl _$$AuthenticationImplFromJson(Map<String, dynamic> json) =>
-    _$AuthenticationImpl(
+_$DelegatedLoginResponseImpl _$$DelegatedLoginResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DelegatedLoginResponseImpl(
       token: json['token'] as String,
-      refreshToken: json['refreshToken'] as String,
     );
 
-Map<String, dynamic> _$$AuthenticationImplToJson(
-        _$AuthenticationImpl instance) =>
+Map<String, dynamic> _$$DelegatedLoginResponseImplToJson(
+        _$DelegatedLoginResponseImpl instance) =>
     <String, dynamic>{
       'token': instance.token,
-      'refreshToken': instance.refreshToken,
     };

--- a/packages/ion_identity_client/lib/src/auth/services/login_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/login_service.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:fpdart/fpdart.dart';
 import 'package:ion_identity_client/src/auth/data_sources/login_data_source.dart';
 import 'package:ion_identity_client/src/auth/result_types/login_user_result.dart';
 import 'package:ion_identity_client/src/core/token_storage/token_storage.dart';
@@ -42,11 +43,13 @@ class LoginService {
           ),
         )
         .flatMap(
-          (r) => tokenStorage.setToken(
-            username: username,
-            newToken: r.token,
-            onError: UnknownLoginUserFailure.new,
-          ),
+          (r) => TaskEither.tryCatch(
+            () => tokenStorage.setTokens(
+              username: username,
+              newTokens: r,
+            ),
+            (e, _) => UnknownLoginUserFailure(e.toString()),
+          ).map((_) => r),
         )
         .run();
 

--- a/packages/ion_identity_client/lib/src/auth/services/register_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/register_service.dart
@@ -45,10 +45,12 @@ class RegisterService {
           ),
         )
         .flatMap(
-          (r) => tokenStorage.setToken(
-            username: username,
-            newToken: r.authentication.token,
-            onError: UnknownRegisterUserFailure.new,
+          (r) => TaskEither.tryCatch(
+            () => tokenStorage.setTokens(
+              username: username,
+              newTokens: r.authentication,
+            ),
+            (error, _) => UnknownRegisterUserFailure(error),
           ),
         )
         .run();

--- a/packages/ion_identity_client/lib/src/core/network/auth_interceptor.dart
+++ b/packages/ion_identity_client/lib/src/core/network/auth_interceptor.dart
@@ -2,6 +2,7 @@
 
 import 'package:dio/dio.dart';
 import 'package:ion_identity_client/src/auth/services/delegated_login/delegated_login_service.dart';
+import 'package:ion_identity_client/src/core/types/request_headers.dart';
 
 class AuthInterceptor extends QueuedInterceptor {
   AuthInterceptor({
@@ -24,7 +25,8 @@ class AuthInterceptor extends QueuedInterceptor {
           final newToken = await delegatedLoginService.delegatedLogin(username: username);
 
           // Update the original request with the new token
-          err.requestOptions.headers['Authorization'] = 'Bearer ${newToken.token}';
+          final newAuthHeader = RequestHeaders.getTokenHeader(token: newToken.token).entries.first;
+          err.requestOptions.headers[newAuthHeader.key] = newAuthHeader.value;
 
           // Retry the original request
           final response = await dio.fetch<dynamic>(err.requestOptions);

--- a/packages/ion_identity_client/lib/src/core/network/auth_interceptor.dart
+++ b/packages/ion_identity_client/lib/src/core/network/auth_interceptor.dart
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:dio/dio.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/delegated_login_service.dart';
+
+class AuthInterceptor extends QueuedInterceptor {
+  AuthInterceptor({
+    required this.dio,
+    required this.delegatedLoginService,
+  });
+
+  final Dio dio;
+  final DelegatedLoginService delegatedLoginService;
+
+  @override
+  Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode == 401) {
+      // Extract username from the original request
+      final username = _extractUsername(err.requestOptions);
+
+      if (username != null) {
+        try {
+          // Attempt to refresh the token
+          final newToken = await delegatedLoginService.delegatedLogin(username: username);
+
+          // Update the original request with the new token
+          err.requestOptions.headers['Authorization'] = 'Bearer ${newToken.token}';
+
+          // Retry the original request
+          final response = await dio.fetch<dynamic>(err.requestOptions);
+          return handler.resolve(response);
+        } catch (e) {
+          // If token refresh fails, continue with the error
+          return handler.next(err);
+        }
+      }
+    }
+    // For other errors or if username is not found, continue with the error
+    return handler.next(err);
+  }
+
+  String? _extractUsername(RequestOptions options) {
+    return options.headers['X-Username'] as String?;
+  }
+}

--- a/packages/ion_identity_client/lib/src/core/service_locator/clients_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/clients_service_locator.dart
@@ -3,6 +3,8 @@
 import 'package:ion_identity_client/ion_client.dart';
 import 'package:ion_identity_client/src/auth/data_sources/data_sources.dart';
 import 'package:ion_identity_client/src/auth/data_sources/recover_user_data_source.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/data_sources/delegated_login_data_source.dart';
+import 'package:ion_identity_client/src/auth/services/delegated_login/delegated_login_service.dart';
 import 'package:ion_identity_client/src/auth/services/key_service.dart';
 import 'package:ion_identity_client/src/auth/services/recover_user_service.dart';
 import 'package:ion_identity_client/src/auth/services/services.dart';
@@ -87,6 +89,7 @@ mixin _AuthClient {
         config: config,
         signer: signer,
       ),
+      delegatedLoginService: createDelegatedLoginService(config: config),
       tokenStorage: IonServiceLocator.getTokenStorage(),
     );
   }
@@ -178,6 +181,24 @@ mixin _AuthClient {
   }) {
     return RecoverUserDataSource(
       networkClient: IonServiceLocator.getNetworkClient(config: config),
+    );
+  }
+
+  DelegatedLoginService createDelegatedLoginService({
+    required IonClientConfig config,
+  }) {
+    return DelegatedLoginService(
+      dataSource: createDelegatedLoginDataSource(config: config),
+      tokenStorage: IonServiceLocator.getTokenStorage(),
+    );
+  }
+
+  DelegatedLoginDataSource createDelegatedLoginDataSource({
+    required IonClientConfig config,
+  }) {
+    return DelegatedLoginDataSource(
+      networkClient: IonServiceLocator.getNetworkClient2(config: config),
+      tokenStorage: IonServiceLocator.getTokenStorage(),
     );
   }
 }

--- a/packages/ion_identity_client/lib/src/core/token_storage/token_storage.dart
+++ b/packages/ion_identity_client/lib/src/core/token_storage/token_storage.dart
@@ -5,9 +5,10 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:fpdart/fpdart.dart';
+import 'package:ion_identity_client/src/auth/dtos/dtos.dart';
 import 'package:ion_identity_client/src/core/types/types.dart';
 import 'package:ion_identity_client/src/core/types/user_token.dart';
+import 'package:rxdart/rxdart.dart';
 
 /// A class responsible for securely storing and managing user tokens using
 /// [FlutterSecureStorage]. It provides methods to set, retrieve, and remove
@@ -21,23 +22,19 @@ class TokenStorage {
   }) : _secureStorage = secureStorage;
 
   final FlutterSecureStorage _secureStorage;
-  final StreamController<List<UserToken>> _userTokensStreamController =
-      StreamController.broadcast();
+  final BehaviorSubject<List<UserToken>> _userTokensSubject = BehaviorSubject();
 
   /// A stream of the current list of user tokens. This stream updates whenever
   /// tokens are added, removed, or modified.
-  Stream<List<UserToken>> get userTokens => _userTokensStreamController.stream;
+  Stream<List<UserToken>> get userTokens => _userTokensSubject.stream;
 
-  final Map<String, String?> _userTokensCache = {};
+  final Map<String, Authentication?> _userTokensCache = {};
 
   /// The key used to store the tokens in secure storage.
   static const userTokensKey = 'ion_identity_client_user_tokens_key';
 
   Future<void> init() async {
     await _loadTokensFromStorage();
-    _userTokensStreamController.onListen = () {
-      _userTokensStreamController.add(_tokensAsList());
-    };
   }
 
   /// Retrieves the [UserToken] for the specified [username] from the cache.
@@ -52,31 +49,41 @@ class TokenStorage {
 
     return UserToken(
       username: username,
-      token: savedToken,
+      token: savedToken.token,
+      refreshToken: savedToken.refreshToken,
     );
   }
 
-  /// Sets a new token for the specified [username] and updates the cache.
-  /// If [newToken] is `null`, the existing token is removed. The [onError]
-  /// callback is used to handle any errors that occur during the operation.
-  /// Returns a [TaskEither] that either contains an error of type [E] or
-  /// a unit value indicating success.
-  TaskEither<E, Unit> setToken<E>({
+  Future<void> setToken({
     required String username,
-    required String? newToken,
-    required E Function(Object?, StackTrace?) onError,
-  }) {
-    return TaskEither<E, Unit>.tryCatch(
-      () async {
-        _userTokensCache[username] = newToken;
-        await _saveTokensToStorage();
+    required String newToken,
+  }) async {
+    final currentTokens = _userTokensCache[username];
+    final newTokens = currentTokens?.copyWith(token: newToken);
+    _userTokensCache[username] = newTokens;
 
-        final streamState = _tokensAsList();
-        _userTokensStreamController.add(streamState);
-        return unit;
-      },
-      onError,
-    );
+    await _saveTokensToStorage();
+    _userTokensSubject.add(_tokensAsList());
+  }
+
+  /// Sets a new token for the specified [username] and updates the cache.
+  /// If [newToken] is `null`, the existing token is removed.
+  /// This method also updates the secure storage and notifies listeners
+  /// of the token stream about the change.
+  ///
+  /// Parameters:
+  ///   [username]: The username associated with the token.
+  ///   [newToken]: The new token to be set. If null, the token is removed.
+  ///
+  /// Returns a [Future] that completes when the operation is finished.
+  Future<void> setTokens({
+    required String username,
+    required Authentication newTokens,
+  }) async {
+    _userTokensCache[username] = newTokens;
+    await _saveTokensToStorage();
+
+    _userTokensSubject.add(_tokensAsList());
   }
 
   /// Removes the token associated with the specified [username] from the cache
@@ -86,7 +93,7 @@ class TokenStorage {
   }) async {
     _userTokensCache.remove(username);
     await _saveTokensToStorage();
-    _userTokensStreamController.add(_tokensAsList());
+    _userTokensSubject.add(_tokensAsList());
   }
 
   /// Clears all stored tokens from the cache, updates the storage, and emits
@@ -94,12 +101,12 @@ class TokenStorage {
   Future<void> clearAllTokens() async {
     _userTokensCache.clear();
     await _saveTokensToStorage();
-    _userTokensStreamController.add(_tokensAsList());
+    _userTokensSubject.add(_tokensAsList());
   }
 
   /// Disposes of the stream controller, closing the stream to prevent memory leaks.
   void dispose() {
-    _userTokensStreamController.close();
+    _userTokensSubject.close();
   }
 
   /// Loads the tokens from secure storage into the in-memory cache and
@@ -107,18 +114,34 @@ class TokenStorage {
   Future<void> _loadTokensFromStorage() async {
     final tokensJson = await _secureStorage.read(key: userTokensKey);
     if (tokensJson == null) {
-      _userTokensStreamController.add([]);
+      _userTokensSubject.add([]);
       return;
     }
 
     final tokensMap = json.decode(tokensJson) as JsonObject;
-    _userTokensCache.addAll(Map<String, String?>.from(tokensMap));
-    _userTokensStreamController.add(_tokensAsList());
+    _userTokensCache.addAll(
+      Map<String, Authentication?>.from(
+        tokensMap.map(
+          (key, value) => MapEntry(
+            key,
+            Authentication.fromJson(value as JsonObject),
+          ),
+        ),
+      ),
+    );
+    _userTokensSubject.add(_tokensAsList());
   }
 
   /// Saves the current token cache to secure storage, serializing it as a JSON object.
   Future<void> _saveTokensToStorage() async {
-    final tokensJson = json.encode(_userTokensCache);
+    final tokensJson = json.encode(
+      _userTokensCache.map(
+        (key, value) => MapEntry(
+          key,
+          value?.toJson(),
+        ),
+      ),
+    );
     await _secureStorage.write(key: userTokensKey, value: tokensJson);
   }
 
@@ -127,7 +150,13 @@ class TokenStorage {
   List<UserToken> _tokensAsList() {
     return _userTokensCache.entries
         .map(
-          (e) => e.value == null ? null : UserToken(username: e.key, token: e.value!),
+          (e) => e.value == null
+              ? null
+              : UserToken(
+                  username: e.key,
+                  token: e.value!.token,
+                  refreshToken: e.value!.refreshToken,
+                ),
         )
         .whereNotNull()
         .toList();

--- a/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
+++ b/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
@@ -10,6 +10,14 @@ class UnauthenticatedException extends IonException {
   const UnauthenticatedException() : super('User is not authenticated');
 }
 
+class UserDeactivatedException extends IonException {
+  const UserDeactivatedException() : super('User account has been deactivated');
+}
+
+class UserNotFoundException extends IonException {
+  const UserNotFoundException() : super('User not found');
+}
+
 class UnknownIonException extends IonException {
   const UnknownIonException([super.message]);
 }

--- a/packages/ion_identity_client/lib/src/core/types/request_headers.dart
+++ b/packages/ion_identity_client/lib/src/core/types/request_headers.dart
@@ -2,14 +2,33 @@
 
 class RequestHeaders {
   static const ionIdentityClientId = 'X-Client-ID';
+  static const ionIdentityKeyName = 'X-Username';
   static const ionIdentityUserAction = 'X-Useraction';
   static const authorization = 'Authorization';
 
-  static Map<String, String> getAuthorizationHeader({
+  static Map<String, String> getAuthorizationHeaders({
+    required String token,
+    required String username,
+  }) {
+    return {
+      ...getTokenHeader(token: token),
+      ...getIonIdentityKeyNameHeader(username: username),
+    };
+  }
+
+  static Map<String, String> getTokenHeader({
     required String token,
   }) {
     return {
       authorization: 'Bearer $token',
+    };
+  }
+
+  static Map<String, String> getIonIdentityKeyNameHeader({
+    required String username,
+  }) {
+    return {
+      ionIdentityKeyName: username,
     };
   }
 }

--- a/packages/ion_identity_client/lib/src/core/types/user_token.freezed.dart
+++ b/packages/ion_identity_client/lib/src/core/types/user_token.freezed.dart
@@ -1,0 +1,203 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_token.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+UserToken _$UserTokenFromJson(Map<String, dynamic> json) {
+  return _UserToken.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UserToken {
+  String get username => throw _privateConstructorUsedError;
+  String get token => throw _privateConstructorUsedError;
+  String get refreshToken => throw _privateConstructorUsedError;
+
+  /// Serializes this UserToken to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of UserToken
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $UserTokenCopyWith<UserToken> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserTokenCopyWith<$Res> {
+  factory $UserTokenCopyWith(UserToken value, $Res Function(UserToken) then) =
+      _$UserTokenCopyWithImpl<$Res, UserToken>;
+  @useResult
+  $Res call({String username, String token, String refreshToken});
+}
+
+/// @nodoc
+class _$UserTokenCopyWithImpl<$Res, $Val extends UserToken>
+    implements $UserTokenCopyWith<$Res> {
+  _$UserTokenCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of UserToken
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? username = null,
+    Object? token = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_value.copyWith(
+      username: null == username
+          ? _value.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      token: null == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$UserTokenImplCopyWith<$Res>
+    implements $UserTokenCopyWith<$Res> {
+  factory _$$UserTokenImplCopyWith(
+          _$UserTokenImpl value, $Res Function(_$UserTokenImpl) then) =
+      __$$UserTokenImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String username, String token, String refreshToken});
+}
+
+/// @nodoc
+class __$$UserTokenImplCopyWithImpl<$Res>
+    extends _$UserTokenCopyWithImpl<$Res, _$UserTokenImpl>
+    implements _$$UserTokenImplCopyWith<$Res> {
+  __$$UserTokenImplCopyWithImpl(
+      _$UserTokenImpl _value, $Res Function(_$UserTokenImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserToken
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? username = null,
+    Object? token = null,
+    Object? refreshToken = null,
+  }) {
+    return _then(_$UserTokenImpl(
+      username: null == username
+          ? _value.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      token: null == token
+          ? _value.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+      refreshToken: null == refreshToken
+          ? _value.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UserTokenImpl extends _UserToken {
+  const _$UserTokenImpl(
+      {required this.username, required this.token, required this.refreshToken})
+      : super._();
+
+  factory _$UserTokenImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UserTokenImplFromJson(json);
+
+  @override
+  final String username;
+  @override
+  final String token;
+  @override
+  final String refreshToken;
+
+  @override
+  String toString() {
+    return 'UserToken(username: $username, token: $token, refreshToken: $refreshToken)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserTokenImpl &&
+            (identical(other.username, username) ||
+                other.username == username) &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.refreshToken, refreshToken) ||
+                other.refreshToken == refreshToken));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, username, token, refreshToken);
+
+  /// Create a copy of UserToken
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserTokenImplCopyWith<_$UserTokenImpl> get copyWith =>
+      __$$UserTokenImplCopyWithImpl<_$UserTokenImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UserTokenImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UserToken extends UserToken {
+  const factory _UserToken(
+      {required final String username,
+      required final String token,
+      required final String refreshToken}) = _$UserTokenImpl;
+  const _UserToken._() : super._();
+
+  factory _UserToken.fromJson(Map<String, dynamic> json) =
+      _$UserTokenImpl.fromJson;
+
+  @override
+  String get username;
+  @override
+  String get token;
+  @override
+  String get refreshToken;
+
+  /// Create a copy of UserToken
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UserTokenImplCopyWith<_$UserTokenImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/ion_identity_client/lib/src/core/types/user_token.g.dart
+++ b/packages/ion_identity_client/lib/src/core/types/user_token.g.dart
@@ -1,20 +1,21 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'authentication.dart';
+part of 'user_token.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthenticationImpl _$$AuthenticationImplFromJson(Map<String, dynamic> json) =>
-    _$AuthenticationImpl(
+_$UserTokenImpl _$$UserTokenImplFromJson(Map<String, dynamic> json) =>
+    _$UserTokenImpl(
+      username: json['username'] as String,
       token: json['token'] as String,
       refreshToken: json['refreshToken'] as String,
     );
 
-Map<String, dynamic> _$$AuthenticationImplToJson(
-        _$AuthenticationImpl instance) =>
+Map<String, dynamic> _$$UserTokenImplToJson(_$UserTokenImpl instance) =>
     <String, dynamic>{
+      'username': instance.username,
       'token': instance.token,
       'refreshToken': instance.refreshToken,
     };

--- a/packages/ion_identity_client/lib/src/ion_api_client.dart
+++ b/packages/ion_identity_client/lib/src/ion_api_client.dart
@@ -3,10 +3,10 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:ion_identity_client/ion_client.dart';
 import 'package:ion_identity_client/src/core/service_locator/ion_service_locator.dart';
 import 'package:ion_identity_client/src/core/token_storage/token_storage.dart';
 import 'package:ion_identity_client/src/ion_api_user_client.dart';
-import 'package:ion_identity_client/src/ion_client_config.dart';
 import 'package:ion_identity_client/src/signer/passkey_signer.dart';
 
 /// This class is an entry point for interacting with the API.Provids user-specific operations
@@ -67,8 +67,6 @@ class IonApiClient {
   /// A stream of the usernames of currently authorized users. This stream updates
   /// whenever the user tokens change, providing a real-time view of authenticated users.
   Stream<Iterable<String>> get authorizedUsers => _tokenStorage.userTokens.map(
-        (list) => list.map(
-          (e) => e.username,
-        ),
+        (tokens) => tokens.map((token) => token.username),
       );
 }

--- a/packages/ion_identity_client/lib/src/signer/data_sources/user_action_signer_data_source.dart
+++ b/packages/ion_identity_client/lib/src/signer/data_sources/user_action_signer_data_source.dart
@@ -42,9 +42,10 @@ class UserActionSignerDataSource {
         .post(
           initPath,
           data: request.toJson(),
-          headers: {
-            ...RequestHeaders.getAuthorizationHeader(token: token.token),
-          },
+          headers: RequestHeaders.getAuthorizationHeaders(
+            token: token.token,
+            username: username,
+          ),
           decoder: UserActionChallenge.fromJson,
         )
         .mapLeft(
@@ -76,9 +77,10 @@ class UserActionSignerDataSource {
         .post(
           completePath,
           data: requestData.toJson(),
-          headers: {
-            ...RequestHeaders.getAuthorizationHeader(token: token.token),
-          },
+          headers: RequestHeaders.getAuthorizationHeaders(
+            token: token.token,
+            username: username,
+          ),
           decoder: (response) => response['userAction'] as String,
         )
         .mapLeft(
@@ -103,7 +105,10 @@ class UserActionSignerDataSource {
     }
 
     final headers = {
-      ...RequestHeaders.getAuthorizationHeader(token: token.token),
+      ...RequestHeaders.getAuthorizationHeaders(
+        token: token.token,
+        username: username,
+      ),
       RequestHeaders.ionIdentityUserAction: signature,
     };
 

--- a/packages/ion_identity_client/lib/src/signer/data_sources/user_action_signer_data_source2.dart
+++ b/packages/ion_identity_client/lib/src/signer/data_sources/user_action_signer_data_source2.dart
@@ -36,9 +36,10 @@ class UserActionSignerDataSource2 {
     return networkClient.post(
       initPath,
       data: request.toJson(),
-      headers: {
-        ...RequestHeaders.getAuthorizationHeader(token: token.token),
-      },
+      headers: RequestHeaders.getAuthorizationHeaders(
+        token: token.token,
+        username: username,
+      ),
       decoder: UserActionChallenge.fromJson,
     );
   }
@@ -61,9 +62,10 @@ class UserActionSignerDataSource2 {
     return networkClient.post(
       completePath,
       data: requestData.toJson(),
-      headers: {
-        ...RequestHeaders.getAuthorizationHeader(token: token.token),
-      },
+      headers: RequestHeaders.getAuthorizationHeaders(
+        token: token.token,
+        username: username,
+      ),
       decoder: (response) => response['userAction'] as String,
     );
   }
@@ -80,7 +82,10 @@ class UserActionSignerDataSource2 {
     }
 
     final headers = {
-      ...RequestHeaders.getAuthorizationHeader(token: token.token),
+      ...RequestHeaders.getAuthorizationHeaders(
+        token: token.token,
+        username: username,
+      ),
       RequestHeaders.ionIdentityUserAction: signature,
     };
 

--- a/packages/ion_identity_client/lib/src/wallets/services/get_wallet_assets/data_sources/get_wallet_assets_data_source.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/get_wallet_assets/data_sources/get_wallet_assets_data_source.dart
@@ -32,7 +32,10 @@ class GetWalletAssetsDataSource {
     try {
       return await _networkClient.get(
         sprintf(walletAssetsPath, [walletId]),
-        headers: RequestHeaders.getAuthorizationHeader(token: token.token),
+        headers: RequestHeaders.getAuthorizationHeaders(
+          token: token.token,
+          username: username,
+        ),
         decoder: WalletAssets.fromJson,
       );
     } on NetworkException catch (e) {

--- a/packages/ion_identity_client/lib/src/wallets/services/get_wallet_history/data_sources/get_wallet_history_data_source.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/get_wallet_history/data_sources/get_wallet_history_data_source.dart
@@ -35,7 +35,10 @@ class GetWalletHistoryDataSource {
     try {
       return await _networkClient.get(
         sprintf(walletHistoryPath, [walletId]),
-        headers: RequestHeaders.getAuthorizationHeader(token: token.token),
+        headers: RequestHeaders.getAuthorizationHeaders(
+          token: token.token,
+          username: username,
+        ),
         queryParams: GetWalletHistoryRequestParams(
           limit: pageSize,
           paginationToken: pageToken,

--- a/packages/ion_identity_client/lib/src/wallets/services/get_wallet_nfts/data_sources/get_wallet_nfts_data_source.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/get_wallet_nfts/data_sources/get_wallet_nfts_data_source.dart
@@ -32,7 +32,10 @@ class GetWalletNftsDataSource {
     try {
       return await _networkClient.get(
         sprintf(walletNftsPath, [walletId]),
-        headers: RequestHeaders.getAuthorizationHeader(token: token.token),
+        headers: RequestHeaders.getAuthorizationHeaders(
+          token: token.token,
+          username: username,
+        ),
         decoder: WalletNfts.fromJson,
       );
     } on NetworkException catch (e) {

--- a/packages/ion_identity_client/lib/src/wallets/services/get_wallet_transfer_requests/data_sources/get_wallet_transfer_requests_data_source.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/get_wallet_transfer_requests/data_sources/get_wallet_transfer_requests_data_source.dart
@@ -33,7 +33,10 @@ class GetWalletTransferRequestsDataSource {
     try {
       return await _networkClient.get(
         sprintf(walletTransfersPath, [walletId]),
-        headers: RequestHeaders.getAuthorizationHeader(token: token.token),
+        headers: RequestHeaders.getAuthorizationHeaders(
+          token: token.token,
+          username: username,
+        ),
         queryParams: pageToken != null ? {'paginationToken': pageToken} : {},
         decoder: WalletTransferRequests.fromJson,
       );

--- a/packages/ion_identity_client/lib/src/wallets/services/get_wallets/data_sources/get_wallets_data_source.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/get_wallets/data_sources/get_wallets_data_source.dart
@@ -28,7 +28,10 @@ class GetWalletsDataSource {
     try {
       final response = await _networkClient.get(
         walletsPath,
-        headers: RequestHeaders.getAuthorizationHeader(token: token.token),
+        headers: RequestHeaders.getAuthorizationHeaders(
+          token: token.token,
+          username: username,
+        ),
         decoder: GetWalletsResponse.fromJson,
       );
       return response.items;

--- a/packages/ion_identity_client/pubspec.yaml
+++ b/packages/ion_identity_client/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   passkeys: ^2.1.0
   pointycastle: ^3.9.1
   pretty_dio_logger: ^1.4.0
+  rxdart: ^0.28.0
   sprintf: ^7.0.0
   uuid: ^4.5.1
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,26 +378,26 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
+      sha256: "832fcdc676171205201c9cffafd6b5add19393962f6598af8472b48b413026e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.8"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
+      sha256: c3d82779026f91b8e00c9ac18934595cbc9b490094ea682052beeafdb2bd50ac
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.8"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
+      sha256: "4ddbbdaa774265de44c97054dcec058a83d9081d071785ece601e348c18c267d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.5"
   dart_quill_delta:
     dependency: transitive
     description:
@@ -1766,10 +1766,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   screen_retriever:
     dependency: transitive
     description:


### PR DESCRIPTION
### What does this PR do?
This PR adds a feature to refresh tokens, so a user is not logged out after their token expires.

### Changes brought by this PR
- The main change is `AuthInterceptor `, it catches 401 errors from BE, blocks other requests (because it's a `QueuedInterceptor`) and tries to refresh token. After that it sets a new token header.

- Added `DelegatedLoginService` with its dependencies to ion_identity_client. This thing makes the request to get a new token.
- Updated ion_identity_client/example a little bit.
- Added `AppLifecycleProvider`, it holds the `AppLifecycleState`