### PR TITLE
feat(ion identity client): improve recover user flow

### DIFF
--- a/lib/app/extensions/riverpod.dart
+++ b/lib/app/extensions/riverpod.dart
@@ -81,7 +81,7 @@ extension ListenResultExtension on WidgetRef {
         return;
       }
 
-      if (next.hasValue) {
+      if (next is AsyncData) {
         onSuccess(next.value);
       }
     });

--- a/lib/app/features/auth/views/pages/recover_user_page/components/recovery_creds_step.dart
+++ b/lib/app/features/auth/views/pages/recover_user_page/components/recovery_creds_step.dart
@@ -15,15 +15,15 @@ class RecoveryCredsStep extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isLoading = ref.watch(
-          initUserRecoveryActionNotifierProvider.select((it) => it.isLoading),
-        ) ||
-        ref.watch(
-          completeUserRecoveryActionNotifierProvider.select((it) => it.isLoading),
-        );
+    final isInitLoading = ref.watch(
+      initUserRecoveryActionNotifierProvider.select((it) => it.isLoading),
+    );
+    final isCompleteLoading = ref.watch(
+      completeUserRecoveryActionNotifierProvider.select((it) => it.isLoading),
+    );
 
     return RecoveryKeysInputContainer(
-      isLoading: isLoading,
+      isLoading: isInitLoading || isCompleteLoading,
       validator: (value, property) => value == null || value.isEmpty ? '' : null,
       onContinuePressed: onContinuePressed,
     );

--- a/lib/app/features/auth/views/pages/recover_user_page/components/recovery_creds_step.dart
+++ b/lib/app/features/auth/views/pages/recover_user_page/components/recovery_creds_step.dart
@@ -15,9 +15,15 @@ class RecoveryCredsStep extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final recoverUserState = ref.watch(recoverUserActionNotifierProvider);
+    final isLoading = ref.watch(
+          initUserRecoveryActionNotifierProvider.select((it) => it.isLoading),
+        ) ||
+        ref.watch(
+          completeUserRecoveryActionNotifierProvider.select((it) => it.isLoading),
+        );
+
     return RecoveryKeysInputContainer(
-      isLoading: recoverUserState.isLoading,
+      isLoading: isLoading,
       validator: (value, property) => value == null || value.isEmpty ? '' : null,
       onContinuePressed: onContinuePressed,
     );

