### PR TITLE
feat: add default colors, textThemes

### DIFF
--- a/lib/app/extensions/theme_data.dart
+++ b/lib/app/extensions/theme_data.dart
@@ -6,8 +6,10 @@ import 'package:ion/app/theme/app_text_themes.dart';
 
 extension AppThemeExtension on ThemeData {
   /// Usage example: Theme.of(context).appColors;
-  AppColorsExtension get appColors => extension<AppColorsExtension>()!;
+  AppColorsExtension get appColors =>
+      extension<AppColorsExtension>() ?? AppColorsExtension.defaultColors();
 
   /// Usage example: Theme.of(context).appTextThemes;
-  AppTextThemesExtension get appTextThemes => extension<AppTextThemesExtension>()!;
+  AppTextThemesExtension get appTextThemes =>
+      extension<AppTextThemesExtension>() ?? AppTextThemesExtension.defaultTextThemes();
 }

--- a/lib/app/theme/app_colors.dart
+++ b/lib/app/theme/app_colors.dart
@@ -60,6 +60,35 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
     );
   }
 
+  factory AppColorsExtension.defaultColors() {
+    return AppColorsExtension(
+      primaryAccent: const Color(0xFF0166FF),
+      primaryText: const Color(0xFF0E0E0E),
+      secondaryText: const Color(0xFF494949),
+      tertararyText: const Color(0xFF9A9A9A),
+      sharkText: const Color(0xFF333436),
+      primaryBackground: const Color(0xFFF5F7FF),
+      secondaryBackground: const Color(0xFFFFFFFF),
+      tertararyBackground: const Color(0xFFFAFBFF),
+      backgroundSheet: const Color(0x32081532),
+      onPrimaryAccent: const Color(0xFFFFFFFF),
+      onTertararyBackground: const Color(0xFF5A5E66),
+      onTerararyFill: const Color(0xFFE1EAF8),
+      onSecondaryBackground: const Color(0xFFF5F7FF),
+      strokeElements: const Color(0xFFCCCCCC),
+      sheetLine: const Color(0xFFB8BCCA),
+      attentionRed: const Color(0xFFFD4E4E),
+      success: const Color(0xFF35D487),
+      orangePeel: const Color(0xFFFFA143),
+      purple: const Color(0xFF7D40FF),
+      raspberry: const Color(0xFFEA3665),
+      darkBlue: const Color(0xFF1D46EB),
+      lightBlue: const Color(0xFF1B9CF0),
+      quaternaryText: const Color(0xFF727689),
+      attentionBlock: const Color(0xFFEEF1FF),
+    );
+  }
+
   final Color primaryAccent;
   final Color primaryText;
   final Color secondaryText;

--- a/lib/app/theme/app_text_themes.dart
+++ b/lib/app/theme/app_text_themes.dart
@@ -38,6 +38,24 @@ class AppTextThemesExtension extends ThemeExtension<AppTextThemesExtension> {
     );
   }
 
+  factory AppTextThemesExtension.defaultTextThemes() {
+    return const AppTextThemesExtension(
+      headline1: TextStyle(fontSize: 28, fontWeight: FontWeight.w700),
+      headline2: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+      inputFieldText: TextStyle(fontSize: 25, fontWeight: FontWeight.w700),
+      title: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+      subtitle: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+      subtitle2: TextStyle(fontSize: 15, fontWeight: FontWeight.w500),
+      subtitle3: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+      body: TextStyle(fontSize: 13, height: 1.38, fontWeight: FontWeight.w600),
+      body2: TextStyle(fontSize: 13, fontWeight: FontWeight.w400),
+      caption: TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
+      caption2: TextStyle(fontSize: 12, fontWeight: FontWeight.w400),
+      caption3: TextStyle(fontSize: 11, height: 1.63, fontWeight: FontWeight.w400),
+      caption4: TextStyle(fontSize: 10, fontWeight: FontWeight.w500),
+    );
+  }
+
   final TextStyle headline1;
   final TextStyle headline2;
   final TextStyle inputFieldText;


### PR DESCRIPTION
## Description
Add default `colors` and `textThemes` to avoid force unwrap

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore