### PR TITLE
feat: General error modal dialog UI

### DIFF
--- a/lib/app/extensions/riverpod.dart
+++ b/lib/app/extensions/riverpod.dart
@@ -4,6 +4,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/core/views/pages/error_modal.dart';
+import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 
 extension DebounceExtension on Ref {
   Future<void> debounce({Duration duration = const Duration(milliseconds: 300)}) {
@@ -34,11 +36,9 @@ extension DisplayErrorsExtension on WidgetRef {
           next.error != null &&
           isCurrentRoute &&
           context.mounted) {
-        showDialog<void>(
+        showSimpleBottomSheet<void>(
           context: context,
-          builder: (context) => AlertDialog(
-            content: Text(next.error.toString()),
-          ),
+          child: ErrorModal(error: next.error!),
         );
       }
     });

--- a/lib/app/features/core/providers/env_provider.dart
+++ b/lib/app/features/core/providers/env_provider.dart
@@ -32,11 +32,13 @@ class Env extends _$Env {
         .toList();
   }
 
-  String get(EnvVariable variable) {
-    return dotenv.get(variable.name);
-  }
+  T get<T>(EnvVariable variable) {
+    final value = dotenv.get(variable.name);
 
-  bool getBoolean(EnvVariable variable) {
-    return get(variable).toLowerCase() == 'true';
+    if (T == bool) {
+      return (value.toLowerCase() == 'true') as T;
+    }
+
+    return value as T;
   }
 }

--- a/lib/app/features/core/providers/env_provider.dart
+++ b/lib/app/features/core/providers/env_provider.dart
@@ -12,6 +12,7 @@ enum EnvVariable {
   ION_ANDROID_APP_ID,
   ION_IOS_APP_ID,
   ION_ORIGIN,
+  SHOW_DEBUG_INFO,
 }
 
 @Riverpod(keepAlive: true)
@@ -33,5 +34,9 @@ class Env extends _$Env {
 
   String get(EnvVariable variable) {
     return dotenv.get(variable.name);
+  }
+
+  bool getBoolean(EnvVariable variable) {
+    return get(variable).toLowerCase() == 'true';
   }
 }

--- a/lib/app/features/core/views/pages/error_modal.dart
+++ b/lib/app/features/core/views/pages/error_modal.dart
@@ -2,20 +2,33 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
+import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/providers/env_provider.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-class ErrorModal extends StatelessWidget {
+class ErrorModal extends ConsumerWidget {
   const ErrorModal({required this.error, super.key});
 
   final Object error;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final showDebugInfo =
+        ref.watch(envProvider.notifier).getBoolean(EnvVariable.SHOW_DEBUG_INFO);
+
+    final errorInfo = switch (error) {
+      Object _ when showDebugInfo => error.toString(),
+      IONException(code: final int code) =>
+        context.i18n.error_general_error_code(code),
+      _ => ''
+    };
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -24,7 +37,7 @@ class ErrorModal extends StatelessWidget {
           child: InfoCard(
             iconAsset: Assets.svg.actionWalletKeyserror,
             title: context.i18n.error_general_title,
-            description: error.toString(),
+            description: context.i18n.error_general_description(errorInfo),
           ),
         ),
         SizedBox(height: 24.0.s),

--- a/lib/app/features/core/views/pages/error_modal.dart
+++ b/lib/app/features/core/views/pages/error_modal.dart
@@ -19,13 +19,11 @@ class ErrorModal extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showDebugInfo =
-        ref.watch(envProvider.notifier).getBoolean(EnvVariable.SHOW_DEBUG_INFO);
+    final showDebugInfo = ref.watch(envProvider.notifier).getBoolean(EnvVariable.SHOW_DEBUG_INFO);
 
     final errorInfo = switch (error) {
       Object _ when showDebugInfo => error.toString(),
-      IONException(code: final int code) =>
-        context.i18n.error_general_error_code(code),
+      IONException(code: final int code) => context.i18n.error_general_error_code(code),
       _ => ''
     };
 

--- a/lib/app/features/core/views/pages/error_modal.dart
+++ b/lib/app/features/core/views/pages/error_modal.dart
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:ion/app/components/button/button.dart';
+import 'package:ion/app/components/card/info_card.dart';
+import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
+import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/generated/assets.gen.dart';
+
+class ErrorModal extends StatelessWidget {
+  const ErrorModal({required this.error, super.key});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: EdgeInsets.only(left: 30.0.s, right: 30.0.s, top: 30.0.s),
+          child: InfoCard(
+            iconAsset: Assets.svg.actionWalletKeyserror,
+            title: context.i18n.error_general_title,
+            description: error.toString(),
+          ),
+        ),
+        SizedBox(height: 24.0.s),
+        ScreenSideOffset.small(
+          child: Button(
+            label: Text(context.i18n.button_try_again),
+            mainAxisSize: MainAxisSize.max,
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        ScreenBottomOffset(),
+      ],
+    );
+  }
+}

--- a/lib/app/features/core/views/pages/error_modal.dart
+++ b/lib/app/features/core/views/pages/error_modal.dart
@@ -19,7 +19,7 @@ class ErrorModal extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showDebugInfo = ref.watch(envProvider.notifier).getBoolean(EnvVariable.SHOW_DEBUG_INFO);
+    final showDebugInfo = ref.watch(envProvider.notifier).get<bool>(EnvVariable.SHOW_DEBUG_INFO);
 
     final errorInfo = switch (error) {
       Object _ when showDebugInfo => error.toString(),

--- a/lib/app/services/ion_identity/ion_identity_provider.dart
+++ b/lib/app/services/ion_identity/ion_identity_provider.dart
@@ -14,8 +14,9 @@ Future<Raw<IONIdentity>> ionIdentity(Ref ref) async {
   await ref.watch(envProvider.future);
   final envController = ref.watch(envProvider.notifier);
 
-  final appId = envController
-      .get(Platform.isAndroid ? EnvVariable.ION_ANDROID_APP_ID : EnvVariable.ION_IOS_APP_ID);
+  final appId = envController.get<String>(
+    Platform.isAndroid ? EnvVariable.ION_ANDROID_APP_ID : EnvVariable.ION_IOS_APP_ID,
+  );
 
   final config = IONIdentityConfig(
     appId: appId,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -380,6 +380,8 @@
   "error_screenshots_arent_secure_description": "Anyone who has access to your keys can use your assets. We recommend writing with your hands.",
   "error_nickname_invalid": "Only letters, numbers, and dots are allowed",
   "error_general_title": "Something went wrong",
+  "error_general_description": "An unexpected error occurred. Please try again later. {info}",
+  "error_general_error_code": "Error code: {error}",
   "warning_avoid_storing_keys": "Avoid storing keys on any device to prevent losing access to funds in case of a hack",
   "warning_authenticator_setup": "Save and keep your key safe in case it is lost",
   "authenticator_setup_title": "Authenticator setup",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -379,6 +379,7 @@
   "error_screenshots_arent_secure_title": "Screenshots aren’t secure",
   "error_screenshots_arent_secure_description": "Anyone who has access to your keys can use your assets. We recommend writing with your hands.",
   "error_nickname_invalid": "Only letters, numbers, and dots are allowed",
+  "error_general_title": "Something went wrong",
   "warning_avoid_storing_keys": "Avoid storing keys on any device to prevent losing access to funds in case of a hack",
   "warning_authenticator_setup": "Save and keep your key safe in case it is lost",
   "authenticator_setup_title": "Authenticator setup",


### PR DESCRIPTION
## What does this PR do?
This PR implements the modal sheet to display general errors in the app.

## Resources
[Design](https://www.figma.com/design/3TnZngoFeklOVC8TexlR1D/%F0%9F%A7%8A-ICE-Cloud?node-id=42325-154130&t=DxnabsBFUzBEk15G-4)

## Changes brought by this PR
1. Added `ErrorModal` widget.
2. Replaced `AlertDialog` with `ErrorModal` in the `displayErrors` method.
3. Added `SHOW_DEBUG_INFO` flag.
4. Improved `get` method so it can read boolean env variables. 

## Screenshots
<img src="https://github.com/user-attachments/assets/523d76bd-7776-4415-b6a8-d6c0ddf05274" width=200>

