### PR TITLE
fix: display a gallery preview image in the create story flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ fastlane/keys
 
 # Third-party tools
 .cursorrules
+
+# FVM Version Cache
+.fvm/

--- a/lib/app/features/feed/stories/providers/story_camera_provider.c.dart
+++ b/lib/app/features/feed/stories/providers/story_camera_provider.c.dart
@@ -7,6 +7,7 @@ import 'package:ion/app/features/feed/content_notification/data/models/content_n
 import 'package:ion/app/features/feed/content_notification/providers/content_notification_provider.c.dart';
 import 'package:ion/app/features/feed/stories/data/models/story_camera_state.c.dart';
 import 'package:ion/app/features/gallery/providers/camera_provider.c.dart';
+import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -24,9 +25,12 @@ class StoryCameraController extends _$StoryCameraController {
     if (picture != null) {
       final mediaFile = await ref.read(mediaServiceProvider).saveImageToGallery(File(picture.path));
 
-      state = mediaFile != null
-          ? StoryCameraState.saved(file: mediaFile)
-          : const StoryCameraState.error(message: 'Failed to save photo.');
+      if (mediaFile != null) {
+        ref.invalidate(latestGalleryPreviewProvider);
+        state = StoryCameraState.saved(file: mediaFile);
+      } else {
+        state = const StoryCameraState.error(message: 'Failed to save photo.');
+      }
     }
   }
 

--- a/lib/app/features/feed/stories/views/components/story_capture/camera/idle_camera_preview.dart
+++ b/lib/app/features/feed/stories/views/components/story_capture/camera/idle_camera_preview.dart
@@ -4,15 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
-import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
-import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_sheets.dart';
 import 'package:ion/app/features/feed/stories/providers/story_camera_provider.c.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_capture/controls/story_control_button.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_capture/controls/story_gallery_button.dart';
 import 'package:ion/app/features/gallery/providers/camera_provider.c.dart';
-import 'package:ion/app/router/app_routes.c.dart';
-import 'package:ion/app/services/media_service/banuba_service.c.dart';
-import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class IdleCameraPreview extends ConsumerWidget {
@@ -51,35 +46,7 @@ class IdleCameraPreview extends ConsumerWidget {
         Positioned(
           bottom: 30.0.s,
           left: 16.0.s,
-          child: PermissionAwareWidget(
-            permissionType: Permission.photos,
-            onGranted: () async {
-              if (context.mounted) {
-                final mediaFiles =
-                    await MediaPickerRoute(maxSelection: 1).push<List<MediaFile>>(context);
-                if (mediaFiles != null && mediaFiles.isNotEmpty && context.mounted) {
-                  final filePath = await ref.read(editMediaProvider(mediaFiles.first).future);
-
-                  if (context.mounted) {
-                    await StoryPreviewRoute(
-                      path: filePath,
-                      mimeType: mediaFiles.first.mimeType,
-                    ).push<void>(context);
-                  }
-                }
-              }
-            },
-            requestDialog: const PermissionRequestSheet(
-              permission: Permission.photos,
-            ),
-            settingsDialog: SettingsRedirectSheet.fromType(context, Permission.photos),
-            builder: (context, onPressed) => StoryControlButton(
-              onPressed: onPressed,
-              icon: Assets.svg.iconGalleryOpen.icon(
-                color: context.theme.appColors.onPrimaryAccent,
-              ),
-            ),
-          ),
+          child: const StoryGalleryButton(),
         ),
       ],
     );

--- a/lib/app/features/feed/stories/views/components/story_capture/components.dart
+++ b/lib/app/features/feed/stories/views/components/story_capture/components.dart
@@ -4,6 +4,7 @@ export 'camera/idle_camera_preview.dart';
 export 'camera/story_camera_preview.dart';
 export 'controls/story_capture_button.dart';
 export 'controls/story_control_button.dart';
+export 'controls/story_gallery_button.dart';
 export 'controls/story_recording_indicator.dart';
 export 'progress/inner_capture_circle.dart';
 export 'progress/story_circular_progress_indicator.dart';

--- a/lib/app/features/feed/stories/views/components/story_capture/controls/story_gallery_button.dart
+++ b/lib/app/features/feed/stories/views/components/story_capture/controls/story_gallery_button.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';

