### PR TITLE
feat: support opus codec

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -36,12 +36,12 @@ PODS:
   - DKPhotoGallery/Resource (0.0.19):
     - SDWebImage
     - SwiftyGif
-  - ffmpeg-kit-ios-min-gpl (5.1)
-  - ffmpeg_kit_flutter_min_gpl (5.1.0):
-    - ffmpeg_kit_flutter_min_gpl/min-gpl (= 5.1.0)
+  - ffmpeg-kit-ios-full-gpl (6.0)
+  - ffmpeg_kit_flutter_full_gpl (6.0.3):
+    - ffmpeg_kit_flutter_full_gpl/full-gpl (= 6.0.3)
     - Flutter
-  - ffmpeg_kit_flutter_min_gpl/min-gpl (5.1.0):
-    - ffmpeg-kit-ios-min-gpl (= 5.1)
+  - ffmpeg_kit_flutter_full_gpl/full-gpl (6.0.3):
+    - ffmpeg-kit-ios-full-gpl (= 6.0)
     - Flutter
   - file_picker (0.0.1):
     - DKImagePickerController/PhotoGallery
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - audio_waveforms (from `.symlinks/plugins/audio_waveforms/ios`)
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
-  - ffmpeg_kit_flutter_min_gpl (from `.symlinks/plugins/ffmpeg_kit_flutter_min_gpl/ios`)
+  - ffmpeg_kit_flutter_full_gpl (from `.symlinks/plugins/ffmpeg_kit_flutter_full_gpl/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - file_saver (from `.symlinks/plugins/file_saver/ios`)
   - Flutter (from `Flutter`)
@@ -154,7 +154,7 @@ SPEC REPOS:
   trunk:
     - DKImagePickerController
     - DKPhotoGallery
-    - ffmpeg-kit-ios-min-gpl
+    - ffmpeg-kit-ios-full-gpl
     - libwebp
     - Mantle
     - MTBBarcodeScanner
@@ -170,8 +170,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/camera_avfoundation/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
-  ffmpeg_kit_flutter_min_gpl:
-    :path: ".symlinks/plugins/ffmpeg_kit_flutter_min_gpl/ios"
+  ffmpeg_kit_flutter_full_gpl:
+    :path: ".symlinks/plugins/ffmpeg_kit_flutter_full_gpl/ios"
   file_picker:
     :path: ".symlinks/plugins/file_picker/ios"
   file_saver:
@@ -223,8 +223,8 @@ SPEC CHECKSUMS:
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  ffmpeg-kit-ios-min-gpl: ac5eb47f98b27e26d14c009de3ce9181007ce688
-  ffmpeg_kit_flutter_min_gpl: f657651b493b7608fad9dda3ad606eb0946c9faa
+  ffmpeg-kit-ios-full-gpl: 80adc341962e55ef709e36baa8ed9a70cf4ea62b
+  ffmpeg_kit_flutter_full_gpl: 8d15c14c0c3aba616fac04fe44b3d27d02e3c330
   file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -49,37 +49,15 @@ PODS:
   - file_saver (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_image_compress_common (1.0.0):
-    - Flutter
-    - Mantle
-    - SDWebImage
-    - SDWebImageWebPCoder
   - flutter_keyboard_visibility (0.0.1):
     - Flutter
   - flutter_secure_storage (6.0.0):
-    - Flutter
-  - image_compression_flutter (1.0.0):
     - Flutter
   - image_cropper (0.0.4):
     - Flutter
     - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
-  - libwebp (1.3.2):
-    - libwebp/demux (= 1.3.2)
-    - libwebp/mux (= 1.3.2)
-    - libwebp/sharpyuv (= 1.3.2)
-    - libwebp/webp (= 1.3.2)
-  - libwebp/demux (1.3.2):
-    - libwebp/webp
-  - libwebp/mux (1.3.2):
-    - libwebp/demux
-  - libwebp/sharpyuv (1.3.2)
-  - libwebp/webp (1.3.2):
-    - libwebp/sharpyuv
-  - Mantle (2.2.0):
-    - Mantle/extobjc (= 2.2.0)
-  - Mantle/extobjc (2.2.0)
   - MTBBarcodeScanner (5.0.11)
   - package_info_plus (0.4.5):
     - Flutter
@@ -101,9 +79,6 @@ PODS:
   - SDWebImage (5.19.7):
     - SDWebImage/Core (= 5.19.7)
   - SDWebImage/Core (5.19.7)
-  - SDWebImageWebPCoder (0.14.6):
-    - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.17)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -130,10 +105,8 @@ DEPENDENCIES:
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - file_saver (from `.symlinks/plugins/file_saver/ios`)
   - Flutter (from `Flutter`)
-  - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
-  - image_compression_flutter (from `.symlinks/plugins/image_compression_flutter/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -155,11 +128,8 @@ SPEC REPOS:
     - DKImagePickerController
     - DKPhotoGallery
     - ffmpeg-kit-ios-full-gpl
-    - libwebp
-    - Mantle
     - MTBBarcodeScanner
     - SDWebImage
-    - SDWebImageWebPCoder
     - SwiftyGif
     - TOCropViewController
 
@@ -178,14 +148,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/file_saver/ios"
   Flutter:
     :path: Flutter
-  flutter_image_compress_common:
-    :path: ".symlinks/plugins/flutter_image_compress_common/ios"
   flutter_keyboard_visibility:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
-  image_compression_flutter:
-    :path: ".symlinks/plugins/image_compression_flutter/ios"
   image_cropper:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
@@ -228,14 +194,10 @@ SPEC CHECKSUMS:
   file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  image_compression_flutter: 5327fc5ee43f5ee6107d44ff0d4480a363788358
   image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
-  Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
@@ -245,7 +207,6 @@ SPEC CHECKSUMS:
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   quill_native_bridge: e5afa7d49c08cf68c52a5e23bc272eba6925c622
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
-  SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec

--- a/lib/app/features/chat/messages/views/pages/messages_page.dart
+++ b/lib/app/features/chat/messages/views/pages/messages_page.dart
@@ -130,7 +130,7 @@ class MessagesPage extends HookConsumerWidget {
                           case 8:
                             return const AudioMessage(
                               '112133',
-                              audioUrl: 'https://www2.cs.uic.edu/~i101/SoundFiles/preamble10.wav',
+                              audioUrl: 'https://getsamplefiles.com/download/opus/sample-3.opus',
                               isMe: false,
                               reactions: mockReactionsMany,
                             );

--- a/lib/app/features/feed/create_post/views/pages/compress_test_page.dart
+++ b/lib/app/features/feed/create_post/views/pages/compress_test_page.dart
@@ -160,7 +160,8 @@ class ImageCompressTab extends HookConsumerWidget {
             );
 
         // Display the compressed image size in MB
-        compressedSize.value = '${(compressedFile.size ?? 0 / 1024 / 1024).toStringAsFixed(2)} MB';
+        compressedSize.value =
+            '${(await XFile(compressedFile.path).length() / 1024 / 1024).toStringAsFixed(2)} MB';
 
         compressedImage.value = compressedFile;
         isCompressing.value = false;

--- a/lib/app/services/audio_wave_playback_service/audio_wave_playback_service.dart
+++ b/lib/app/services/audio_wave_playback_service/audio_wave_playback_service.dart
@@ -7,13 +7,15 @@ import 'package:file_saver/file_saver.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/services/logger/logger.dart';
+import 'package:ion/app/services/media_service/media_compress_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'audio_wave_playback_service.g.dart';
 
 class AudioWavePlaybackService {
-  const AudioWavePlaybackService();
+  const AudioWavePlaybackService(this._mediaCompressionService);
+  final MediaCompressionService _mediaCompressionService;
 
   Future<void> initializePlayer(
     String id,
@@ -60,9 +62,11 @@ class AudioWavePlaybackService {
       name: id,
       link: LinkDetails(link: audioUrl),
     );
-    return savedFilePath;
+    final compressedFilePath = await _mediaCompressionService.compressAudioToWav(savedFilePath);
+    return compressedFilePath;
   }
 }
 
 @riverpod
-AudioWavePlaybackService audioWavePlaybackService(Ref ref) => const AudioWavePlaybackService();
+AudioWavePlaybackService audioWavePlaybackService(Ref ref) =>
+    AudioWavePlaybackService(ref.read(mediaCompressServiceProvider));

--- a/lib/app/services/audio_wave_playback_service/audio_wave_playback_service.dart
+++ b/lib/app/services/audio_wave_playback_service/audio_wave_playback_service.dart
@@ -69,4 +69,4 @@ class AudioWavePlaybackService {
 
 @riverpod
 AudioWavePlaybackService audioWavePlaybackService(Ref ref) =>
-    AudioWavePlaybackService(ref.read(mediaCompressServiceProvider));
+    AudioWavePlaybackService(ref.watch(mediaCompressServiceProvider));

--- a/lib/app/services/media_service/media_compress_service.dart
+++ b/lib/app/services/media_service/media_compress_service.dart
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'dart:io';
-
 import 'package:cross_file/cross_file.dart';
-import 'package:ffmpeg_helper/ffmpeg_helper.dart';
-import 'package:ffmpeg_wasm/ffmpeg_wasm.dart';
-import 'package:file_saver/file_saver.dart';
-import 'package:flutter/foundation.dart';
+import 'package:ffmpeg_kit_flutter_full_gpl/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_full_gpl/return_code.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:image/image.dart' as img;
-import 'package:image_compression_flutter/image_compression_flutter.dart' as compressor_package;
 import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_audio_bitrate_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_audio_codec_arg.dart';
@@ -24,7 +18,18 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'media_compress_service.g.dart';
 
+///
+/// A service that handles media file compression.
+/// Provides methods to compress video and audio  and image files using FFmpeg,
+/// with configurable compression parameters
+/// TODO: Support windows and web platforms
+///
 class MediaCompressionService {
+  ///
+  /// Compresses a video file to a new file with the same name in the application cache directory.
+  /// If success, returns a new [XFile] with the compressed video.
+  /// If fails, throws an exception.
+  ///
   Future<XFile> compressVideo(
     XFile inputFile, {
     FFmpegVideoCodecArg videoCodec = FFmpegVideoCodecArg.libx264,
@@ -36,68 +41,157 @@ class MediaCompressionService {
     int fps = 30,
     FfmpegAudioCodecArg audioCodec = FfmpegAudioCodecArg.aac,
     FfmpegAudioBitrateArg audioBitrate = FfmpegAudioBitrateArg.low,
-    bool overwrite = true,
   }) async {
     try {
+      final output = await _generateOutputPath(extension: 'mp4');
       final args = [
-        const CustomArgument(['-threads', '0']),
-        if (overwrite) const CustomArgument(['-y']),
-        CustomArgument(['-codec:v', videoCodec.codec]),
-        CustomArgument(['-preset', preset.value]),
-        CustomArgument(['-b:v', videoBitrate.bitrate]),
-        CustomArgument(['-maxrate', maxRate.bitrate]),
-        CustomArgument(['-bufsize', bufSize.bitrate]),
-        CustomArgument(['-vf', 'scale=${scale.resolution},fps=$fps']),
-        CustomArgument(['-codec:a', audioCodec.codec]),
-        CustomArgument(['-b:a', audioBitrate.bitrate]),
+        '-i',
+        inputFile.path,
+        '-codec:v',
+        videoCodec.codec,
+        '-preset',
+        preset.value,
+        '-b:v',
+        videoBitrate.bitrate,
+        '-maxrate',
+        maxRate.bitrate,
+        '-bufsize',
+        bufSize.bitrate,
+        '-codec:a',
+        audioCodec.codec,
+        '-b:a',
+        audioBitrate.bitrate,
+        // TODO: Add scale and fps
+        output,
       ];
-
-      if (kIsWeb) {
-        return _compressVideoForWeb(inputFile, args);
-      }
-
-      if (Platform.isWindows) {
-        await _initWindowsPackage();
-      }
-
-      return await _defaultVideoCompress(inputFile, args);
+      return await FFmpegKit.executeWithArguments(args).then((session) async {
+        final returnCode = await session.getReturnCode();
+        if (ReturnCode.isSuccess(returnCode)) {
+          return XFile(output);
+        }
+        final logs = await session.getAllLogsAsString();
+        final stackTrace = await session.getFailStackTrace();
+        Logger.log('Failed to compress video. Logs: $logs, StackTrace: $stackTrace');
+        throw Exception('Failed to compress video.');
+      });
     } catch (error, stackTrace) {
       Logger.log('Error during video compression!', error: error, stackTrace: stackTrace);
       throw Exception('Failed to compress video.');
     }
   }
 
-  Future<XFile> _defaultVideoCompress(XFile inputFile, List<CustomArgument> args) async {
-    final output = await _generateOutputPath();
-    final savedFilePath = await FileSaver.instance
-        .saveFile(name: path.basename(output), bytes: await inputFile.readAsBytes());
-    await FFMpegHelper.instance.runSync(
-      FFMpegCommand(
-        outputFilepath: output,
-        inputs: [
-          FFMpegInput.asset(savedFilePath),
-        ],
-        args: args,
-      ),
-    );
-
-    return XFile(output);
+  ///
+  /// Compresses an image file to webp format.
+  /// If success, returns a new [MediaFile] with the compressed image.
+  /// If fails, throws an exception.
+  ///
+  Future<MediaFile> compressImage(
+    MediaFile file, {
+    int? width,
+    int? height,
+    int quality = 80,
+    bool keepAspectRatio = true,
+  }) async {
+    try {
+      final output = await _generateOutputPath();
+      return await FFmpegKit.executeWithArguments([
+        '-i',
+        file.path,
+        '-c:v',
+        'libwebp',
+        '-vf',
+        'scale=${width ?? '-1'}:${height ?? '-1'}:force_original_aspect_ratio=decrease',
+        '-q:v',
+        quality.toString(),
+        output,
+      ]).then((session) async {
+        final returnCode = await session.getReturnCode();
+        if (ReturnCode.isSuccess(returnCode)) {
+          return MediaFile(path: output);
+        }
+        throw Exception('Failed to compress image.');
+      });
+    } catch (error, stackTrace) {
+      Logger.log('Error during image compression!', error: error, stackTrace: stackTrace);
+      rethrow;
+    }
   }
 
+  ///
+  /// Compresses an audio file to opus format.
+  /// If success, returns the path to the compressed audio file.
+  /// If fails, throws an exception.
+  ///
+  Future<String> compressAudio(String inputPath) async {
+    final outputPath = await _generateOutputPath(extension: 'opus');
+    return FFmpegKit.executeWithArguments([
+      '-i',
+      inputPath,
+      '-c:a',
+      'libopus',
+      outputPath,
+    ]).then((session) async {
+      final returnCode = await session.getReturnCode();
+      if (ReturnCode.isSuccess(returnCode)) {
+        return outputPath;
+      }
+      final logs = await session.getAllLogsAsString();
+      final stackTrace = await session.getFailStackTrace();
+      Logger.log('Failed to convert audio to opus. Logs: $logs, StackTrace: $stackTrace');
+      throw Exception('Failed to convert audio to opus.');
+    });
+  }
+
+  ///
+  /// Compress an audio to wav format.
+  /// If success, returns the path to the compressed audio file.
+  /// If fails, throws an exception.
+  ///
+  Future<String> compressAudioToWav(String inputPath) async {
+    final outputPath = await _generateOutputPath(extension: 'wav');
+
+    return FFmpegKit.executeWithArguments([
+      '-i',
+      inputPath,
+      '-c:a',
+      'pcm_s16le',
+      outputPath,
+    ]).then((session) async {
+      final returnCode = await session.getReturnCode();
+      if (ReturnCode.isSuccess(returnCode)) {
+        return outputPath;
+      }
+      final logs = await session.getAllLogsAsString();
+      final stackTrace = await session.getFailStackTrace();
+      Logger.log('Failed to convert audio to wav. Logs: $logs, StackTrace: $stackTrace');
+      throw Exception('Failed to convert audio to wav.');
+    });
+  }
+
+  ///
+  ///
+  /// Extracts a thumbnail from a video file.
+  /// If success, returns a new [MediaFile] with the thumbnail.
+  /// If fails, throws an exception.
+  ///
   Future<MediaFile> getThumbnail(
     MediaFile inputFile, {
     Duration duration = const Duration(seconds: 1),
   }) async {
     try {
-      final outputPath = await _generateOutputPath(isThumbnail: true);
-      final file = await FFMpegHelper.instance.getThumbnailFileSync(
-        videoPath: inputFile.path,
-        fromDuration: duration,
-        outputPath: outputPath,
-      );
+      final outputPath = await _generateOutputPath();
+      await FFmpegKit.executeWithArguments([
+        '-i',
+        inputFile.path,
+        '-ss',
+        '00:00:01.000',
+        '-vframes',
+        '1',
+        outputPath,
+      ]);
 
       final compressedImage = await compressImage(
-        MediaFile(path: file!.path),
+        MediaFile(path: outputPath),
         quality: 100,
         width: 200,
         height: 200,
@@ -110,131 +204,15 @@ class MediaCompressionService {
     }
   }
 
-  Future<void> _initWindowsPackage() async {
-    final success = await FFMpegHelper.instance.setupFFMpegOnWindows();
-    if (!success) {
-      Logger.log('Failed to setup ffmpeg on Windows');
-      throw Exception('Failed to setup ffmpeg on Windows');
-    }
-  }
-
-  Future<XFile> _compressVideoForWeb(XFile inputFile, List<CustomArgument> args) async {
-    const input = 'input.mp4';
-    const output = 'output.mp4';
-    final ffmpeg = createFFmpeg(CreateFFmpegParam());
-
-    if (!ffmpeg.isLoaded()) {
-      await ffmpeg.load();
-    }
-
-    ffmpeg.writeFile(input, await inputFile.readAsBytes());
-
-    await ffmpeg.runCommand(
-      "${FFMpegInput.asset(input).toCli()} ${args.map((arg) => FFMpegInput(arg.toArgs()).toCli()).join(' ')} $output",
-    );
-
-    final compressedVideoBytes = ffmpeg.readFile(output);
-    return XFile.fromData(compressedVideoBytes, name: output);
-  }
-
-  // TODO: We're using the default ImageOutputType.webpThenJpg
-  // But we need to log the exact reason if webp conversion is not available
-  // In case of fallback we need to use avif instead of jpg
-  Future<MediaFile> compressImage(
-    MediaFile file, {
-    int? width,
-    int? height,
-    int quality = 80,
-    bool keepAspectRatio = true,
-  }) async {
-    try {
-      final resizedBytes = await compute<ResizeImageParams, Uint8List>(
-        (params) async {
-          return resizeImage(
-            params.file,
-            width: params.width,
-            height: params.height,
-            keepAspectRatio: params.keepAspectRatio,
-          );
-        },
-        ResizeImageParams(
-          file: XFile(file.path),
-          width: width,
-          height: height,
-          keepAspectRatio: keepAspectRatio,
-        ),
-      );
-
-      if (resizedBytes.isEmpty) {
-        throw Exception('Failed to resize image.');
-      }
-
-      final config = compressor_package.ImageFileConfiguration(
-        input: compressor_package.ImageFile(
-          filePath: '', // File path left empty since we're using rawBytes
-          rawBytes: resizedBytes,
-        ),
-        config: compressor_package.Configuration(
-          quality: quality,
-        ),
-      );
-
-      final output = await compressor_package.compressor.compress(config);
-
-      final fileName = path.basename(file.path);
-
-      final savedFilePath =
-          await FileSaver.instance.saveFile(name: fileName, bytes: output.rawBytes);
-
-      return MediaFile(
-        path: savedFilePath,
-        mimeType: output.contentType,
-        width: width,
-        height: height,
-        name: fileName,
-        size: output.sizeInBytes,
-      );
-    } catch (error, stackTrace) {
-      Logger.log('Error during image compression!', error: error, stackTrace: stackTrace);
-      rethrow;
-    }
-  }
-
-  Future<Uint8List> resizeImage(
-    XFile file, {
-    int? width,
-    int? height,
-    bool keepAspectRatio = true,
-  }) async {
-    try {
-      final originalBytes = await file.readAsBytes();
-      final decodedImage = img.decodeImage(originalBytes);
-
-      if (decodedImage == null) {
-        throw Exception('Failed to decode image.');
-      }
-
-      final resizedImage = img.copyResize(
-        decodedImage,
-        width: width,
-        height: height,
-        maintainAspect: keepAspectRatio,
-      );
-
-      return Uint8List.fromList(img.encodePng(resizedImage));
-    } catch (error, stackTrace) {
-      Logger.log('Error during image resizing!', error: error, stackTrace: stackTrace);
-      rethrow;
-    }
-  }
-
-  Future<String> _generateOutputPath({bool isThumbnail = false}) async {
+  ///
+  /// Generates a new output path for a compressed file.
+  ///
+  Future<String> _generateOutputPath({String extension = 'webp'}) async {
     // Get a platform-independent temporary directory
     final tempDir = await getApplicationCacheDirectory();
 
     // Generate a new output filename
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final extension = isThumbnail ? 'jpg' : 'mp4';
     final outputFileName = 'compressed_$timestamp.$extension';
 
     // Join temp directory with the generated filename
@@ -246,16 +224,3 @@ class MediaCompressionService {
 
 @riverpod
 MediaCompressionService mediaCompressService(Ref ref) => MediaCompressionService();
-
-class ResizeImageParams {
-  ResizeImageParams({
-    required this.file,
-    required this.keepAspectRatio,
-    this.width,
-    this.height,
-  });
-  final XFile file;
-  final int? height;
-  final int? width;
-  final bool keepAspectRatio;
-}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -542,22 +542,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  ffmpeg_helper:
+  ffmpeg_kit_flutter_full_gpl:
     dependency: "direct main"
     description:
-      name: ffmpeg_helper
-      sha256: "9652adb5aa14ef014a677a85a55ceef2fdbe07c3cffe04ebab0b73f979eca952"
+      name: ffmpeg_kit_flutter_full_gpl
+      sha256: "4f269bcb636bfcb544e5b4d65c706a3d311839970cb42638e72406410c1b5b7b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
-  ffmpeg_kit_flutter_min_gpl:
-    dependency: transitive
-    description:
-      name: ffmpeg_kit_flutter_min_gpl
-      sha256: ca3dc2330c176c8ef96fb512e7a1a37ab369e15685d2e72a52ec1d50726360a0
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.0"
+    version: "6.0.3"
   ffmpeg_kit_flutter_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -699,54 +699,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.20.5"
-  flutter_image_compress:
-    dependency: transitive
-    description:
-      name: flutter_image_compress
-      sha256: "45a3071868092a61b11044c70422b04d39d4d9f2ef536f3c5b11fb65a1e7dd90"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
-  flutter_image_compress_common:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_common
-      sha256: "7f79bc6c8a363063620b4e372fa86bc691e1cb28e58048cd38e030692fbd99ee"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
-  flutter_image_compress_macos:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_macos
-      sha256: "26df6385512e92b3789dc76b613b54b55c457a7f1532e59078b04bf189782d47"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
-  flutter_image_compress_ohos:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_ohos
-      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
-  flutter_image_compress_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_platform_interface
-      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
-  flutter_image_compress_web:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_web
-      sha256: f02fe352b17f82b72f481de45add240db062a2585850bea1667e82cc4cd6c311
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4+1"
   flutter_keyboard_visibility:
     dependency: "direct main"
     description:
@@ -1051,29 +1003,13 @@ packages:
     source: hosted
     version: "4.0.2"
   image:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: image
       sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
-  image_compression:
-    dependency: transitive
-    description:
-      name: image_compression
-      sha256: "0ab2ad255fc3877c0e425a3f46796b2872806c1d7260207ec72b723975f6f3e0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
-  image_compression_flutter:
-    dependency: "direct main"
-    description:
-      name: image_compression_flutter
-      sha256: "0d7fc5d37bb69996285dd57342b3a37ad92fa4bb0616484af084ec924d6818b4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.4"
   image_cropper:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,8 +45,6 @@ dependencies:
   freezed_annotation: ^2.4.1
   go_router: ^14.2.0
   hooks_riverpod: ^2.6.1
-  image: ^4.2.0
-  image_compression_flutter: ^1.0.4
   image_cropper: ^8.0.2
   image_picker: ^1.1.2
   intl: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   dotted_border: ^2.1.0
   email_validator: ^3.0.0
   extended_text: ^14.1.0
-  # ffmpeg_helper: ^1.0.1
   ffmpeg_kit_flutter_full_gpl: ^6.0.3
   ffmpeg_wasm: ^1.0.3
   file_picker: ^8.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,8 @@ dependencies:
   dotted_border: ^2.1.0
   email_validator: ^3.0.0
   extended_text: ^14.1.0
-  ffmpeg_helper: ^1.0.1
+  # ffmpeg_helper: ^1.0.1
+  ffmpeg_kit_flutter_full_gpl: ^6.0.3
   ffmpeg_wasm: ^1.0.3
   file_picker: ^8.1.2
   file_saver: ^0.2.12


### PR DESCRIPTION
## Description
- Added Opus audio codec compression functionality
- Implemented WAV audio compression
- Streamlined video/image compression with FFmpeg Kit direct integration
- Removed deprecated compression methods and dependencies
- WAV conversion is required as audio waveforms cannot be generated from Opus format

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
