### PR TITLE
chore: remove figma link section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,3 @@
 ## Screenshots (if applicable)
 <!-- Include screenshots to demonstrate any UI changes. -->
 <!-- <img width="180" alt="image" src="image_url_here"> -->
-
-## Figma Link (if applicable)
-<!-- Add a link to the Figma design here if relevant to the PR. -->
-


### PR DESCRIPTION
## Description
Remove the optional Figma link section from the pull request template.

## Additional Notes
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore
