### PR TITLE
fix: logic of the viewing stories

### DIFF
--- a/lib/app/features/feed/providers/feed_stories_data_source_provider.dart
+++ b/lib/app/features/feed/providers/feed_stories_data_source_provider.dart
@@ -26,7 +26,7 @@ List<EntitiesDataSource>? feedStoriesDataSource(Ref ref) {
               kinds: [PostEntity.kind],
               // TODO: uncomment when our relays are used
               // authors: [entry.value],
-              limit: 50,
+              limit: 70,
             ),
           ],
         ),

--- a/lib/app/features/feed/providers/feed_stories_data_source_provider.dart
+++ b/lib/app/features/feed/providers/feed_stories_data_source_provider.dart
@@ -26,7 +26,7 @@ List<EntitiesDataSource>? feedStoriesDataSource(Ref ref) {
               kinds: [PostEntity.kind],
               // TODO: uncomment when our relays are used
               // authors: [entry.value],
-              limit: 20,
+              limit: 50,
             ),
           ],
         ),

--- a/lib/app/features/feed/stories/providers/story_viewing_provider.dart
+++ b/lib/app/features/feed/stories/providers/story_viewing_provider.dart
@@ -72,14 +72,6 @@ class StoryViewingController extends _$StoryViewingController {
     }
   }
 
