### PR TITLE
fix: qr scanner padding

### DIFF
--- a/lib/app/features/wallet/views/pages/wallet_scan/wallet_scan_modal_page.dart
+++ b/lib/app/features/wallet/views/pages/wallet_scan/wallet_scan_modal_page.dart
@@ -11,6 +11,7 @@ class WalletScanModalPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const SheetContent(
       bottomPadding: 0,
+      topPadding: 0,
       body: QRScannerBottomSheet(),
     );
   }

--- a/lib/app/features/wallet/views/pages/wallet_scan/wallet_scan_modal_page.dart
+++ b/lib/app/features/wallet/views/pages/wallet_scan/wallet_scan_modal_page.dart
@@ -10,6 +10,7 @@ class WalletScanModalPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const SheetContent(
+      bottomPadding: 0,
       body: QRScannerBottomSheet(),
     );
   }


### PR DESCRIPTION
## Description
Removes top and bottom padding on qr scanner page.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/74be08ec-99c3-43be-898f-6e7dcbfd2da0">