### PR TITLE
feat: Add forwarded and replied message indicators in chat

### DIFF
--- a/lib/app/features/chat/messages/views/components/forwarded_message_info/forwarded_message_info.dart
+++ b/lib/app/features/chat/messages/views/components/forwarded_message_info/forwarded_message_info.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:ion/app/components/avatar/avatar.dart';
 import 'package:ion/app/extensions/extensions.dart';

--- a/lib/app/features/chat/messages/views/components/forwarded_message_info/forwarded_message_info.dart
+++ b/lib/app/features/chat/messages/views/components/forwarded_message_info/forwarded_message_info.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:ion/app/components/avatar/avatar.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/generated/assets.gen.dart';
+
+class ForwardedMessageInfo extends StatelessWidget {
+  const ForwardedMessageInfo({required this.isMe, required this.isPublic, super.key});
+
+  final bool isMe;
+  final bool isPublic;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicWidth(
+      child: Container(
+        margin: EdgeInsets.only(bottom: 12.0.s),
+        decoration: BoxDecoration(
+          color: isMe
+              ? context.theme.appColors.primaryAccent
+              : context.theme.appColors.onPrimaryAccent,
+        ),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Assets.svg.iconChatForward.icon(
+                  size: 16.0.s,
+                  color: isMe
+                      ? context.theme.appColors.strokeElements
+                      : context.theme.appColors.onTertararyBackground,
+                ),
+                SizedBox(width: 4.0.s),
+                Text(
+                  isPublic ? context.i18n.common_forwarded_from : context.i18n.common_forwarded,
+                  style: context.theme.appTextThemes.body2.copyWith(
+                    color: isMe
+                        ? context.theme.appColors.strokeElements
+                        : context.theme.appColors.onTertararyBackground,
+                  ),
+                ),
+              ],
+            ),
+            if (isPublic)
+              Padding(
+                padding: EdgeInsets.only(top: 4.0.s),
+                child: Row(
+                  children: [
+                    Avatar(size: 20.0.s, imageUrl: 'https://picsum.photos/200/300'),
+                    SizedBox(width: 8.0.s),
+                    Text(
+                      'John Doe',
+                      style: context.theme.appTextThemes.body2.copyWith(
+                        color: isMe
+                            ? context.theme.appColors.onPrimaryAccent
+                            : context.theme.appColors.primaryText,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/features/chat/messages/views/components/message_types/emoji_message/emoji_message.dart
+++ b/lib/app/features/chat/messages/views/components/message_types/emoji_message/emoji_message.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/messages/views/components/forwarded_message_info/forwarded_message_info.dart';
 import 'package:ion/app/features/chat/messages/views/components/message_item_wrapper/message_item_wrapper.dart';
 import 'package:ion/app/features/chat/messages/views/components/message_metadata/message_metadata.dart';
 import 'package:ion/app/features/chat/messages/views/components/message_reactions/message_reactions.dart';
@@ -12,11 +13,13 @@ class EmojiMessage extends StatelessWidget {
     required this.emoji,
     required this.isMe,
     this.reactions,
+    this.hasForwardedMessage = false,
     super.key,
   });
   final bool isMe;
   final String emoji;
   final List<MessageReactionGroup>? reactions;
+  final bool hasForwardedMessage;
 
   @override
   Widget build(BuildContext context) {
@@ -26,21 +29,29 @@ class EmojiMessage extends StatelessWidget {
         horizontal: 12.0.s,
         vertical: 6.0.s,
       ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: reactions == null ? CrossAxisAlignment.center : CrossAxisAlignment.end,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: (reactions != null || hasForwardedMessage)
+                ? CrossAxisAlignment.end
+                : CrossAxisAlignment.center,
             children: [
-              Text(
-                emoji,
-                style: context.theme.appTextThemes.headline1.copyWith(height: 1),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (hasForwardedMessage) ForwardedMessageInfo(isMe: isMe, isPublic: true),
+                  Text(
+                    emoji,
+                    style: context.theme.appTextThemes.headline1.copyWith(height: 1),
+                  ),
+                  MessageReactions(reactions: reactions),
+                ],
               ),
-              MessageReactions(reactions: reactions),
+              MessageMetaData(isMe: isMe),
             ],
           ),
-          MessageMetaData(isMe: isMe),
         ],
       ),
     );

--- a/lib/app/features/chat/messages/views/components/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/messages/views/components/message_types/text_message/text_message.dart
@@ -5,7 +5,9 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/messages/views/components/message_item_wrapper/message_item_wrapper.dart';
 import 'package:ion/app/features/chat/messages/views/components/message_metadata/message_metadata.dart';
 import 'package:ion/app/features/chat/messages/views/components/message_reactions/message_reactions.dart';
+import 'package:ion/app/features/chat/messages/views/components/replied_message_info/replied_message_info.dart';
 import 'package:ion/app/features/chat/model/message_reaction_group.dart';
+import 'package:ion/app/features/chat/providers/mock.dart';
 
 class TextMessage extends StatelessWidget {
   const TextMessage({
@@ -25,33 +27,45 @@ class TextMessage extends StatelessWidget {
         vertical: 12.0.s,
       ),
       isMe: isMe,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Flexible(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      message,
-                      style: context.theme.appTextThemes.body2.copyWith(
-                        color: isMe
-                            ? context.theme.appColors.onPrimaryAccent
-                            : context.theme.appColors.primaryText,
-                      ),
-                    ),
-                    if (reactions.isNotEmpty) MessageReactions(reactions: reactions),
-                  ],
-                ),
+      child: IntrinsicWidth(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            RepliedMessageInfo(
+              isMe: isMe,
+              sender: ChatSender(
+                'Boris Johnson',
+                'https://picsum.photos/200/300',
+                isApproved: true,
+                isIceUser: false,
               ),
-              MessageMetaData(isMe: isMe),
-            ],
-          ),
-        ],
+              message: PhotoRecentChatMessage(DateTime.now()),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Flexible(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        message,
+                        style: context.theme.appTextThemes.body2.copyWith(
+                          color: isMe
+                              ? context.theme.appColors.onPrimaryAccent
+                              : context.theme.appColors.primaryText,
+                        ),
+                      ),
+                      if (reactions.isNotEmpty) MessageReactions(reactions: reactions),
+                    ],
+                  ),
+                ),
+                MessageMetaData(isMe: isMe),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/chat/messages/views/components/replied_message_info/replied_message_info.dart
+++ b/lib/app/features/chat/messages/views/components/replied_message_info/replied_message_info.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ion/app/extensions/extensions.dart';