--- a/lib/app/features/feed/stories/views/components/story_capture/controls/story_gallery_button.dart
+++ b/lib/app/features/feed/stories/views/components/story_capture/controls/story_gallery_button.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
+import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
+import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_sheets.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_capture/components.dart';
+import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
+import 'package:ion/app/router/app_routes.c.dart';
+import 'package:ion/app/services/media_service/media_service.c.dart';
+import 'package:ion/generated/assets.gen.dart';
+import 'package:photo_manager/photo_manager.dart';
+import 'package:photo_manager_image_provider/photo_manager_image_provider.dart';
+
+class StoryGalleryButton extends ConsumerWidget {
+  const StoryGalleryButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PermissionAwareWidget(
+      permissionType: Permission.photos,
+      onGranted: () async {
+        if (context.mounted) {
+          final mediaFiles = await MediaPickerRoute(maxSelection: 1).push<List<MediaFile>>(context);
+          if (mediaFiles != null && mediaFiles.isNotEmpty && context.mounted) {
+            // TODO: uncomment after getting the actual the banuba's token
+            // final filePath = await ref.read(editMediaProvider(mediaFiles.first).future);
+            final filePath = await ref.read(assetFilePathProvider(mediaFiles.first.path).future);
+
+            if (filePath != null && context.mounted) {
+              await StoryPreviewRoute(
+                path: filePath,
+                mimeType: mediaFiles.first.mimeType,
+              ).push<void>(context);
+            }
+          }
+        }
+      },
+      requestDialog: const PermissionRequestSheet(
+        permission: Permission.photos,
+      ),
+      settingsDialog: SettingsRedirectSheet.fromType(context, Permission.photos),
+      builder: (context, onPressed) {
+        return Consumer(
+          builder: (context, ref, _) {
+            final galleryPreview = ref.watch(latestGalleryPreviewProvider).valueOrNull;
+
+            if (galleryPreview == null) {
+              return StoryControlButton(
+                onPressed: onPressed,
+                icon: Assets.svg.iconGalleryOpen.icon(
+                  color: context.theme.appColors.onPrimaryAccent,
+                ),
+              );
+            }
+
+            return StoryControlButton(
+              iconPadding: 0.0.s,
+              onPressed: onPressed,
+              icon: Image(
+                width: 36.0.s,
+                height: 36.0.s,
+                fit: BoxFit.cover,
+                image: AssetEntityImageProvider(
+                  galleryPreview,
+                  isOriginal: false,
+                  thumbnailSize: const ThumbnailSize.square(300),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/share/story_share_modal.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/share/story_share_modal.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/share/share_actions_buttons.dart';
 import 'package:ion/app/features/feed/views/components/share_modal_base/share_modal_base.dart';
@@ -14,6 +15,7 @@ class StoryShareModal extends StatelessWidget {
       title: context.i18n.feed_share_via,
       showBackButton: true,
       showNextIcon: false,
+      onClose: context.pop,
       emptyStateWidget: const ShareActionButtons(),
     );
   }

--- a/lib/app/features/feed/stories/views/pages/story_preview_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_preview_page.dart
@@ -83,7 +83,7 @@ class StoryPreviewPage extends ConsumerWidget {
                     await showSimpleBottomSheet<bool>(
                       context: context,
                       child: VisibilitySettingsModal(
-                        title: context.i18n.visibility_settings_title_story,
+                        title: context.i18n.story_settings_title,
                       ),
                     );
                   },

--- a/lib/app/features/feed/stories/views/pages/story_record_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_record_page.dart
@@ -14,8 +14,8 @@ import 'package:ion/app/features/feed/stories/providers/story_camera_provider.c.
 import 'package:ion/app/features/feed/stories/views/components/story_capture/components.dart';
 import 'package:ion/app/features/gallery/data/models/camera_state.c.dart';
 import 'package:ion/app/features/gallery/providers/camera_provider.c.dart';
+import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
-import 'package:ion/app/services/media_service/banuba_service.c.dart';
 
 class StoryRecordPage extends HookConsumerWidget {
   const StoryRecordPage({super.key});
@@ -38,9 +38,12 @@ class StoryRecordPage extends HookConsumerWidget {
 
     ref.listen<StoryCameraState>(storyCameraControllerProvider, (_, next) async {
       if (next is StoryCameraSaved && context.mounted) {
-        final filePath = await ref.read(editMediaProvider(next.file).future);
+        // TODO: uncomment after getting the actual the banuba's token
+        // final filePath = await ref.read(editMediaProvider(next.file).future);
 
-        if (context.mounted) {
+        final filePath = await ref.read(assetFilePathProvider(next.file.path).future);
+
+        if (filePath != null && context.mounted) {
           await StoryPreviewRoute(
             path: filePath,
             mimeType: next.file.mimeType,

--- a/lib/app/features/gallery/providers/gallery_provider.c.dart
+++ b/lib/app/features/gallery/providers/gallery_provider.c.dart
@@ -20,6 +20,18 @@ Future<AssetEntity?> assetEntity(Ref ref, String id) {
 }
 
 @riverpod
+Future<AssetEntity?> latestGalleryPreview(Ref ref) async {
+  final mediaService = ref.watch(mediaServiceProvider);
+  final mediaData = await mediaService.fetchGalleryMedia(
+    page: 0,
+    size: 1,
+    type: MediaPickerType.image,
+  );
+
+  return await ref.watch(assetEntityProvider(mediaData.first.path).future);
+}
+
+@riverpod
 Future<String?> assetFilePath(Ref ref, String assetId) async {
   final assetEntity = await ref.watch(assetEntityProvider(assetId).future);
 


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
- Disable `Banuba editor` due to token expiration
- Add a close button to the bottom sheet for story-sharing
- Update the title in the story-sharing bottom sheet
- Display the latest gallery preview image in the custom camera

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