-  void moveToStoryIndex(int storyIndex) {
-    if (storyIndex >= 0 && storyIndex < state.userStories[state.currentUserIndex].stories.length) {
-      state = state.copyWith(
-        currentStoryIndex: storyIndex,
-      );
-    }
-  }
-
   void moveToNextUser() {
     if (state.hasNextUser) {
       state = state.copyWith(
@@ -94,19 +86,6 @@ class StoryViewingController extends _$StoryViewingController {
       state = state.copyWith(
         currentUserIndex: state.currentUserIndex - 1,
         currentStoryIndex: 0,
-      );
-    }
-  }
-
-  void moveToStory(int userIndex, int storyIndex) {
-    final isValidUser = userIndex >= 0 && userIndex < state.userStories.length;
-    final isValidStory =
-        isValidUser && storyIndex >= 0 && storyIndex < state.userStories[userIndex].stories.length;
-
-    if (isValidStory) {
-      state = state.copyWith(
-        currentUserIndex: userIndex,
-        currentStoryIndex: storyIndex,
       );
     }
   }

--- a/lib/app/features/feed/stories/providers/story_viewing_provider.dart
+++ b/lib/app/features/feed/stories/providers/story_viewing_provider.dart
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'dart:developer';
-
-import 'package:collection/collection.dart';
-import 'package:ion/app/extensions/object.dart';
 import 'package:ion/app/features/feed/stories/data/models/models.dart';
 import 'package:ion/app/features/feed/stories/providers/stories_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -17,37 +13,34 @@ part 'story_viewing_provider.g.dart';
 @riverpod
 class StoryViewingController extends _$StoryViewingController {
   @override
-  StoryViewerState build({required String startingPubkey}) {
-    final stories = ref.watch(storiesProvider);
+  StoryViewerState build() {
+    final stories = ref.watch(storiesProvider) ?? [];
 
-    const emptyState = StoryViewerState(
-      userStories: [],
+    return StoryViewerState(
+      userStories: stories,
       currentUserIndex: 0,
       currentStoryIndex: 0,
     );
+  }
 
-    log('Stories count: ${stories?.length}', name: 'StoryViewingController');
+  void loadStoriesByPubkey(String startingPubkey) {
+    final currentStories = state.userStories;
 
-    log('starting pubkey: $startingPubkey', name: 'StoryViewingController');
+    if (currentStories.isEmpty) return;
 
-    final result = stories?.firstWhereOrNull((UserStories userStories) {
-          return userStories.pubkey == startingPubkey;
-        })?.let<StoryViewerState>(
-          (UserStories foundStories) {
-            log(
-              'Stories count: ${stories.length}, Found index: ${stories.indexOf(foundStories)}',
-              name: 'StoryViewingController',
-            );
-            return StoryViewerState(
-              userStories: stories,
-              currentUserIndex: stories.indexOf(foundStories),
-              currentStoryIndex: 0,
-            );
-          },
-        ) ??
-        emptyState;
+    final startingUserIndex = currentStories.indexWhere(
+      (userStories) => userStories.pubkey == startingPubkey,
+    );
 
-    return result;
+    if (startingUserIndex == -1) return;
+
+    final filteredStories = currentStories.sublist(startingUserIndex);
+
+    state = StoryViewerState(
+      userStories: filteredStories,
+      currentUserIndex: 0,
+      currentStoryIndex: 0,
+    );
   }
 
   void moveToNextStory() {

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/core.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/core.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+export 'cube_page_view.dart';
 export 'stories_swiper.dart';
 export 'story_content.dart';
 export 'story_gesture_handler.dart';

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
@@ -5,6 +5,9 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+/// This widget is adapted from https://github.com/aeyrium/cube_transition
+/// with modifications to the disposal behavior of the PageController to prevent an exception 
+/// when the page attempts to use a disposed controller.
 enum CubeTransformStyle { inside, outside }
 
 /// Signature for a function that creates a widget for a given index in a [CubePageView]

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'dart:math';
 import 'dart:ui';
 

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/cube_page_view.dart
@@ -1,0 +1,223 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+enum CubeTransformStyle { inside, outside }
+
+/// Signature for a function that creates a widget for a given index in a [CubePageView]
+///
+/// Used by [CubePageView.builder] and other APIs that use lazily-generated widgets.
+///
+typedef CubeWidgetBuilder = CubeWidget Function(
+  BuildContext context,
+  int index,
+  double pageNotifier,
+);
+
+/// This Widget has the [PageView] widget inside.
+/// It works in two modes :
+///   1 - Using the default constructor [CubePageView] passing the items in `children` property.
+///   2 - Using the factory constructor [CubePageView.builder] passing a `itemBuilder` and `itemCount` properties.
+class CubePageView extends StatefulWidget {
+  /// Creates a scrollable list that works page by page from an explicit [List]
+  /// of widgets.
+  const CubePageView({
+    required this.children,
+    super.key,
+    this.onPageChanged,
+    this.controller,
+    this.scrollDirection = Axis.horizontal,
+    this.startPage = 0,
+    this.transformStyle = CubeTransformStyle.outside,
+  })  : itemBuilder = null,
+        itemCount = null;
+
+  /// Creates a scrollable list that works page by page using widgets that are
+  /// created on demand.
+  ///
+  /// This constructor is appropriate if you want to customize the behavior
+  ///
+  /// Providing a non-null [itemCount] lets the [CubePageView] compute the maximum
+  /// scroll extent.
+  ///
+  /// [itemBuilder] will be called only with indices greater than or equal to
+  /// zero and less than [itemCount].
+  const CubePageView.builder({
+    required this.itemCount,
+    required this.itemBuilder,
+    super.key,
+    this.onPageChanged,
+    this.controller,
+    this.scrollDirection = Axis.horizontal,
+    this.startPage = 0,
+    this.transformStyle = CubeTransformStyle.outside,
+  }) : children = null;
+
+  /// Called whenever the page in the center of the viewport changes.
+  final ValueChanged<int>? onPageChanged;
+
+  /// An object that can be used to control the position to which this page
+  /// view is scrolled.
+  final PageController? controller;
+
+  /// Builder to customize your items
+  final CubeWidgetBuilder? itemBuilder;
+
+  /// Starting page
+  final int startPage;
+
+  /// The number of items you have, this is only required if you use [CubePageView.builder]
+  final int? itemCount;
+
+  /// Widgets you want to use inside the [CubePageView], this is only required if you use [CubePageView] constructor
+  final List<Widget>? children;
+
+  /// Direction
+  final Axis scrollDirection;
+
+  /// inside or outside
+  final CubeTransformStyle transformStyle;
+
+  @override
+  CubePageViewState createState() => CubePageViewState();
+}
+
+class CubePageViewState extends State<CubePageView> {
+  final _pageNotifier = ValueNotifier<double>(0);
+  late PageController _pageController;
+
+  void _listener() {
+    _pageNotifier.value = _pageController.page ?? 0;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = widget.controller ?? PageController();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pageController.addListener(_listener);
+    });
+  }
+
+  @override
+  void dispose() {
+    _pageController.removeListener(_listener);
+    if (widget.controller == null) {
+      _pageController.dispose();
+    }
+    _pageNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ValueListenableBuilder<double>(
+        valueListenable: _pageNotifier,
+        builder: (_, value, child) => PageView.builder(
+          scrollDirection: widget.scrollDirection,
+          controller: _pageController,
+          onPageChanged: widget.onPageChanged,
+          physics: const ClampingScrollPhysics(),
+          itemCount: widget.itemCount ?? widget.children?.length ?? 0,
+          itemBuilder: (_, index) {
+            if (widget.itemBuilder != null) {
+              return widget.itemBuilder!(context, index, value);
+            }
+            return CubeWidget(
+              index: index,
+              pageNotifier: value,
+              rotationDirection: widget.scrollDirection,
+              transformStyle: widget.transformStyle,
+              child: widget.children![index],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// This widget has the logic to do the 3D cube transformation
+/// It only should be used if you use [CubePageView.builder]
+class CubeWidget extends StatelessWidget {
+  const CubeWidget({
+    required this.index,
+    required this.pageNotifier,
+    required this.child,
+    super.key,
+    this.rotationDirection = Axis.horizontal,
+    this.centerAligned = false,
+    this.transformStyle = CubeTransformStyle.outside,
+  });
+
+  /// Index of the current item
+  final int index;
+
+  /// Page Notifier value, it comes from the [CubeWidgetBuilder]
+  final double pageNotifier;
+
+  /// Rotation direction
+  final Axis rotationDirection;
+
+  /// sides are center-aligned, it looks not like a cube, but nice
+  final bool centerAligned;
+
+  /// inside or outside
+  final CubeTransformStyle transformStyle;
+
+  /// Child you want to use inside the Cube
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLeaving = (index - pageNotifier) <= 0;
+    final t = index - pageNotifier;
+    final rotation = lerpDouble(0, 90, t) ?? 0;
+    final opacity = lerpDouble(0, 1, t.abs())?.clamp(0.0, 1.0) ?? 0;
+    final transform = Matrix4.identity();
+
+    rotationDirection == Axis.horizontal
+        ? transform.setEntry(3, 2, 0.003)
+        : transform.setEntry(3, 2, 0.001);
+
+    if (transformStyle == CubeTransformStyle.outside) {
+      rotationDirection == Axis.horizontal
+          ? transform.rotateY(-degToRad(rotation))
+          : transform.rotateX(degToRad(rotation));
+    } else {
+      rotationDirection == Axis.horizontal
+          ? transform.rotateY(degToRad(rotation))
+          : transform.rotateX(-degToRad(rotation));
+    }
+
+    Alignment alignment;
+    if (rotationDirection == Axis.horizontal) {
+      alignment = isLeaving ? Alignment.centerRight : Alignment.centerLeft;
+    } else {
+      alignment = !isLeaving ? Alignment.topCenter : Alignment.bottomCenter;
+    }
+
+    return Transform(
+      alignment: alignment,
+      transform: transform,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Opacity(
+              opacity: opacity,
+              child: Container(
+                color: Colors.black87,
+              ),
+            ),
+          ),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+double degToRad(double deg) => deg * (pi / 180.0);
+double radToDeg(double rad) => rad * (180.0 / pi);

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/stories_swiper.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/stories_swiper.dart
@@ -4,31 +4,32 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/feed/stories/data/models/story.dart';
 import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/core.dart';
 import 'package:ion/app/utils/future.dart';
 
 class StoriesSwiper extends HookConsumerWidget {
   const StoriesSwiper({
-    required this.pubkey,
+    required this.userStories,
+    required this.currentUserIndex,
     super.key,
   });
 
-  final String pubkey;
+  final List<UserStories> userStories;
+  final int currentUserIndex;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final storyState = ref.watch(storyViewingControllerProvider(startingPubkey: pubkey));
-    final userPageController = usePageController(initialPage: storyState.currentUserIndex);
+    final userPageController = usePageController(initialPage: currentUserIndex);
 
     return CubePageView.builder(
       controller: userPageController,
-      itemCount: storyState.userStories.length,
-      onPageChanged:
-          ref.read(storyViewingControllerProvider(startingPubkey: pubkey).notifier).moveToUser,
+      itemCount: userStories.length,
+      onPageChanged: ref.read(storyViewingControllerProvider.notifier).moveToUser,
       itemBuilder: (context, userIndex, userNotifier) {
-        final userStory = storyState.userStories[userIndex];
-        final isCurrentUser = userIndex == storyState.currentUserIndex;
+        final userStory = userStories[userIndex];
+        final isCurrentUser = userIndex == currentUserIndex;
 
         return CubeWidget(
           index: userIndex,
@@ -38,16 +39,13 @@ class StoriesSwiper extends HookConsumerWidget {
               return UserStoryPageView(
                 userStory: userStory,
                 isCurrentUser: isCurrentUser,
-                currentStoryIndex: isCurrentUser ? storyState.currentStoryIndex : 0,
-                onNextStory: ref
-                    .read(storyViewingControllerProvider(startingPubkey: pubkey).notifier)
-                    .moveToNextStory,
-                onPreviousStory: ref
-                    .read(storyViewingControllerProvider(startingPubkey: pubkey).notifier)
-                    .moveToPreviousStory,
+                currentStoryIndex:
+                    isCurrentUser ? ref.read(storyViewingControllerProvider).currentStoryIndex : 0,
+                onNextStory: ref.read(storyViewingControllerProvider.notifier).moveToNextStory,
+                onPreviousStory:
+                    ref.read(storyViewingControllerProvider.notifier).moveToPreviousStory,
                 onNextUser: () {
-                  if (userPageController.hasClients &&
-                      userIndex < storyState.userStories.length - 1) {
+                  if (userPageController.hasClients && userIndex < userStories.length - 1) {
                     userPageController.nextPage(
                       duration: 300.ms,
                       curve: Curves.easeInOut,

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/stories_swiper.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/stories_swiper.dart
@@ -27,45 +27,34 @@ class StoriesSwiper extends HookConsumerWidget {
       controller: userPageController,
       itemCount: userStories.length,
       onPageChanged: ref.read(storyViewingControllerProvider.notifier).moveToUser,
-      itemBuilder: (context, userIndex, userNotifier) {
+      itemBuilder: (context, userIndex, pageNotifier) {
         final userStory = userStories[userIndex];
         final isCurrentUser = userIndex == currentUserIndex;
 
+        final storyController = ref.read(storyViewingControllerProvider);
+        final storyNotifier = ref.read(storyViewingControllerProvider.notifier);
+
         return CubeWidget(
           index: userIndex,
-          pageNotifier: userNotifier,
-          child: Consumer(
-            builder: (context, ref, _) {
-              return UserStoryPageView(
-                userStory: userStory,
-                isCurrentUser: isCurrentUser,
-                currentStoryIndex:
-                    isCurrentUser ? ref.read(storyViewingControllerProvider).currentStoryIndex : 0,
-                onNextStory: ref.read(storyViewingControllerProvider.notifier).moveToNextStory,
-                onPreviousStory:
-                    ref.read(storyViewingControllerProvider.notifier).moveToPreviousStory,
-                onNextUser: () {
-                  if (userPageController.hasClients && userIndex < userStories.length - 1) {
-                    userPageController.nextPage(
-                      duration: 300.ms,
-                      curve: Curves.easeInOut,
-                    );
-                  } else {
-                    context.pop();
-                  }
-                },
-                onPreviousUser: () {
-                  if (userPageController.hasClients && userIndex > 0) {
-                    userPageController.previousPage(
-                      duration: 300.ms,
-                      curve: Curves.easeInOut,
-                    );
-                  } else {
-                    context.pop();
-                  }
-                },
-              );
-            },
+          pageNotifier: pageNotifier,
+          child: UserStoryPageView(
+            userStory: userStory,
+            isCurrentUser: isCurrentUser,
+            currentStoryIndex: isCurrentUser ? storyController.currentStoryIndex : 0,
+            onNextStory: storyNotifier.moveToNextStory,
+            onPreviousStory: storyNotifier.moveToPreviousStory,
+            onNextUser: () => userPageController.hasClients && userIndex < userStories.length - 1
+                ? userPageController.nextPage(
+                    duration: 300.ms,
+                    curve: Curves.easeInOut,
+                  )
+                : context.pop(),
+            onPreviousUser: () => userPageController.hasClients && userIndex > 0
+                ? userPageController.previousPage(
+                    duration: 300.ms,
+                    curve: Curves.easeInOut,
+                  )
+                : context.pop(),
           ),
         );
       },

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
@@ -39,9 +39,7 @@ class StoryContent extends HookConsumerWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          StoryViewerContent(
-            post: post,
-          ),
+          StoryViewerContent(post: post),
           StoryViewerHeader(currentPost: post),
           Stack(
             children: [

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_viewer_action_buttons.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_viewer_action_buttons.dart
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'dart:math';
-
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
@@ -91,18 +90,19 @@ class _SoundButton extends ConsumerWidget {
   }
 }
 
-class _LikeButton extends ConsumerWidget {
+class _LikeButton extends HookConsumerWidget {
   const _LikeButton({required this.post});
 
   final PostEntity post;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isLiked = Random().nextBool();
+    final isLiked = useState(false);
 
-    final icon = isLiked ? Assets.svg.iconVideoLikeOn : Assets.svg.iconVideoLikeOff;
-    final color =
-        isLiked ? context.theme.appColors.attentionRed : context.theme.appColors.onPrimaryAccent;
+    final icon = isLiked.value ? Assets.svg.iconVideoLikeOn : Assets.svg.iconVideoLikeOff;
+    final color = isLiked.value
+        ? context.theme.appColors.attentionRed
+        : context.theme.appColors.onPrimaryAccent;
 
     return StoryControlButton(
       icon: icon.icon(
@@ -111,9 +111,10 @@ class _LikeButton extends ConsumerWidget {
       ),
       borderRadius: 16.0.s,
       iconPadding: 8.0.s,
-      onPressed: () => ref
-          .read(storyViewingControllerProvider(startingPubkey: post.pubkey).notifier)
-          .toggleLike(post.id),
+      onPressed: () {
+        isLiked.value = !isLiked.value;
+        ref.read(storyViewingControllerProvider.notifier).toggleLike(post.id);
+      },
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
@@ -11,7 +11,6 @@ class UserStoryPageView extends StatelessWidget {
     required this.userStory,
     required this.isCurrentUser,
     required this.currentStoryIndex,
-    required this.onStoryPageChanged,
     required this.onNextStory,
     required this.onPreviousStory,
     required this.onNextUser,
@@ -22,7 +21,6 @@ class UserStoryPageView extends StatelessWidget {
   final UserStories userStory;
   final bool isCurrentUser;
   final int currentStoryIndex;
-  final ValueChanged<int> onStoryPageChanged;
   final VoidCallback onNextStory;
   final VoidCallback onPreviousStory;
   final VoidCallback onNextUser;
@@ -37,9 +35,7 @@ class UserStoryPageView extends StatelessWidget {
         onTapLeft: () => currentStoryIndex > 0 ? onPreviousStory() : onPreviousUser(),
         onTapRight: () =>
             currentStoryIndex < userStory.stories.length - 1 ? onNextStory() : onNextUser(),
-        child: StoryContent(
-          post: currentStory,
-        ),
+        child: StoryContent(post: currentStory),
       ),
     );
   }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_viewer_header.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_viewer_header.dart
@@ -31,7 +31,7 @@ class StoryViewerHeader extends ConsumerWidget {
           left: 16.0.s,
           right: 22.0.s,
           child: GestureDetector(
-            onTap: () => ProfileRoute(pubkey: currentPost.pubkey).go(context),
+            onTap: () => StoryProfileRoute(pubkey: currentPost.pubkey).push<void>(context),
             child: ListItem.user(
               profilePicture: userMetadata.data.picture,
               title: Text(

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/progress/story_progress_bar_container.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/progress/story_progress_bar_container.dart
@@ -9,31 +9,36 @@ import 'package:ion/app/features/feed/stories/views/components/story_viewer/comp
 
 class StoryProgressBarContainer extends ConsumerWidget {
   const StoryProgressBarContainer({
-    required this.pubkey,
     super.key,
   });
 
-  final String pubkey;
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final storyState = ref.watch(storyViewingControllerProvider(startingPubkey: pubkey));
-    final posts = storyState.userStories[storyState.currentUserIndex].stories;
+    final storyState = ref.watch(storyViewingControllerProvider);
+
+    final userStories = storyState.userStories;
+    final currentStoryIndex = storyState.currentStoryIndex;
+    final currentUserIndex = storyState.currentUserIndex;
+
+    final posts = userStories.isNotEmpty ? userStories[currentUserIndex].stories : null;
+
+    if (posts?.isEmpty ?? true) {
+      return const SizedBox();
+    }
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 16.0.s),
       child: Row(
-        children: posts.asMap().entries.map((post) {
+        children: posts!.asMap().entries.map((post) {
           final index = post.key;
           return Expanded(
             child: StoryProgressTracker(
               post: post.value,
-              isActive: index <= storyState.currentStoryIndex,
-              isCurrent: index == storyState.currentStoryIndex,
-              isPreviousStory: index < storyState.currentStoryIndex,
+              isActive: index <= currentStoryIndex,
+              isCurrent: index == currentStoryIndex,
+              isPreviousStory: index < currentStoryIndex,
               onCompleted: () {
-                final notifier =
-                    ref.read(storyViewingControllerProvider(startingPubkey: pubkey).notifier);
+                final notifier = ref.read(storyViewingControllerProvider.notifier);
 
                 if (storyState.hasNextStory) {
                   notifier.moveToNextStory();

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 
 class ImageStoryViewer extends StatelessWidget {
   const ImageStoryViewer({required this.path, super.key});
@@ -9,11 +11,15 @@ class ImageStoryViewer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Image.network(
-      path,
-      fit: BoxFit.cover,
+    return CachedNetworkImage(
+      imageUrl: path,
+      fit: BoxFit.contain,
       width: double.infinity,
-      height: double.infinity,
+      filterQuality: FilterQuality.medium,
+      placeholderFadeInDuration: Duration.zero,
+      progressIndicatorBuilder: (context, url, downloadProgress) =>
+          const CenteredLoadingIndicator(),
+      errorWidget: (context, url, error) => const SizedBox.shrink(),
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
@@ -15,10 +15,8 @@ class ImageStoryViewer extends StatelessWidget {
       imageUrl: path,
       fit: BoxFit.contain,
       width: double.infinity,
-      filterQuality: FilterQuality.medium,
-      placeholderFadeInDuration: Duration.zero,
-      progressIndicatorBuilder: (context, url, downloadProgress) =>
-          const CenteredLoadingIndicator(),
+      filterQuality: FilterQuality.high,
+      progressIndicatorBuilder: (_, __, ___) => const CenteredLoadingIndicator(),
       errorWidget: (context, url, error) => const SizedBox.shrink(),
     );
   }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/story_viewer_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/story_viewer_content.dart
@@ -18,15 +18,15 @@ class StoryViewerContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final media = post.data.primaryMedia;
-    if (media == null) {
-      return const SizedBox.shrink();
-    }
+    // if (media == null) {
+    //   return const SizedBox.shrink();
+    // }
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(16.0.s),
-      child: switch (media.mediaType) {
-        MediaType.image => ImageStoryViewer(path: media.url),
-        MediaType.video => VideoStoryViewer(videoPath: media.url),
+      child: switch (media?.mediaType) {
+        MediaType.image => ImageStoryViewer(path: media!.url),
+        MediaType.video => VideoStoryViewer(videoPath: media!.url),
         _ => const CenteredLoadingIndicator()
       },
     );

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/story_viewer_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/story_viewer_content.dart
@@ -18,15 +18,16 @@ class StoryViewerContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final media = post.data.primaryMedia;
-    // if (media == null) {
-    //   return const SizedBox.shrink();
-    // }
+
+    if (media == null) {
+      return const SizedBox.shrink();
+    }
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(16.0.s),
-      child: switch (media?.mediaType) {
-        MediaType.image => ImageStoryViewer(path: media!.url),
-        MediaType.video => VideoStoryViewer(videoPath: media!.url),
+      child: switch (media.mediaType) {
+        MediaType.image => ImageStoryViewer(path: media.url),
+        MediaType.video => VideoStoryViewer(videoPath: media.url),
         _ => const CenteredLoadingIndicator()
       },
     );

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -37,14 +37,11 @@ class VideoStoryViewer extends HookConsumerWidget {
 
     final videoAspectRatio = videoController.value.aspectRatio;
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SizedBox(
-          width: constraints.maxWidth,
-          height: constraints.maxWidth / videoAspectRatio,
-          child: VideoPlayer(videoController),
-        );
-      },
+    return Center(
+      child: AspectRatio(
+        aspectRatio: videoAspectRatio,
+        child: VideoPlayer(videoController),
+      ),
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -37,11 +37,14 @@ class VideoStoryViewer extends HookConsumerWidget {
 
     final videoAspectRatio = videoController.value.aspectRatio;
 
-    return Center(
-      child: AspectRatio(
-        aspectRatio: videoAspectRatio,
-        child: VideoPlayer(videoController),
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SizedBox(
+          width: constraints.maxWidth,
+          height: constraints.maxWidth / videoAspectRatio,
+          child: VideoPlayer(videoController),
+        );
+      },
     );
   }
 }

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -2,15 +2,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:go_router/go_router.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/components.dart';
 
-class StoryViewerPage extends HookConsumerWidget {
+class StoryViewerPage extends StatelessWidget {
   const StoryViewerPage({
     required this.pubkey,
     super.key,
@@ -19,24 +15,7 @@ class StoryViewerPage extends HookConsumerWidget {
   final String pubkey;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final storyViewingController =
-        ref.watch(storyViewingControllerProvider(startingPubkey: pubkey).notifier);
-    final storyState = ref.watch(storyViewingControllerProvider(startingPubkey: pubkey));
-
-    final currentPauseState = useState(false);
-    final userPageController = usePageController();
-
-    useEffect(
-      () {
-        if (userPageController.hasClients) {
-          userPageController.jumpToPage(storyState.currentUserIndex);
-        }
-        return null;
-      },
-      [storyState],
-    );
-
+  Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
         statusBarColor: context.theme.appColors.primaryText,
@@ -51,34 +30,12 @@ class StoryViewerPage extends HookConsumerWidget {
             children: [
               Expanded(
                 child: StoriesSwiper(
-                  userPageController: userPageController,
-                  userStories: storyState.userStories,
-                  currentUserIndex: storyState.currentUserIndex,
-                  currentStoryIndex: storyState.currentStoryIndex,
-                  onUserPageChanged: storyViewingController.moveToUser,
-                  onStoryPageChanged: storyViewingController.moveToStoryIndex,
-                  onNextStory: storyViewingController.moveToNextStory,
-                  onPreviousStory: storyViewingController.moveToPreviousStory,
-                  onPausedChanged: (paused) => currentPauseState.value = paused,
+                  key: ValueKey(pubkey),
+                  pubkey: pubkey,
                 ),
               ),
               SizedBox(height: 28.0.s),
-              StoryProgressBarContainer(
-                posts: storyState.userStories[storyState.currentUserIndex].stories,
-                currentStoryIndex: storyState.currentStoryIndex,
-                onStoryCompleted: () {
-                  if (storyState.hasNextStory) {
-                    storyViewingController.moveToNextStory();
-                  } else if (storyState.hasNextUser) {
-                    userPageController.nextPage(
-                      duration: const Duration(milliseconds: 300),
-                      curve: Curves.easeInOut,
-                    );
-                  } else {
-                    context.pop();
-                  }
-                },
-              ),
+              StoryProgressBarContainer(pubkey: pubkey),
               ScreenBottomOffset(margin: 16.0.s),
             ],
           ),

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -2,11 +2,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/components.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 
-class StoryViewerPage extends StatelessWidget {
+class StoryViewerPage extends HookConsumerWidget {
   const StoryViewerPage({
     required this.pubkey,
     super.key,
@@ -15,7 +18,13 @@ class StoryViewerPage extends StatelessWidget {
   final String pubkey;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final storyState = ref.watch(storyViewingControllerProvider);
+
+    useOnInit(
+      () => ref.read(storyViewingControllerProvider.notifier).loadStoriesByPubkey(pubkey),
+    );
+
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
         statusBarColor: context.theme.appColors.primaryText,
@@ -30,12 +39,12 @@ class StoryViewerPage extends StatelessWidget {
             children: [
               Expanded(
                 child: StoriesSwiper(
-                  key: ValueKey(pubkey),
-                  pubkey: pubkey,
+                  userStories: storyState.userStories,
+                  currentUserIndex: storyState.currentUserIndex,
                 ),
               ),
               SizedBox(height: 28.0.s),
-              StoryProgressBarContainer(pubkey: pubkey),
+              const StoryProgressBarContainer(),
               ScreenBottomOffset(margin: 16.0.s),
             ],
           ),

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart
@@ -1,29 +1,25 @@
-// SPDX-License-Identifier: ice License 1.0
-
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/avatar/avatar.dart';
-import 'package:ion/app/extensions/build_context.dart';
-import 'package:ion/app/extensions/num.dart';
-import 'package:ion/app/extensions/theme_data.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/plus_icon.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_colored_border.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.dart';
 import 'package:ion/app/router/app_routes.dart';
 
-class StoryListItem extends HookConsumerWidget {
-  const StoryListItem({
+class CurrentUserStoryListItem extends HookConsumerWidget {
+  const CurrentUserStoryListItem({
     required this.pubkey,
+    required this.gradient,
     super.key,
-    this.gradient,
   });
 
   final String pubkey;
   final Gradient? gradient;
 
-  static double get width => 65.0.s;
-  static double get height => 91.0.s;
-  static double get borderSize => 2.0.s;
+  static double get plusSize => 18.0.s;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -37,8 +33,8 @@ class StoryListItem extends HookConsumerWidget {
         return GestureDetector(
           onTap: () => StoryViewerRoute(pubkey: pubkey).push<void>(context),
           child: SizedBox(
-            width: width,
-            height: height,
+            width: StoryListItem.width,
+            height: StoryListItem.height,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -47,16 +43,22 @@ class StoryListItem extends HookConsumerWidget {
                   alignment: Alignment.bottomCenter,
                   children: [
                     StoryColoredBorder(
-                      size: width,
+                      size: StoryListItem.width,
                       color: context.theme.appColors.strokeElements,
                       gradient: viewed.value ? null : gradient,
                       child: StoryColoredBorder(
-                        size: width - borderSize * 2,
+                        size: StoryListItem.width - StoryListItem.borderSize * 2,
                         color: context.theme.appColors.secondaryBackground,
                         child: Avatar(
-                          size: width - borderSize * 4,
+                          size: StoryListItem.width - StoryListItem.borderSize * 4,
                           imageUrl: userMetadata.data.picture,
                         ),
+                      ),
+                    ),
+                    Positioned(
+                      bottom: -plusSize / 2,
+                      child: PlusIcon(
+                        size: plusSize,
                       ),
                     ),
                   ],
@@ -64,7 +66,7 @@ class StoryListItem extends HookConsumerWidget {
                 Padding(
                   padding: EdgeInsets.symmetric(horizontal: 2.0.s),
                   child: Text(
-                    userMetadata.data.name,
+                    context.i18n.common_you,
                     style: context.theme.appTextThemes.caption3.copyWith(
                       color: context.theme.appColors.primaryText,
                     ),

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart
@@ -1,8 +1,13 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/avatar/avatar.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
+import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
+import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_sheets.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/plus_icon.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_colored_border.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart';
@@ -30,52 +35,60 @@ class CurrentUserStoryListItem extends HookConsumerWidget {
       data: (userMetadata) {
         if (userMetadata == null) return const SizedBox.shrink();
 
-        return GestureDetector(
-          onTap: () => StoryViewerRoute(pubkey: pubkey).push<void>(context),
-          child: SizedBox(
-            width: StoryListItem.width,
-            height: StoryListItem.height,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Stack(
-                  clipBehavior: Clip.none,
-                  alignment: Alignment.bottomCenter,
+        return PermissionAwareWidget(
+          permissionType: Permission.camera,
+          onGranted: () => StoryRecordRoute().push<void>(context),
+          requestDialog: const PermissionRequestSheet(permission: Permission.camera),
+          settingsDialog: SettingsRedirectSheet.fromType(context, Permission.camera),
+          builder: (context, onPressed) {
+            return GestureDetector(
+              onTap: onPressed,
+              child: SizedBox(
+                width: StoryListItem.width,
+                height: StoryListItem.height,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    StoryColoredBorder(
-                      size: StoryListItem.width,
-                      color: context.theme.appColors.strokeElements,
-                      gradient: viewed.value ? null : gradient,
-                      child: StoryColoredBorder(
-                        size: StoryListItem.width - StoryListItem.borderSize * 2,
-                        color: context.theme.appColors.secondaryBackground,
-                        child: Avatar(
-                          size: StoryListItem.width - StoryListItem.borderSize * 4,
-                          imageUrl: userMetadata.data.picture,
+                    Stack(
+                      clipBehavior: Clip.none,
+                      alignment: Alignment.bottomCenter,
+                      children: [
+                        StoryColoredBorder(
+                          size: StoryListItem.width,
+                          color: context.theme.appColors.strokeElements,
+                          gradient: viewed.value ? null : gradient,
+                          child: StoryColoredBorder(
+                            size: StoryListItem.width - StoryListItem.borderSize * 2,
+                            color: context.theme.appColors.secondaryBackground,
+                            child: Avatar(
+                              size: StoryListItem.width - StoryListItem.borderSize * 4,
+                              imageUrl: userMetadata.data.picture,
+                            ),
+                          ),
                         ),
-                      ),
+                        Positioned(
+                          bottom: -plusSize / 2,
+                          child: PlusIcon(
+                            size: plusSize,
+                          ),
+                        ),
+                      ],
                     ),
-                    Positioned(
-                      bottom: -plusSize / 2,
-                      child: PlusIcon(
-                        size: plusSize,
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 2.0.s),
+                      child: Text(
+                        context.i18n.common_you,
+                        style: context.theme.appTextThemes.caption3.copyWith(
+                          color: context.theme.appColors.primaryText,
+                        ),
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                   ],
                 ),
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 2.0.s),
-                  child: Text(
-                    context.i18n.common_you,
-                    style: context.theme.appTextThemes.caption3.copyWith(
-                      color: context.theme.appColors.primaryText,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         );
       },
       orElse: () => const SizedBox.shrink(),

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/current_user_story_list_item.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_list_separator.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/mock.dart';
@@ -29,20 +30,17 @@ class StoryList extends ConsumerWidget {
         separatorBuilder: (_, __) => const StoryListSeparator(),
         itemBuilder: (_, index) {
           if (index == 0) {
-            return StoryListItem(
+            return CurrentUserStoryListItem( 
               pubkey: currentUserPubkey,
               gradient: storyBorderGradients.first,
             );
           }
 
           final pubkey = pubkeys[index - 1];
-
-          final item = StoryListItem(
+          return StoryListItem(
             pubkey: pubkey,
             gradient: storyBorderGradients[Random().nextInt(storyBorderGradients.length)],
           );
-
-          return item;
         },
       ),
     );

--- a/lib/app/router/feed_routes.dart
+++ b/lib/app/router/feed_routes.dart
@@ -232,12 +232,25 @@ class StoryPreviewRoute extends BaseRouteData {
 
 @TypedGoRoute<StoryViewerRoute>(
   path: '/story-viewing/:pubkey',
+  routes: [
+    TypedGoRoute<StoryProfileRoute>(path: 'story-profile'),
+  ],
 )
 class StoryViewerRoute extends BaseRouteData {
   StoryViewerRoute({required this.pubkey})
       : super(
           child: StoryViewerPage(pubkey: pubkey),
         );
+
+  final String pubkey;
+}
+
+class StoryProfileRoute extends BaseRouteData {
+  StoryProfileRoute({required this.pubkey})
+      : super(
+          child: ProfilePage(pubkey: pubkey),
+        );
+
   final String pubkey;
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -374,14 +374,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  cube_transition_plus:
-    dependency: "direct main"
-    description:
-      name: cube_transition_plus
-      sha256: "30b2119d20f0337f5dd297ebae00df102723085ec02e7257ac97600a837315d8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   convert: ^3.1.2
   cross_file: ^0.3.4+2
   cryptography: ^2.7.0
-  cube_transition_plus: ^2.0.1
   cupertino_icons: ^1.0.6
   device_info_plus: ^10.1.2
   dio: ^5.7.0


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
- fix ION-490 - The user’s profile button on the story screen leads to the single hardcoded profile
- fix ION-375 - after clicking on the user’s stories, all the stories playback starts from the first stories in the list
- simplify the logic of the stories viewing
- remove the `cube_transition_plus` library and move a class from that one to the project to resolve a limitation of the library

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->

## Figma Link (if applicable)
<!-- Add a link to the Figma design here if relevant to the PR. -->