--- a/lib/app/features/chat/messages/views/components/replied_message_info/replied_message_info.dart
+++ b/lib/app/features/chat/messages/views/components/replied_message_info/replied_message_info.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/providers/mock.dart';
+import 'package:ion/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart';
+
+class RepliedMessageInfo extends HookWidget {
+  const RepliedMessageInfo({
+    required this.isMe,
+    required this.sender,
+    required this.message,
+    super.key,
+  });
+
+  final bool isMe;
+  final ChatSender sender;
+  final RecentChatMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final bgColor = useMemoized(
+      () => isMe ? context.theme.appColors.darkBlue : context.theme.appColors.primaryBackground,
+      [isMe],
+    );
+
+    final textColor = useMemoized(
+      () => isMe ? context.theme.appColors.onPrimaryAccent : null,
+      [isMe],
+    );
+
+    return IntrinsicWidth(
+      child: Container(
+        padding: EdgeInsets.fromLTRB(6.0.s, 4.0.s, 8.0.s, 4.0.s),
+        margin: EdgeInsets.only(bottom: 12.0.s),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(10.0.s),
+        ),
+        child: IntrinsicHeight(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _SideVerticalDivider(isMe: isMe),
+              Flexible(
+                child: Column(
+                  children: [
+                    SenderSummary(sender: sender, textColor: textColor),
+                    ChatPreview(message: message, textColor: textColor, maxLines: 1),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SideVerticalDivider extends StatelessWidget {
+  const _SideVerticalDivider({
+    required this.isMe,
+  });
+
+  final bool isMe;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 2.0.s,
+      margin: EdgeInsets.only(right: 6.0.s),
+      decoration: BoxDecoration(
+        color:
+            isMe ? context.theme.appColors.onPrimaryAccent : context.theme.appColors.primaryAccent,
+        borderRadius: BorderRadius.circular(2.0.s),
+      ),
+    );
+  }
+}

--- a/lib/app/features/chat/messages/views/pages/messages_page.dart
+++ b/lib/app/features/chat/messages/views/pages/messages_page.dart
@@ -57,10 +57,12 @@ class MessagesPage extends ConsumerWidget {
                             emoji: '😂',
                             isMe: true,
                             reactions: mockReactionsSimple,
+                            hasForwardedMessage: true,
                           );
                         case 3:
                           return const EmojiMessage(
                             emoji: '🤔',
+                            hasForwardedMessage: true,
                             isMe: false,
                           );
                         case 4:

--- a/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
+++ b/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
@@ -58,7 +58,7 @@ class RecentChatTile extends ConsumerWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
-                          SenderSummary(chat: chat),
+                          SenderSummary(sender: chat.sender),
                           ChatTimestamp(chat: chat),
                         ],
                       ),
@@ -66,7 +66,7 @@ class RecentChatTile extends ConsumerWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          ChatPreview(chat: chat),
+                          Expanded(child: ChatPreview(message: chat.message)),
                           UnreadCountBadge(unreadCount: chat.unreadMessageCount),
                         ],
                       ),