--- a/lib/app/features/auth/views/pages/recover_user_page/components/twofa_options_step.dart
+++ b/lib/app/features/auth/views/pages/recover_user_page/components/twofa_options_step.dart
@@ -20,10 +20,12 @@ import 'package:ion/generated/assets.gen.dart';
 
 class TwoFAOptionsStep extends HookConsumerWidget {
   const TwoFAOptionsStep({
+    required this.twoFAOptionsCount,
     required this.onConfirm,
     super.key,
   });
 
+  final int twoFAOptionsCount;
   final VoidCallback onConfirm;
 
   @override

--- a/lib/app/features/auth/views/pages/recover_user_page/recover_user_page.dart
+++ b/lib/app/features/auth/views/pages/recover_user_page/recover_user_page.dart
@@ -27,7 +27,13 @@ class RecoverUserPage extends HookConsumerWidget {
     final twoFAOptions = useRef<Map<TwoFaType, String>?>(null);
     final twoFAOptionsCount = useRef<int>(0);
 
-    _listenInitRecoverResult(ref, recoveryCreds, twoFAOptions, twoFAOptionsCount, step);
+    _listenInitRecoverResult(
+      ref: ref,
+      recoveryCreds: recoveryCreds,
+      twoFAOptions: twoFAOptions,
+      twoFAOptionsCountRef: twoFAOptionsCount,
+      step: step,
+    );
     _listenCompleteRecoverResult(ref);
 
     return switch (step.value) {
@@ -77,13 +83,13 @@ class RecoverUserPage extends HookConsumerWidget {
         );
   }
 
-  void _listenInitRecoverResult(
-    WidgetRef ref,
-    ObjectRef<RecoveryCreds?> recoveryCreds,
-    ObjectRef<Map<TwoFaType, String>?> twoFAOptions,
-    ObjectRef<int> twoFAOptionsCountRef,
-    ValueNotifier<RecoverUserStep> step,
-  ) {
+  void _listenInitRecoverResult({
+    required WidgetRef ref,
+    required ObjectRef<RecoveryCreds?> recoveryCreds,
+    required ObjectRef<Map<TwoFaType, String>?> twoFAOptions,
+    required ObjectRef<int> twoFAOptionsCountRef,
+    required ValueNotifier<RecoverUserStep> step,
+  }) {
     ref
       ..listenError(initUserRecoveryActionNotifierProvider, (error) async {
         switch (error) {

--- a/lib/app/features/auth/views/pages/recover_user_page/recover_user_page.dart
+++ b/lib/app/features/auth/views/pages/recover_user_page/recover_user_page.dart
@@ -25,32 +25,44 @@ class RecoverUserPage extends HookConsumerWidget {
     final step = useState(RecoverUserStep.recoveryCreds);
     final recoveryCreds = useRef<RecoveryCreds?>(null);
     final twoFAOptions = useRef<Map<TwoFaType, String>?>(null);
+    final twoFAOptionsCount = useRef<int>(0);
 
-    _listenRecoverUserResult(ref, step);
+    _listenInitRecoverResult(ref, recoveryCreds, twoFAOptions, twoFAOptionsCount, step);
+    _listenCompleteRecoverResult(ref);
 
-    return ProviderScope(
-      overrides: [
-        availableTwoFaTypesProvider.overrideWithValue(TwoFaType.values),
-      ],
-      child: switch (step.value) {
-        RecoverUserStep.recoveryCreds => RecoveryCredsStep(
-            onContinuePressed: (name, id, code) {
-              recoveryCreds.value = (name: name, id: id, code: code);
-              _makeRecoverUserRequest(ref, recoveryCreds.value!);
-            },
-          ),
-        RecoverUserStep.twoFAOptions => TwoFAOptionsStep(
+    return switch (step.value) {
+      RecoverUserStep.recoveryCreds => RecoveryCredsStep(
+          onContinuePressed: (name, id, code) {
+            recoveryCreds.value = (name: name, id: id, code: code);
+            _makeRecoverUserRequest(ref, recoveryCreds.value!);
+          },
+        ),
+      RecoverUserStep.twoFAOptions => ProviderScope(
+          overrides: [
+            availableTwoFaTypesProvider.overrideWithValue(
+              (types: TwoFaType.values, count: twoFAOptionsCount.value),
+            ),
+          ],
+          child: TwoFAOptionsStep(
+            twoFAOptionsCount: twoFAOptionsCount.value,
             onConfirm: () => step.value = RecoverUserStep.twoFAInput,
           ),
-        RecoverUserStep.twoFAInput => TwoFAInputStep(
+        ),
+      RecoverUserStep.twoFAInput => ProviderScope(
+          overrides: [
+            availableTwoFaTypesProvider.overrideWithValue(
+              (types: TwoFaType.values, count: twoFAOptionsCount.value),
+            ),
+          ],
+          child: TwoFAInputStep(
             recoveryIdentityKeyName: recoveryCreds.value!.name,
             onContinuePressed: (twoFaTypes) {
               twoFAOptions.value = twoFaTypes;
               _makeRecoverUserRequest(ref, recoveryCreds.value!, twoFaTypes);
             },
           ),
-      },
-    );
+        ),
+    };
   }
 
   void _makeRecoverUserRequest(
@@ -58,37 +70,57 @@ class RecoverUserPage extends HookConsumerWidget {
     RecoveryCreds recoveryCreds, [
     Map<TwoFaType, String>? twoFaTypes,
   ]) {
-    guardPasskeyDialog(
-      ref.context,
-      (child) => RiverpodPasskeyRequestBuilder(
-        provider: recoverUserActionNotifierProvider,
-        request: () => ref.read(recoverUserActionNotifierProvider.notifier).recoverUser(
-              username: recoveryCreds.name,
-              credentialId: recoveryCreds.id,
-              recoveryKey: recoveryCreds.code,
-              twoFaTypes: twoFaTypes,
-            ),
-        child: child,
-      ),
-    );
+    ref.read(initUserRecoveryActionNotifierProvider.notifier).initRecovery(
+          username: recoveryCreds.name,
+          credentialId: recoveryCreds.id,
+          twoFaTypes: twoFaTypes,
+        );
   }
 
-  void _listenRecoverUserResult(WidgetRef ref, ValueNotifier<RecoverUserStep> step) {
+  void _listenInitRecoverResult(
+    WidgetRef ref,
+    ObjectRef<RecoveryCreds?> recoveryCreds,
+    ObjectRef<Map<TwoFaType, String>?> twoFAOptions,
+    ObjectRef<int> twoFAOptionsCountRef,
+    ValueNotifier<RecoverUserStep> step,
+  ) {
     ref
-      ..listenError(recoverUserActionNotifierProvider, (error) async {
+      ..listenError(initUserRecoveryActionNotifierProvider, (error) async {
         switch (error) {
-          case TwoFARequiredException():
+          case TwoFARequiredException(:final twoFAOptionsCount):
+            twoFAOptionsCountRef.value = twoFAOptionsCount;
             step.value = RecoverUserStep.twoFAOptions;
           default:
         }
       })
-      ..listenSuccess(
-        recoverUserActionNotifierProvider,
-        (value) {
-          value?.whenOrNull(
-            success: () => RecoverUserSuccessRoute().push<void>(ref.context),
-          );
-        },
-      );
+      ..listenSuccess(initUserRecoveryActionNotifierProvider, (value) {
+        final challenge = value?.whenOrNull(success: (challenge) => challenge);
+
+        guardPasskeyDialog(
+          ref.context,
+          (child) => RiverpodPasskeyRequestBuilder(
+            provider: completeUserRecoveryActionNotifierProvider,
+            request: () =>
+                ref.read(completeUserRecoveryActionNotifierProvider.notifier).completeRecovery(
+                      username: recoveryCreds.value!.name,
+                      credentialId: recoveryCreds.value!.id,
+                      recoveryKey: recoveryCreds.value!.code,
+                      challenge: challenge!,
+                    ),
+            child: child,
+          ),
+        );
+      });
+  }
+
+  void _listenCompleteRecoverResult(WidgetRef ref) {
+    ref.listenSuccess(
+      completeUserRecoveryActionNotifierProvider,
+      (value) {
+        value?.whenOrNull(
+          success: () => RecoverUserSuccessRoute().push<void>(ref.context),
+        );
+      },
+    );
   }
 }

--- a/lib/app/features/protect_account/backup/providers/recover_user_action_notifier.dart
+++ b/lib/app/features/protect_account/backup/providers/recover_user_action_notifier.dart
@@ -4,26 +4,33 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ion/app/features/auth/data/models/twofa_type.dart';
 import 'package:ion/app/features/protect_account/authenticator/data/adapter/twofa_type_adapter.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_provider.dart';
+import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'recover_user_action_notifier.freezed.dart';
 part 'recover_user_action_notifier.g.dart';
 
 @freezed
-class RecoverUserActionState with _$RecoverUserActionState {
-  const factory RecoverUserActionState.initial() = _RecoverUserActionStateInitial;
-  const factory RecoverUserActionState.success() = _RecoverUserActionStateSuccess;
+class InitUserRecoveryActionState with _$InitUserRecoveryActionState {
+  const factory InitUserRecoveryActionState.initial() = _InitUserRecoveryActionStateInitial;
+  const factory InitUserRecoveryActionState.success(UserRegistrationChallenge challenge) =
+      _InitUserRecoveryActionStateSuccess;
+}
+
+@freezed
+class CompleteUserRecoveryActionState with _$CompleteUserRecoveryActionState {
+  const factory CompleteUserRecoveryActionState.initial() = _CompleteUserRecoveryActionStateInitial;
+  const factory CompleteUserRecoveryActionState.success() = _CompleteUserRecoveryActionStateSuccess;
 }
 
 @riverpod
-class RecoverUserActionNotifier extends _$RecoverUserActionNotifier {
+class InitUserRecoveryActionNotifier extends _$InitUserRecoveryActionNotifier {
   @override
-  FutureOr<RecoverUserActionState> build() => const RecoverUserActionState.initial();
+  FutureOr<InitUserRecoveryActionState> build() => const InitUserRecoveryActionState.initial();
 
-  Future<void> recoverUser({
+  Future<void> initRecovery({
     required String username,
     required String credentialId,
-    required String recoveryKey,
     Map<TwoFaType, String>? twoFaTypes,
   }) async {
     state = const AsyncLoading();
@@ -36,13 +43,40 @@ class RecoverUserActionNotifier extends _$RecoverUserActionNotifier {
           TwoFaTypeAdapter(entry.key, entry.value).twoFAType,
       ];
 
-      await ionIdentity(username: username).auth.recoverUser(
+      final challenge = await ionIdentity(username: username).auth.initRecovery(
             credentialId: credentialId,
-            recoveryKey: recoveryKey,
             twoFATypes: twoFATypes,
           );
 
-      return const RecoverUserActionState.success();
+      return InitUserRecoveryActionState.success(challenge);
+    });
+  }
+}
+
+@riverpod
+class CompleteUserRecoveryActionNotifier extends _$CompleteUserRecoveryActionNotifier {
+  @override
+  FutureOr<CompleteUserRecoveryActionState> build() =>
+      const CompleteUserRecoveryActionState.initial();
+
+  Future<void> completeRecovery({
+    required String username,
+    required String credentialId,
+    required String recoveryKey,
+    required UserRegistrationChallenge challenge,
+  }) async {
+    state = const AsyncLoading();
+
+    state = await AsyncValue.guard(() async {
+      final ionIdentity = await ref.read(ionIdentityProvider.future);
+
+      await ionIdentity(username: username).auth.completeRecovery(
+            challenge: challenge,
+            credentialId: credentialId,
+            recoveryKey: recoveryKey,
+          );
+
+      return const CompleteUserRecoveryActionState.success();
     });
   }
 }

--- a/lib/app/features/protect_account/secure_account/providers/selected_two_fa_types_provider.dart
+++ b/lib/app/features/protect_account/secure_account/providers/selected_two_fa_types_provider.dart
@@ -23,11 +23,11 @@ class SelectedTwoFAOptionsNotifier extends _$SelectedTwoFAOptionsNotifier {
   @override
   SelectTwoFAOptionsState build() {
     final availableTwoFATypes = ref.watch(availableTwoFaTypesProvider);
-    final optionsAmount = availableTwoFATypes.length;
+    final optionsAmount = availableTwoFATypes.count;
 
     return SelectTwoFAOptionsState(
       optionsAmount: optionsAmount,
-      availableOptions: availableTwoFATypes.toSet(),
+      availableOptions: availableTwoFATypes.types.toSet(),
       selectedValues: List.generate(optionsAmount, (_) => null),
     );
   }
@@ -52,11 +52,17 @@ Set<TwoFaType> selectedTwoFaOptions(Ref ref) {
   return state.selectedValues.whereType<TwoFaType>().toSet();
 }
 
+typedef AvailableTwoFATypesState = ({
+  List<TwoFaType> types,
+  int count,
+});
+
 @Riverpod(dependencies: [])
-List<TwoFaType> availableTwoFaTypes(Ref ref) =>
+AvailableTwoFATypesState availableTwoFaTypes(Ref ref) =>
     throw UnimplementedError('availableTwoFaTypesProvider must be overridden');
 
 @riverpod
-List<TwoFaType> securityMethodsEnabledTypes(Ref ref) {
-  return ref.watch(securityAccountControllerProvider).requireValue.enabledTypes;
+AvailableTwoFATypesState securityMethodsEnabledTypes(Ref ref) {
+  final enabledTypes = ref.watch(securityAccountControllerProvider).requireValue.enabledTypes;
+  return (types: enabledTypes, count: enabledTypes.length);
 }

--- a/packages/ion_identity_client/lib/ion_identity.dart
+++ b/packages/ion_identity_client/lib/ion_identity.dart
@@ -11,6 +11,7 @@ export 'src/core/types/user_token.dart';
 export 'src/ion_identity.dart';
 export 'src/ion_identity_client.dart';
 export 'src/ion_identity_config.dart';
+export 'src/signer/dtos/user_registration_challenge.dart';
 export 'src/users/ion_connect_indexers/models/ion_connect_indexers_response.dart';
 export 'src/users/set_ion_connect_relays/models/set_ion_connect_relays_response.dart';
 export 'src/users/user_details/models/user_details.dart';

--- a/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
+++ b/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
@@ -47,15 +47,24 @@ class IONIdentityAuth {
   Future<CreateRecoveryCredentialsSuccess> createRecoveryCredentials() =>
       createRecoveryCredentialsService.createRecoveryCredentials();
 
-  Future<void> recoverUser({
+  Future<UserRegistrationChallenge> initRecovery({
     required String credentialId,
-    required String recoveryKey,
     List<TwoFAType> twoFATypes = const [],
   }) =>
-      recoverUserService.recoverUser(
+      recoverUserService.initRecovery(
+        credentialId: credentialId,
+        twoFATypes: twoFATypes,
+      );
+
+  Future<void> completeRecovery({
+    required UserRegistrationChallenge challenge,
+    required String credentialId,
+    required String recoveryKey,
+  }) =>
+      recoverUserService.completeRecovery(
+        challenge: challenge,
         credentialId: credentialId,
         recoveryKey: recoveryKey,
-        twoFATypes: twoFATypes,
       );
 
   Future<void> logOut() async {

--- a/packages/ion_identity_client/lib/src/auth/services/recover_user/data_sources/recover_user_data_source.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/recover_user/data_sources/recover_user_data_source.dart
@@ -6,7 +6,6 @@ import 'package:ion_identity_client/src/core/network/network_client.dart';
 import 'package:ion_identity_client/src/core/network/network_exception.dart';
 import 'package:ion_identity_client/src/core/types/request_headers.dart';
 import 'package:ion_identity_client/src/core/types/types.dart';
-import 'package:ion_identity_client/src/signer/dtos/dtos.dart';
 
 class RecoverUserDataSource {
   RecoverUserDataSource({
@@ -40,7 +39,8 @@ class RecoverUserDataSource {
 
       if (dioException?.response?.statusCode == 403 &&
           dioException?.response?.data['error']['message'] == '2FA_REQUIRED') {
-        throw const TwoFARequiredException();
+        final twoFAOptionsCount = dioException?.response?.data['data']['n'] as int;
+        throw TwoFARequiredException(twoFAOptionsCount);
       }
       rethrow;
     }

--- a/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
+++ b/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
@@ -27,7 +27,11 @@ class PasskeyValidationException extends IONIdentityException {
 }
 
 class TwoFARequiredException extends IONIdentityException {
-  const TwoFARequiredException() : super('Two-factor authentication is required');
+  const TwoFARequiredException(
+    this.twoFAOptionsCount,
+  ) : super('Two-factor authentication is required');
+
+  final int twoFAOptionsCount;
 }
 
 class UnknownIONIdentityException extends IONIdentityException {

--- a/packages/ion_identity_client/lib/src/signer/passkey_signer.dart
+++ b/packages/ion_identity_client/lib/src/signer/passkey_signer.dart
@@ -8,7 +8,6 @@ import 'package:ion_identity_client/src/signer/dtos/fido_2_assertion_data.dart';
 import 'package:ion_identity_client/src/signer/dtos/fido_2_attestation.dart';
 import 'package:ion_identity_client/src/signer/dtos/fido_2_attestation_data.dart';
 import 'package:ion_identity_client/src/signer/dtos/user_action_challenge.dart';
-import 'package:ion_identity_client/src/signer/dtos/user_registration_challenge.dart';
 import 'package:passkeys/authenticator.dart';
 import 'package:passkeys/types.dart';
 


### PR DESCRIPTION
## Description
This PR does 2 things:
- splits recoverUser into 2 methods (initRecover and completeRecover) to let the app show Passkey prompt properly (most of the changes are related to this)
- adds 2FA options count for recover flow (only few files changed)

## Type of Change
- [ ] Bug fix
- [X] New feature
- [x] Breaking change
- [X] Refactoring
- [ ] Documentation
- [ ] Chore

