### PR TITLE
fix: add error handling for recovery keys modal when passkeys validation fails

### DIFF
--- a/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
+import 'package:ion_identity_client/ion_identity.dart';
 
 class CreateRecoveryKeyPage extends StatelessWidget {
   const CreateRecoveryKeyPage({super.key});
@@ -80,6 +81,8 @@ class _Body extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final recoveryData = ref.watch(createRecoveryKeyActionNotifierProvider);
 
+    ref.displayErrors(createRecoveryKeyActionNotifierProvider);
+
     useOnInit(() {
       guardPasskeyDialog(
         context,
@@ -93,16 +96,11 @@ class _Body extends HookConsumerWidget {
       );
     });
 
-    if (recoveryData.isLoading || recoveryData.valueOrNull == null) {
-      return const CreateRecoveryKeyLoadingState();
-    }
-    if (recoveryData.hasError) {
-      return const CreateRecoveryKeyErrorState();
-    }
-    if (recoveryData.hasValue) {
-      return CreateRecoveryKeySuccessState(recoveryData: recoveryData.requireValue!);
-    }
-
-    return const CreateRecoveryKeyLoadingState();
+    return switch (recoveryData) {
+      AsyncData(:final CreateRecoveryCredentialsSuccess value) =>
+        CreateRecoveryKeySuccessState(recoveryData: value),
+      AsyncError() => const CreateRecoveryKeyErrorState(),
+      _ => const CreateRecoveryKeyLoadingState(),
+    };
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -455,7 +455,7 @@
   "protect_account_description_secure_account": "Securing your account ensures you never lose access to your data and funds",
   "protect_account_button": "Protect account",
   "protect_account_description_secure_account_2fa": "To secure your account, back it up and enable at least one 2FA option",
-  "protect_account_create_recovery_error": "An error occurred while uploading the data. Try again later.",
+  "protect_account_create_recovery_error": "An error occurred while fetching the data.",
   "backup_title": "Select backup",
   "backup_description": "Backups enable you to restore your data and wallet if something goes wrong",
   "backup_option_with_icloud_title": "Backup with iCloud",


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/3f4de97a-0e3e-455c-8afe-80c13191134a">
<img width="180" alt="image" src="https://github.com/user-attachments/assets/cb4460c8-2808-4f7a-baa5-c71db9fe432d">
