### PR TITLE
fix: change overflow three dots text alignment to center on recovery key options

### DIFF
--- a/lib/app/features/protect_account/backup/views/components/recovery_key_option.dart
+++ b/lib/app/features/protect_account/backup/views/components/recovery_key_option.dart
@@ -63,6 +63,7 @@ class RecoveryKeyOption extends StatelessWidget {
                           maxLines: 1,
                           overflowWidget: TextOverflowWidget(
                             position: TextOverflowPosition.middle,
+                            align: TextOverflowAlign.center,
                             child: Text('...', style: textTheme.subtitle),
                           ),
                         ),


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/26db1f6b-e32a-4022-816c-f75cca1f4329">
