### PR TITLE
fix: correctly display error modal on phone number verification delete page

### DIFF
--- a/lib/app/features/protect_account/components/delete_twofa_input_step.dart
+++ b/lib/app/features/protect_account/components/delete_twofa_input_step.dart
@@ -129,10 +129,12 @@ class DeleteTwoFAInputStep extends HookConsumerWidget {
       }
 
       if (next.hasError) {
-        showSimpleBottomSheet<void>(
-          context: ref.context,
-          child: const TwoFaTryAgainPage(),
-        );
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          showSimpleBottomSheet<void>(
+            context: ref.context,
+            child: const TwoFaTryAgainPage(),
+          );
+        });
         return;
       }
 

--- a/lib/app/features/protect_account/phone/views/pages/delete_phone/components/delete_phone_select_options_step.dart
+++ b/lib/app/features/protect_account/phone/views/pages/delete_phone/components/delete_phone_select_options_step.dart
@@ -18,7 +18,7 @@ class DeletePhoneSelectOptionsStep extends HookWidget {
     final locale = context.i18n;
 
     return DeleteTwoFAStepScaffold(
-      headerIcon: Assets.svg.icon2faEmailauth.icon(size: 36.0.s),
+      headerIcon: Assets.svg.icon2faPhoneconfirm.icon(size: 36.0.s),
       headerTitle: locale.two_fa_deleting_phone_title,
       headerDescription: locale.two_fa_deleting_phone_description,
       child: DeleteTwoFASelectOptionStep(


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/ce2d7a21-5b24-43b2-96de-a60afb7e03d5">
