### PR TITLE
fix: replace explicit navigation with Navigator.pop via root navigator

### DIFF
--- a/lib/app/features/protect_account/authenticator/views/pages/delete_authenticator/authenticator_delete_success.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/delete_authenticator/authenticator_delete_success.dart
@@ -7,7 +7,6 @@ import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/router/app_routes.dart';
@@ -22,7 +21,6 @@ class AuthenticatorDeleteSuccessPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: Column(
@@ -31,7 +29,7 @@ class AuthenticatorDeleteSuccessPage extends ConsumerWidget {
           NavigationAppBar.modal(
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),

--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_page.dart
@@ -9,7 +9,6 @@ import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/features/protect_account/authenticator/data/model/authenticator_steps.dart';
@@ -29,7 +28,6 @@ class AuthenticatorSetupPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final formKey = useState<GlobalKey<FormState>?>(null);
     final codeController = useRef<TextEditingController?>(null);
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: CustomScrollView(
@@ -37,7 +35,7 @@ class AuthenticatorSetupPage extends HookConsumerWidget {
           SliverAppBarWithProgress(
             progressValue: step == AuthenticatorSetupSteps.success ? null : step.progressValue,
             title: step.getAppBarTitle(context),
-            onClose: () => ProfileRoute(pubkey: currentPubkey).go(context),
+            onClose: Navigator.of(context, rootNavigator: true).pop,
             showBackButton: step != AuthenticatorSetupSteps.success,
             showProgress: step != AuthenticatorSetupSteps.success,
           ),

--- a/lib/app/features/protect_account/backup/views/components/errors/secure_account_error_alert.dart
+++ b/lib/app/features/protect_account/backup/views/components/errors/secure_account_error_alert.dart
@@ -7,8 +7,6 @@ import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
-import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
@@ -20,7 +18,6 @@ class SecureAccountErrorAlert extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: Column(
@@ -30,7 +27,7 @@ class SecureAccountErrorAlert extends ConsumerWidget {
             title: Text(locale.protect_account_header_security),
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),

--- a/lib/app/features/protect_account/backup/views/pages/backup_options_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_options_page.dart
@@ -5,7 +5,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/protect_account/backup/views/components/backup_option.dart';
 import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
@@ -19,7 +18,6 @@ class BackupOptionsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: Column(
@@ -29,7 +27,7 @@ class BackupOptionsPage extends ConsumerWidget {
             title: Text(locale.protect_account_header_security),
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),

--- a/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/features/protect_account/backup/providers/create_recovery_key_action_notifier.dart';
@@ -11,7 +10,6 @@ import 'package:ion/app/features/protect_account/backup/views/pages/create_recov
 import 'package:ion/app/features/protect_account/backup/views/pages/create_recover_key_page/components/create_recovery_key_loading_state.dart';
 import 'package:ion/app/features/protect_account/backup/views/pages/create_recover_key_page/components/create_recovery_key_success_state.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
-import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
@@ -39,11 +37,10 @@ class _NavBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
     return NavigationAppBar.modal(
       actions: [
         NavigationCloseButton(
-          onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+          onPressed: Navigator.of(context, rootNavigator: true).pop,
         ),
       ],
     );

--- a/lib/app/features/protect_account/backup/views/pages/recovery_keys_success_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/recovery_keys_success_page.dart
@@ -7,7 +7,6 @@ import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_scrolled_body.dart';
 import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
@@ -22,7 +21,6 @@ class RecoveryKeysSuccessPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: AuthScrollContainer(
@@ -32,7 +30,7 @@ class RecoveryKeysSuccessPage extends ConsumerWidget {
         ),
         actions: [
           NavigationCloseButton(
-            onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+            onPressed: Navigator.of(context, rootNavigator: true).pop,
           ),
         ],
         title: locale.backup_option_with_recovery_keys_title,

--- a/lib/app/features/protect_account/components/delete_twofa_step_scaffold.dart
+++ b/lib/app/features/protect_account/components/delete_twofa_step_scaffold.dart
@@ -7,10 +7,8 @@ import 'package:ion/app/components/progress_bar/sliver_app_bar_with_progress.dar
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
-import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 
 class DeleteTwoFAStepScaffold extends ConsumerWidget {
@@ -34,7 +32,6 @@ class DeleteTwoFAStepScaffold extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: CustomScrollView(
@@ -42,7 +39,7 @@ class DeleteTwoFAStepScaffold extends ConsumerWidget {
           SliverAppBarWithProgress(
             progressValue: progressValue,
             title: title,
-            onClose: () => ProfileRoute(pubkey: currentPubkey).go(context),
+            onClose: Navigator.of(context, rootNavigator: true).pop,
           ),
           SliverToBoxAdapter(
             child: AuthHeader(

--- a/lib/app/features/protect_account/email/views/pages/delete_email/email_delete_success.dart
+++ b/lib/app/features/protect_account/email/views/pages/delete_email/email_delete_success.dart
@@ -7,7 +7,6 @@ import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/router/app_routes.dart';
@@ -22,7 +21,6 @@ class EmailDeleteSuccessPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: Column(
@@ -31,7 +29,7 @@ class EmailDeleteSuccessPage extends ConsumerWidget {
           NavigationAppBar.modal(
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),

--- a/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_page.dart
+++ b/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_page.dart
@@ -5,12 +5,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/sliver_app_bar_with_progress.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/features/protect_account/email/data/model/email_steps.dart';
 import 'package:ion/app/features/protect_account/email/views/pages/setup_email/step_pages.dart';
-import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -22,14 +20,13 @@ class EmailSetupPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
     return SheetContent(
       body: CustomScrollView(
         slivers: [
           SliverAppBarWithProgress(
             progressValue: step.progressValue,
             title: step.getAppBarTitle(context),
-            onClose: () => ProfileRoute(pubkey: currentPubkey).go(context),
+            onClose: Navigator.of(context, rootNavigator: true).pop,
             showBackButton: step != EmailSetupSteps.success,
             showProgress: step != EmailSetupSteps.success,
           ),

--- a/lib/app/features/protect_account/phone/views/pages/delete_phone/phone_delete_success.dart
+++ b/lib/app/features/protect_account/phone/views/pages/delete_phone/phone_delete_success.dart
@@ -7,7 +7,6 @@ import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/router/app_routes.dart';
@@ -22,7 +21,6 @@ class PhoneDeleteSuccessPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: Column(
@@ -31,7 +29,7 @@ class PhoneDeleteSuccessPage extends ConsumerWidget {
           NavigationAppBar.modal(
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),

--- a/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_page.dart
+++ b/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_page.dart
@@ -5,12 +5,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/sliver_app_bar_with_progress.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/features/protect_account/phone/models/phone_steps.dart';
 import 'package:ion/app/features/protect_account/phone/views/pages/setup_phone/step_pages.dart';
-import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -22,15 +20,13 @@ class PhoneSetupPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
-
     return SheetContent(
       body: CustomScrollView(
         slivers: [
           SliverAppBarWithProgress(
             progressValue: step.progressValue,
             title: step.getAppBarTitle(context),
-            onClose: () => ProfileRoute(pubkey: currentPubkey).go(context),
+            onClose: Navigator.of(context, rootNavigator: true).pop,
             showBackButton: step != PhoneSetupSteps.success,
             showProgress: step != PhoneSetupSteps.success,
           ),

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_modal.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_modal.dart
@@ -6,7 +6,6 @@ import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/router/app_routes.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
@@ -19,7 +18,6 @@ class SecureAccountModal extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.i18n;
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
 
     return SheetContent(
       body: Column(
@@ -29,7 +27,7 @@ class SecureAccountModal extends ConsumerWidget {
             title: Text(locale.protect_account_header_security),
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
@@ -6,7 +6,6 @@ import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/auth/providers/auth_provider.dart';
 import 'package:ion/app/features/protect_account/authenticator/data/model/authenticator_steps.dart';
 import 'package:ion/app/features/protect_account/components/secure_account_option.dart';
 import 'package:ion/app/features/protect_account/email/data/model/email_steps.dart';
@@ -26,7 +25,6 @@ class SecureAccountOptionsPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider) ?? '';
     final securityMethodsState = ref.watch(securityAccountControllerProvider);
     final securityMethods = securityMethodsState.valueOrNull;
     final isLoading = securityMethodsState.isLoading;
@@ -44,7 +42,7 @@ class SecureAccountOptionsPage extends HookConsumerWidget {
             title: Text(locale.protect_account_header_security),
             actions: [
               NavigationCloseButton(
-                onPressed: () => ProfileRoute(pubkey: currentPubkey).go(context),
+                onPressed: Navigator.of(context, rootNavigator: true).pop,
               ),
             ],
           ),


### PR DESCRIPTION
## Description
Replaced the explicit navigation via `ProfileRoute(pubkey: currentPubkey).go(context)` for the security sheets with `Navigator.of(context, rootNavigator: true).pop`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
