### PR TITLE
fix(passkey auth): override passkeys_ios with custom fix

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1467,12 +1467,13 @@ packages:
     source: hosted
     version: "2.1.0"
   passkeys_ios:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: passkeys_ios
-      sha256: "1e23e40efd12867725443923a72914c11f926dce8623757b45ed2d7a16e95731"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/passkeys/passkeys_ios"
+      ref: fix-ios-immediate-creds
+      resolved-ref: a282eccc77f7bf91b10273d477958b2ac104c5f9
+      url: "https://github.com/ice-tychon/flutter-passkeys.git"
+    source: git
     version: "2.1.0"
   passkeys_platform_interface:
     dependency: transitive

--- a/pubspec_overrides.yaml
+++ b/pubspec_overrides.yaml
@@ -5,3 +5,8 @@ dependency_overrides:
   ion_screenshot_detector:
     path: packages/ion_screenshot_detector
   js: ^0.7.1
+  passkeys_ios:
+    git:
+      url: https://github.com/ice-tychon/flutter-passkeys.git
+      ref: fix-ios-immediate-creds
+      path: packages/passkeys/passkeys_ios


### PR DESCRIPTION
## Description
This PR adds a fix for iOS to be able to use another device to login.

## Additional Notes
Changes in the passkeys_ios: https://github.com/corbado/flutter-passkeys/pull/83

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
<img width="300" alt="image" src="[image_url_here](https://github.com/user-attachments/assets/103e26f1-870e-49d7-b7ab-3b33e077fce5)">