@@ -83,23 +83,26 @@ class RecentChatTile extends ConsumerWidget {
 }
 
 class SenderSummary extends StatelessWidget {
-  const SenderSummary({required this.chat, super.key});
-  final RecentChatDataModel chat;
+  const SenderSummary({required this.sender, this.textColor, super.key});
+  final ChatSender sender;
+  final Color? textColor;
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
         Text(
-          chat.sender.name,
-          style: context.theme.appTextThemes.subtitle3,
+          sender.name,
+          style: context.theme.appTextThemes.subtitle3.copyWith(
+            color: textColor ?? context.theme.appColors.primaryText,
+          ),
         ),
-        if (chat.sender.isIceUser)
+        if (sender.isIceUser)
           Padding(
             padding: EdgeInsets.only(left: 4.0.s),
             child: Assets.svg.iconBadgeIcelogo.icon(size: 16.0.s),
           ),
-        if (chat.sender.isApproved)
+        if (sender.isApproved)
           Padding(
             padding: EdgeInsets.only(left: 4.0.s),
             child: Assets.svg.iconBadgeVerify.icon(size: 16.0.s),
@@ -129,27 +132,26 @@ class ChatTimestamp extends StatelessWidget {
 }
 
 class ChatPreview extends StatelessWidget {
-  const ChatPreview({required this.chat, super.key});
-  final RecentChatDataModel chat;
-
+  const ChatPreview({required this.message, this.textColor, this.maxLines = 2, super.key});
+  final RecentChatMessage message;
+  final Color? textColor;
+  final int maxLines;
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Row(
-        children: [
-          RecentChatMessageIcon(message: chat.message),
-          Expanded(
-            child: Text(
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              _getMessageContentText(chat.message, context),
-              style: context.theme.appTextThemes.body2.copyWith(
-                color: context.theme.appColors.onTertararyBackground,
-              ),
+    return Row(
+      children: [
+        RecentChatMessageIcon(message: message, color: textColor),
+        Flexible(
+          child: Text(
+            maxLines: maxLines,
+            overflow: TextOverflow.ellipsis,
+            _getMessageContentText(message, context),
+            style: context.theme.appTextThemes.body2.copyWith(
+              color: textColor ?? context.theme.appColors.onTertararyBackground,
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
@@ -169,8 +171,9 @@ class ChatPreview extends StatelessWidget {
 }
 
 class RecentChatMessageIcon extends StatelessWidget {
-  const RecentChatMessageIcon({required this.message, super.key});
+  const RecentChatMessageIcon({required this.message, this.color, super.key});
   final RecentChatMessage message;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
@@ -181,7 +184,7 @@ class RecentChatMessageIcon extends StatelessWidget {
         padding: EdgeInsets.only(right: 2.0.s),
         child: messageIconPath.icon(
           size: 16.0.s,
-          color: context.theme.appColors.onTertararyBackground,
+          color: color ?? context.theme.appColors.onTertararyBackground,
         ),
       );
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -79,6 +79,8 @@
   "common_document": "Document",
   "common_you": "You",
   "common_add_video": "Add video",
+  "common_forwarded": "Forwarded",
+  "common_forwarded_from": "Forwarded from",
   "auth_secured_by": "Secured by",
   "auth_privacy": "By continuing, you are agreeing to our [[:link]]terms_of_service[[/:link]] & [[:link]]privacy_policy[[/:link]]",
   "auth_terms_of_service": "Terms of Service",


### PR DESCRIPTION
## Description
Added visual indicators for forwarded and replied messages in chat, including sender info and message previews.

## Additional Notes
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

<img width="180" alt="image" src="https://github.com/user-attachments/assets/fe71c484-fc32-40d8-b007-36a3619134a9">
<img width="180" alt="image" src="https://github.com/user-attachments/assets/0bfde0ca-e5b4-4b5a-9543-fa00472c4960">
<img width="180" alt="image" src="https://github.com/user-attachments/assets/3e7e72dd-d467-47b2-92d1-2b506cac911f">
<img width="180" alt="image" src="https://github.com/user-attachments/assets/666e46d1-5674-4b1c-9290-404d2f9c4b2a">

## Figma Link (if applicable)
https://www.figma.com/design/3TnZngoFeklOVC8TexlR1D/%F0%9F%A7%8A-ICE-Cloud?node-id=43823-115687&m=dev
