### PR TITLE
feat: Add sync coins once per 24 hours

### DIFF
--- a/lib/app/features/core/providers/init_provider.c.dart
+++ b/lib/app/features/core/providers/init_provider.c.dart
@@ -7,6 +7,7 @@ import 'package:ion/app/features/core/permissions/providers/permissions_provider
 import 'package:ion/app/features/core/providers/env_provider.c.dart';
 import 'package:ion/app/features/core/providers/template_provider.c.dart';
 import 'package:ion/app/features/core/providers/window_manager_provider.c.dart';
+import 'package:ion/app/features/wallet/data/coins/domain/coin_initializer.c.dart';
 import 'package:ion/app/services/nostr/nostr.dart';
 import 'package:ion/app/services/storage/local_storage.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -27,6 +28,7 @@ Future<void> initApp(Ref ref) async {
     ref.read(appTemplateProvider.future),
     ref.read(authProvider.future),
     ref.read(permissionsProvider.notifier).checkAllPermissions(),
+    ref.read(coinInitializerProvider).initialize(),
   ]);
 
   await ref.read(onboardingCompleteProvider.future);

--- a/lib/app/features/wallet/components/coin_sync/coins_sync_wrapper.dart
+++ b/lib/app/features/wallet/components/coin_sync/coins_sync_wrapper.dart
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/wallet/data/coins/domain/coin_sync_service.c.dart';
+
+class CoinsSyncWrapper extends HookConsumerWidget {
+  const CoinsSyncWrapper({
+    required this.child,
+    super.key,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final coinSyncService = ref.watch(coinSyncServiceProvider).valueOrNull;
+    final appState = useAppLifecycleState();
+
+    useEffect(
+      () {
+        if (coinSyncService == null || appState != AppLifecycleState.resumed) return null;
+
+        coinSyncService
+          ..syncCoins()
+          ..startPeriodicSync();
+
+        return coinSyncService.stopPeriodicSync;
+      },
+      [coinSyncService, appState],
+    );
+
+    return child;
+  }
+}

--- a/lib/app/features/wallet/data/coins/database/coins_database.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_database.c.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/wallet/data/coins/database/coins_table.c.dart';
+import 'package:ion/app/features/wallet/data/coins/database/duration_type.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'coins_database.c.g.dart';

--- a/lib/app/features/wallet/data/coins/database/coins_database.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_database.c.dart
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:drift/drift.dart';
+import 'package:drift_flutter/drift_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/wallet/data/coins/database/coins_table.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'coins_database.c.g.dart';
+
+@Riverpod(keepAlive: true)
+CoinsDatabase coinsDatabase(Ref ref) => CoinsDatabase();
+
+// DO NOT create or use database directly, use proxy notifier
+// [IONDatabaseNotifier] methods instead
+@DriftDatabase(
+  tables: [
+    CoinsTable,
+  ],
+)
+class CoinsDatabase extends _$CoinsDatabase {
+  CoinsDatabase() : super(_openConnection());
+
+  // For testing executor
+  CoinsDatabase.test(super.e);
+
+  @override
+  int get schemaVersion => 1;
+
+  static QueryExecutor _openConnection() {
+    return driftDatabase(name: 'coins_database');
+  }
+}

--- a/lib/app/features/wallet/data/coins/database/coins_repository.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_repository.c.dart
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/wallet/data/coins/database/coins_database.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'coins_repository.c.g.dart';
+
+@Riverpod(keepAlive: true)
+CoinsRepository coinsRepository(Ref ref) => CoinsRepository(db: ref.watch(coinsDatabaseProvider));
+
+class CoinsRepository {
+  CoinsRepository({
+    required CoinsDatabase db,
+  }) : _db = db;
+
+  final CoinsDatabase _db;
+
+  Future<bool> hasAny() async {
+    return _db.select(_db.coinsTable).getSingleOrNull().then((value) => value != null);
+  }
+
+  Future<void> upsertAll(List<Coin> coins) async {
+    await _db.batch((batch) {
+      batch.insertAllOnConflictUpdate(_db.coinsTable, coins);
+    });
+  }
+
+  Future<void> clear() async {
+    await _db.delete(_db.coinsTable).go();
+  }
+}

--- a/lib/app/features/wallet/data/coins/database/coins_repository.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_repository.c.dart
@@ -17,7 +17,9 @@ class CoinsRepository {
   final CoinsDatabase _db;
 
   Future<bool> hasAny() async {
-    return _db.select(_db.coinsTable).getSingleOrNull().then((value) => value != null);
+    final query = _db.select(_db.coinsTable)..limit(1);
+    final result = await query.get();
+    return result.isNotEmpty;
   }
 
   Future<void> upsertAll(List<Coin> coins) async {

--- a/lib/app/features/wallet/data/coins/database/coins_table.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_table.c.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:drift/drift.dart';
+import 'package:ion/app/features/wallet/data/coins/database/duration_type.dart';
 
 @DataClassName('Coin')
 class CoinsTable extends Table {
@@ -18,5 +19,5 @@ class CoinsTable extends Table {
   @JsonKey('symbolGroup')
   TextColumn get symbolGroup => text()();
   @JsonKey('syncFrequency')
-  IntColumn get syncFrequency => integer()();
+  Column<Duration> get syncFrequency => customType(const DurationType())();
 }

--- a/lib/app/features/wallet/data/coins/database/coins_table.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_table.c.dart
@@ -20,4 +20,7 @@ class CoinsTable extends Table {
   TextColumn get symbolGroup => text()();
   @JsonKey('syncFrequency')
   Column<Duration> get syncFrequency => customType(const DurationType())();
+
+  @override
+  Set<Column> get primaryKey => {id};
 }

--- a/lib/app/features/wallet/data/coins/database/coins_table.c.dart
+++ b/lib/app/features/wallet/data/coins/database/coins_table.c.dart
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:drift/drift.dart';
+
+@DataClassName('Coin')
+class CoinsTable extends Table {
+  TextColumn get id => text()();
+  @JsonKey('contractAddress')
+  TextColumn get contractAddress => text()();
+  IntColumn get decimals => integer()();
+  @JsonKey('iconURL')
+  TextColumn get iconURL => text()();
+  TextColumn get name => text()();
+  TextColumn get network => text()();
+  @JsonKey('priceUSD')
+  RealColumn get priceUSD => real()();
+  TextColumn get symbol => text()();
+  @JsonKey('symbolGroup')
+  TextColumn get symbolGroup => text()();
+  @JsonKey('syncFrequency')
+  IntColumn get syncFrequency => integer()();
+}

--- a/lib/app/features/wallet/data/coins/database/duration_type.dart
+++ b/lib/app/features/wallet/data/coins/database/duration_type.dart
@@ -1,0 +1,23 @@
+import 'package:drift/drift.dart';
+
+class DurationType implements CustomSqlType<Duration> {
+  const DurationType();
+
+  @override
+  String mapToSqlLiteral(Duration dartValue) {
+    return dartValue.inMilliseconds.toString();
+  }
+
+  @override
+  Object mapToSqlParameter(Duration dartValue) {
+    return dartValue.inMilliseconds;
+  }
+
+  @override
+  Duration read(Object fromSql) {
+    return Duration(milliseconds: fromSql as int);
+  }
+
+  @override
+  String sqlTypeName(GenerationContext context) => 'integer';
+}

--- a/lib/app/features/wallet/data/coins/database/duration_type.dart
+++ b/lib/app/features/wallet/data/coins/database/duration_type.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:drift/drift.dart';
 
 class DurationType implements CustomSqlType<Duration> {

--- a/lib/app/features/wallet/data/coins/database/duration_type.dart
+++ b/lib/app/features/wallet/data/coins/database/duration_type.dart
@@ -6,19 +6,13 @@ class DurationType implements CustomSqlType<Duration> {
   const DurationType();
 
   @override
-  String mapToSqlLiteral(Duration dartValue) {
-    return dartValue.inMilliseconds.toString();
-  }
+  String mapToSqlLiteral(Duration dartValue) => dartValue.inMilliseconds.toString();
 
   @override
-  Object mapToSqlParameter(Duration dartValue) {
-    return dartValue.inMilliseconds;
-  }
+  Object mapToSqlParameter(Duration dartValue) => dartValue.inMilliseconds;
 
   @override
-  Duration read(Object fromSql) {
-    return Duration(milliseconds: fromSql as int);
-  }
+  Duration read(Object fromSql) => Duration(milliseconds: fromSql as int);
 
   @override
   String sqlTypeName(GenerationContext context) => 'integer';

--- a/lib/app/features/wallet/data/coins/domain/coin_initializer.c.dart
+++ b/lib/app/features/wallet/data/coins/domain/coin_initializer.c.dart
@@ -33,7 +33,9 @@ class CoinInitializer {
         .expand(
           (group) =>
               // ignore: avoid_dynamic_calls
-              (group['coins'] as List).map((coin) => Coin.fromJson(coin as Map<String, dynamic>)),
+              (group['coins'] as List).map((coin) {
+                return Coin.fromJson(coin as Map<String, dynamic>);
+              }),
         )
         .toList();
 

--- a/lib/app/features/wallet/data/coins/domain/coin_initializer.c.dart
+++ b/lib/app/features/wallet/data/coins/domain/coin_initializer.c.dart
@@ -4,9 +4,10 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/features/wallet/data/coins/database/coins_database.c.dart';
 import 'package:ion/app/features/wallet/data/coins/database/coins_repository.c.dart';
+import 'package:ion/app/features/wallet/data/coins/domain/coins_mapper.dart';
 import 'package:ion/generated/assets.gen.dart';
+import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'coin_initializer.c.g.dart';
@@ -33,12 +34,10 @@ class CoinInitializer {
         .expand(
           (group) =>
               // ignore: avoid_dynamic_calls
-              (group['coins'] as List).map((coin) {
-                return Coin.fromJson(coin as Map<String, dynamic>);
-              }),
+              (group['coins'] as List).map((coin) => Coin.fromJson(coin as Map<String, dynamic>)),
         )
         .toList();
 
-    await _coinsRepository.upsertAll(coinEntities);
+    await _coinsRepository.upsertAll(CoinsMapper.fromIONIdentityCoins(coinEntities));
   }
 }

--- a/lib/app/features/wallet/data/coins/domain/coin_initializer.c.dart
+++ b/lib/app/features/wallet/data/coins/domain/coin_initializer.c.dart
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/wallet/data/coins/database/coins_database.c.dart';
+import 'package:ion/app/features/wallet/data/coins/database/coins_repository.c.dart';
+import 'package:ion/generated/assets.gen.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'coin_initializer.c.g.dart';
+
+@riverpod
+CoinInitializer coinInitializer(Ref ref) {
+  return CoinInitializer(ref.watch(coinsRepositoryProvider));
+}
+
+class CoinInitializer {
+  CoinInitializer(this._coinsRepository);
+
+  final CoinsRepository _coinsRepository;
+
+  Future<void> initialize() async {
+    final hasCoins = await _coinsRepository.hasAny();
+    if (hasCoins) return;
+
+    // load coins from assets file
+    final coinsJson =
+        (await rootBundle.loadString(Assets.ionIdentity.coins).then(jsonDecode)) as List<dynamic>;
+
+    final coinEntities = coinsJson
+        .expand(
+          (group) =>
+              // ignore: avoid_dynamic_calls
+              (group['coins'] as List).map((coin) => Coin.fromJson(coin as Map<String, dynamic>)),
+        )
+        .toList();
+
+    await _coinsRepository.upsertAll(coinEntities);
+  }
+}

--- a/lib/app/features/wallet/data/coins/domain/coin_sync_service.c.dart
+++ b/lib/app/features/wallet/data/coins/domain/coin_sync_service.c.dart
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:async';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/wallet/data/coins/database/coins_repository.c.dart';
+import 'package:ion/app/features/wallet/data/coins/domain/coins_mapper.dart';
+import 'package:ion/app/services/ion_identity/ion_identity_client_provider.c.dart';
+import 'package:ion/app/services/storage/local_storage.c.dart';
+import 'package:ion_identity_client/ion_identity.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'coin_sync_service.c.g.dart';
+
+@riverpod
+Future<CoinSyncService> coinSyncService(Ref ref) async {
+  final interactor = CoinSyncService(
+    ref.watch(coinsRepositoryProvider),
+    ref.watch(localStorageProvider),
+    await ref.watch(ionIdentityClientProvider.future),
+  );
+
+  return interactor;
+}
+
+class CoinSyncService {
+  CoinSyncService(
+    this._coinsRepository,
+    this._localStorage,
+    this._ionIdentityClient,
+  );
+
+  static const _timerInterval = Duration(hours: 1);
+  static const _syncInterval = Duration(days: 1);
+  Timer? _syncTimer;
+
+  final CoinsRepository _coinsRepository;
+  final LocalStorage _localStorage;
+  final IONIdentityClient _ionIdentityClient;
+
+  void startPeriodicSync() {
+    stopPeriodicSync();
+    _syncTimer = Timer.periodic(_timerInterval, (_) => syncCoins());
+  }
+
+  void stopPeriodicSync() {
+    _syncTimer?.cancel();
+    _syncTimer = null;
+  }
+
+  Future<void> syncCoins() async {
+    final lastSyncTime = _localStorage.getInt('coins_last_sync_time');
+    final currentTime = DateTime.now().millisecondsSinceEpoch;
+    final syncInterval = _syncInterval.inMilliseconds;
+
+    if (lastSyncTime != null && currentTime - lastSyncTime < syncInterval) {
+      return;
+    }
+
+    final version = _localStorage.getInt('coins_version');
+    final response = await _ionIdentityClient.coins.getCoins(currentVersion: version ?? 0);
+
+    await (
+      _localStorage.setInt('coins_version', response.version),
+      _localStorage.setInt('coins_last_sync_time', currentTime),
+    ).wait;
+
+    if (response.coins.isEmpty) {
+      return;
+    }
+
+    await _coinsRepository.upsertAll(CoinsMapper.fromIONIdentityCoins(response.coins));
+  }
+}

--- a/lib/app/features/wallet/data/coins/domain/coins_mapper.dart
+++ b/lib/app/features/wallet/data/coins/domain/coins_mapper.dart
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion/app/features/wallet/data/coins/database/coins_database.c.dart';
+import 'package:ion_identity_client/ion_identity.dart' as ion_identity;
+
+class CoinsMapper {
+  static List<Coin> fromIONIdentityCoins(List<ion_identity.Coin> coins) {
+    return coins
+        .map(
+          (coin) => Coin(
+            id: coin.id,
+            name: coin.name,
+            symbol: coin.symbol,
+            iconURL: coin.iconURL,
+            network: coin.network,
+            priceUSD: coin.priceUSD,
+            decimals: coin.decimals,
+            syncFrequency: coin.syncFrequency,
+            contractAddress: coin.contractAddress,
+            symbolGroup: coin.symbolGroup,
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/app/services/ion_identity/ion_identity_provider.c.dart
+++ b/lib/app/services/ion_identity/ion_identity_provider.c.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/providers/env_provider.c.dart';
+import 'package:ion/app/services/logger/config.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -21,6 +22,7 @@ Future<Raw<IONIdentity>> ionIdentity(Ref ref) async {
   final config = IONIdentityConfig(
     appId: appId,
     origin: envController.get(EnvVariable.ION_ORIGIN),
+    logging: LoggerConfig.ionIdentityLogsEnabled,
   );
 
   final ionClient = IONIdentity.createDefault(config: config);

--- a/lib/app/services/logger/config.dart
+++ b/lib/app/services/logger/config.dart
@@ -9,5 +9,7 @@ class LoggerConfig {
 
   static const bool nostrLogsEnabled = true;
 
+  static const bool ionIdentityLogsEnabled = true;
+
   static const bool dioLogsEnabled = true;
 }

--- a/lib/app/services/storage/local_storage.c.dart
+++ b/lib/app/services/storage/local_storage.c.dart
@@ -39,6 +39,14 @@ class LocalStorage {
     return _prefs.getDouble(key);
   }
 
+  Future<bool> setInt(String key, int value) {
+    return _prefs.setInt(key, value);
+  }
+
+  int? getInt(String key) {
+    return _prefs.getInt(key);
+  }
+
   Future<bool> setString(String key, String value) {
     return _prefs.setString(key, value);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/features/core/providers/template_provider.c.dart';
 import 'package:ion/app/features/core/providers/theme_mode_provider.c.dart';
 import 'package:ion/app/features/core/views/components/app_lifecycle_observer.dart';
 import 'package:ion/app/features/core/views/components/content_scaler.dart';
+import 'package:ion/app/features/wallet/components/coin_sync/coins_sync_wrapper.dart';
 import 'package:ion/app/router/components/app_router_builder.dart';
 import 'package:ion/app/router/components/modal_wrapper/sheet_scope.dart';
 import 'package:ion/app/router/providers/go_router_provider.c.dart';
@@ -41,18 +42,20 @@ class IONApp extends ConsumerWidget {
     return ContentScaler(
       child: AppLifecycleObserver(
         child: SheetScope(
-          child: MaterialApp.router(
-            localizationsDelegates: const [
-              ...I18n.localizationsDelegates,
-              FlutterQuillLocalizations.delegate,
-            ],
-            supportedLocales: I18n.supportedLocales,
-            locale: appLocale,
-            theme: template.whenOrNull(data: (data) => buildLightTheme(data.theme)),
-            darkTheme: template.whenOrNull(data: (data) => buildDarkTheme(data.theme)),
-            themeMode: appThemeMode,
-            routerConfig: goRouter,
-            builder: (context, child) => AppRouterBuilder(child: child),
+          child: CoinsSyncWrapper(
+            child: MaterialApp.router(
+              localizationsDelegates: const [
+                ...I18n.localizationsDelegates,
+                FlutterQuillLocalizations.delegate,
+              ],
+              supportedLocales: I18n.supportedLocales,
+              locale: appLocale,
+              theme: template.whenOrNull(data: (data) => buildLightTheme(data.theme)),
+              darkTheme: template.whenOrNull(data: (data) => buildDarkTheme(data.theme)),
+              themeMode: appThemeMode,
+              routerConfig: goRouter,
+              builder: (context, child) => AppRouterBuilder(child: child),
+            ),
           ),
         ),
       ),

--- a/packages/ion_identity_client/lib/ion_identity.dart
+++ b/packages/ion_identity_client/lib/ion_identity.dart
@@ -6,6 +6,7 @@ export 'src/auth/dtos/dtos.dart';
 export 'src/auth/ion_identity_auth.dart';
 export 'src/auth/services/create_credentials/models/create_recovery_credentials_success.dart';
 export 'src/auth/services/twofa/models/twofa_type.c.dart';
+export 'src/coins/models/coin.c.dart';
 export 'src/core/types/ion_exception.dart';
 export 'src/core/types/types.dart';
 export 'src/core/types/user_token.c.dart';

--- a/packages/ion_identity_client/lib/src/coins/ion_identity_coins.dart
+++ b/packages/ion_identity_client/lib/src/coins/ion_identity_coins.dart
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/src/auth/services/extract_user_id/extract_user_id_service.dart';
+import 'package:ion_identity_client/src/coins/models/coins_response.c.dart';
+import 'package:ion_identity_client/src/coins/services/get_coins_service.dart';
+
+class IONIdentityCoins {
+  IONIdentityCoins({
+    required this.username,
+    required GetCoinsService getCoinsService,
+    required ExtractUserIdService extractUserIdService,
+  })  : _getCoinsService = getCoinsService,
+        _extractUserIdService = extractUserIdService;
+
+  final String username;
+  final GetCoinsService _getCoinsService;
+  final ExtractUserIdService _extractUserIdService;
+
+  Future<CoinsResponse> getCoins({
+    required int currentVersion,
+  }) {
+    final userId = _extractUserIdService.extractUserId(username: username);
+    return _getCoinsService.getCoins(
+      username: username,
+      userId: userId,
+      currentVersion: currentVersion,
+    );
+  }
+}

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.dart
@@ -29,9 +29,7 @@ class DurationConverter implements JsonConverter<Duration, int> {
   const DurationConverter();
 
   @override
-  Duration fromJson(int json) {
-    return Duration(milliseconds: json);
-  }
+  Duration fromJson(int json) => Duration(milliseconds: json);
 
   @override
   int toJson(Duration object) => object.inMilliseconds;

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.dart
@@ -17,8 +17,22 @@ class Coin with _$Coin {
     required double priceUSD,
     required String symbol,
     required String symbolGroup,
-    required int syncFrequency,
+    @DurationConverter() required Duration syncFrequency,
   }) = _Coin;
 
-  factory Coin.fromJson(Map<String, dynamic> json) => _$CoinFromJson(json);
+  factory Coin.fromJson(Map<String, dynamic> json) {
+    return _$CoinFromJson(json);
+  }
+}
+
+class DurationConverter implements JsonConverter<Duration, int> {
+  const DurationConverter();
+
+  @override
+  Duration fromJson(int json) {
+    return Duration(milliseconds: json);
+  }
+
+  @override
+  int toJson(Duration object) => object.inMilliseconds;
 }

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.dart
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'coin.c.freezed.dart';
+part 'coin.c.g.dart';
+
+@freezed
+class Coin with _$Coin {
+  factory Coin({
+    required String contractAddress,
+    required int decimals,
+    required String iconURL,
+    required String id,
+    required String name,
+    required String network,
+    required double priceUSD,
+    required String symbol,
+    required String symbolGroup,
+    required int syncFrequency,
+  }) = _Coin;
+
+  factory Coin.fromJson(Map<String, dynamic> json) => _$CoinFromJson(json);
+}

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.freezed.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.freezed.dart
@@ -29,7 +29,8 @@ mixin _$Coin {
   double get priceUSD => throw _privateConstructorUsedError;
   String get symbol => throw _privateConstructorUsedError;
   String get symbolGroup => throw _privateConstructorUsedError;
-  int get syncFrequency => throw _privateConstructorUsedError;
+  @DurationConverter()
+  Duration get syncFrequency => throw _privateConstructorUsedError;
 
   /// Serializes this Coin to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -55,7 +56,7 @@ abstract class $CoinCopyWith<$Res> {
       double priceUSD,
       String symbol,
       String symbolGroup,
-      int syncFrequency});
+      @DurationConverter() Duration syncFrequency});
 }
 
 /// @nodoc
@@ -124,7 +125,7 @@ class _$CoinCopyWithImpl<$Res, $Val extends Coin>
       syncFrequency: null == syncFrequency
           ? _value.syncFrequency
           : syncFrequency // ignore: cast_nullable_to_non_nullable
-              as int,
+              as Duration,
     ) as $Val);
   }
 }
@@ -146,7 +147,7 @@ abstract class _$$CoinImplCopyWith<$Res> implements $CoinCopyWith<$Res> {
       double priceUSD,
       String symbol,
       String symbolGroup,
-      int syncFrequency});
+      @DurationConverter() Duration syncFrequency});
 }
 
 /// @nodoc
@@ -212,7 +213,7 @@ class __$$CoinImplCopyWithImpl<$Res>
       syncFrequency: null == syncFrequency
           ? _value.syncFrequency
           : syncFrequency // ignore: cast_nullable_to_non_nullable
-              as int,
+              as Duration,
     ));
   }
 }
@@ -230,7 +231,7 @@ class _$CoinImpl implements _Coin {
       required this.priceUSD,
       required this.symbol,
       required this.symbolGroup,
-      required this.syncFrequency});
+      @DurationConverter() required this.syncFrequency});
 
   factory _$CoinImpl.fromJson(Map<String, dynamic> json) =>
       _$$CoinImplFromJson(json);
@@ -254,7 +255,8 @@ class _$CoinImpl implements _Coin {
   @override
   final String symbolGroup;
   @override
-  final int syncFrequency;
+  @DurationConverter()
+  final Duration syncFrequency;
 
   @override
   String toString() {
@@ -315,7 +317,7 @@ abstract class _Coin implements Coin {
       required final double priceUSD,
       required final String symbol,
       required final String symbolGroup,
-      required final int syncFrequency}) = _$CoinImpl;
+      @DurationConverter() required final Duration syncFrequency}) = _$CoinImpl;
 
   factory _Coin.fromJson(Map<String, dynamic> json) = _$CoinImpl.fromJson;
 
@@ -338,7 +340,8 @@ abstract class _Coin implements Coin {
   @override
   String get symbolGroup;
   @override
-  int get syncFrequency;
+  @DurationConverter()
+  Duration get syncFrequency;
 
   /// Create a copy of Coin
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.freezed.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.freezed.dart
@@ -1,0 +1,349 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'coin.c.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Coin _$CoinFromJson(Map<String, dynamic> json) {
+  return _Coin.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Coin {
+  String get contractAddress => throw _privateConstructorUsedError;
+  int get decimals => throw _privateConstructorUsedError;
+  String get iconURL => throw _privateConstructorUsedError;
+  String get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get network => throw _privateConstructorUsedError;
+  double get priceUSD => throw _privateConstructorUsedError;
+  String get symbol => throw _privateConstructorUsedError;
+  String get symbolGroup => throw _privateConstructorUsedError;
+  int get syncFrequency => throw _privateConstructorUsedError;
+
+  /// Serializes this Coin to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Coin
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CoinCopyWith<Coin> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CoinCopyWith<$Res> {
+  factory $CoinCopyWith(Coin value, $Res Function(Coin) then) =
+      _$CoinCopyWithImpl<$Res, Coin>;
+  @useResult
+  $Res call(
+      {String contractAddress,
+      int decimals,
+      String iconURL,
+      String id,
+      String name,
+      String network,
+      double priceUSD,
+      String symbol,
+      String symbolGroup,
+      int syncFrequency});
+}
+
+/// @nodoc
+class _$CoinCopyWithImpl<$Res, $Val extends Coin>
+    implements $CoinCopyWith<$Res> {
+  _$CoinCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Coin
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? contractAddress = null,
+    Object? decimals = null,
+    Object? iconURL = null,
+    Object? id = null,
+    Object? name = null,
+    Object? network = null,
+    Object? priceUSD = null,
+    Object? symbol = null,
+    Object? symbolGroup = null,
+    Object? syncFrequency = null,
+  }) {
+    return _then(_value.copyWith(
+      contractAddress: null == contractAddress
+          ? _value.contractAddress
+          : contractAddress // ignore: cast_nullable_to_non_nullable
+              as String,
+      decimals: null == decimals
+          ? _value.decimals
+          : decimals // ignore: cast_nullable_to_non_nullable
+              as int,
+      iconURL: null == iconURL
+          ? _value.iconURL
+          : iconURL // ignore: cast_nullable_to_non_nullable
+              as String,
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as String,
+      priceUSD: null == priceUSD
+          ? _value.priceUSD
+          : priceUSD // ignore: cast_nullable_to_non_nullable
+              as double,
+      symbol: null == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as String,
+      symbolGroup: null == symbolGroup
+          ? _value.symbolGroup
+          : symbolGroup // ignore: cast_nullable_to_non_nullable
+              as String,
+      syncFrequency: null == syncFrequency
+          ? _value.syncFrequency
+          : syncFrequency // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$CoinImplCopyWith<$Res> implements $CoinCopyWith<$Res> {
+  factory _$$CoinImplCopyWith(
+          _$CoinImpl value, $Res Function(_$CoinImpl) then) =
+      __$$CoinImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String contractAddress,
+      int decimals,
+      String iconURL,
+      String id,
+      String name,
+      String network,
+      double priceUSD,
+      String symbol,
+      String symbolGroup,
+      int syncFrequency});
+}
+
+/// @nodoc
+class __$$CoinImplCopyWithImpl<$Res>
+    extends _$CoinCopyWithImpl<$Res, _$CoinImpl>
+    implements _$$CoinImplCopyWith<$Res> {
+  __$$CoinImplCopyWithImpl(_$CoinImpl _value, $Res Function(_$CoinImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Coin
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? contractAddress = null,
+    Object? decimals = null,
+    Object? iconURL = null,
+    Object? id = null,
+    Object? name = null,
+    Object? network = null,
+    Object? priceUSD = null,
+    Object? symbol = null,
+    Object? symbolGroup = null,
+    Object? syncFrequency = null,
+  }) {
+    return _then(_$CoinImpl(
+      contractAddress: null == contractAddress
+          ? _value.contractAddress
+          : contractAddress // ignore: cast_nullable_to_non_nullable
+              as String,
+      decimals: null == decimals
+          ? _value.decimals
+          : decimals // ignore: cast_nullable_to_non_nullable
+              as int,
+      iconURL: null == iconURL
+          ? _value.iconURL
+          : iconURL // ignore: cast_nullable_to_non_nullable
+              as String,
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      network: null == network
+          ? _value.network
+          : network // ignore: cast_nullable_to_non_nullable
+              as String,
+      priceUSD: null == priceUSD
+          ? _value.priceUSD
+          : priceUSD // ignore: cast_nullable_to_non_nullable
+              as double,
+      symbol: null == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as String,
+      symbolGroup: null == symbolGroup
+          ? _value.symbolGroup
+          : symbolGroup // ignore: cast_nullable_to_non_nullable
+              as String,
+      syncFrequency: null == syncFrequency
+          ? _value.syncFrequency
+          : syncFrequency // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$CoinImpl implements _Coin {
+  _$CoinImpl(
+      {required this.contractAddress,
+      required this.decimals,
+      required this.iconURL,
+      required this.id,
+      required this.name,
+      required this.network,
+      required this.priceUSD,
+      required this.symbol,
+      required this.symbolGroup,
+      required this.syncFrequency});
+
+  factory _$CoinImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CoinImplFromJson(json);
+
+  @override
+  final String contractAddress;
+  @override
+  final int decimals;
+  @override
+  final String iconURL;
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  final String network;
+  @override
+  final double priceUSD;
+  @override
+  final String symbol;
+  @override
+  final String symbolGroup;
+  @override
+  final int syncFrequency;
+
+  @override
+  String toString() {
+    return 'Coin(contractAddress: $contractAddress, decimals: $decimals, iconURL: $iconURL, id: $id, name: $name, network: $network, priceUSD: $priceUSD, symbol: $symbol, symbolGroup: $symbolGroup, syncFrequency: $syncFrequency)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CoinImpl &&
+            (identical(other.contractAddress, contractAddress) ||
+                other.contractAddress == contractAddress) &&
+            (identical(other.decimals, decimals) ||
+                other.decimals == decimals) &&
+            (identical(other.iconURL, iconURL) || other.iconURL == iconURL) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.network, network) || other.network == network) &&
+            (identical(other.priceUSD, priceUSD) ||
+                other.priceUSD == priceUSD) &&
+            (identical(other.symbol, symbol) || other.symbol == symbol) &&
+            (identical(other.symbolGroup, symbolGroup) ||
+                other.symbolGroup == symbolGroup) &&
+            (identical(other.syncFrequency, syncFrequency) ||
+                other.syncFrequency == syncFrequency));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, contractAddress, decimals,
+      iconURL, id, name, network, priceUSD, symbol, symbolGroup, syncFrequency);
+
+  /// Create a copy of Coin
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CoinImplCopyWith<_$CoinImpl> get copyWith =>
+      __$$CoinImplCopyWithImpl<_$CoinImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$CoinImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Coin implements Coin {
+  factory _Coin(
+      {required final String contractAddress,
+      required final int decimals,
+      required final String iconURL,
+      required final String id,
+      required final String name,
+      required final String network,
+      required final double priceUSD,
+      required final String symbol,
+      required final String symbolGroup,
+      required final int syncFrequency}) = _$CoinImpl;
+
+  factory _Coin.fromJson(Map<String, dynamic> json) = _$CoinImpl.fromJson;
+
+  @override
+  String get contractAddress;
+  @override
+  int get decimals;
+  @override
+  String get iconURL;
+  @override
+  String get id;
+  @override
+  String get name;
+  @override
+  String get network;
+  @override
+  double get priceUSD;
+  @override
+  String get symbol;
+  @override
+  String get symbolGroup;
+  @override
+  int get syncFrequency;
+
+  /// Create a copy of Coin
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CoinImplCopyWith<_$CoinImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.g.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'coin.c.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$CoinImpl _$$CoinImplFromJson(Map<String, dynamic> json) => _$CoinImpl(
+      contractAddress: json['contractAddress'] as String,
+      decimals: (json['decimals'] as num).toInt(),
+      iconURL: json['iconURL'] as String,
+      id: json['id'] as String,
+      name: json['name'] as String,
+      network: json['network'] as String,
+      priceUSD: (json['priceUSD'] as num).toDouble(),
+      symbol: json['symbol'] as String,
+      symbolGroup: json['symbolGroup'] as String,
+      syncFrequency: (json['syncFrequency'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$CoinImplToJson(_$CoinImpl instance) =>
+    <String, dynamic>{
+      'contractAddress': instance.contractAddress,
+      'decimals': instance.decimals,
+      'iconURL': instance.iconURL,
+      'id': instance.id,
+      'name': instance.name,
+      'network': instance.network,
+      'priceUSD': instance.priceUSD,
+      'symbol': instance.symbol,
+      'symbolGroup': instance.symbolGroup,
+      'syncFrequency': instance.syncFrequency,
+    };

--- a/packages/ion_identity_client/lib/src/coins/models/coin.c.g.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coin.c.g.dart
@@ -16,7 +16,8 @@ _$CoinImpl _$$CoinImplFromJson(Map<String, dynamic> json) => _$CoinImpl(
       priceUSD: (json['priceUSD'] as num).toDouble(),
       symbol: json['symbol'] as String,
       symbolGroup: json['symbolGroup'] as String,
-      syncFrequency: (json['syncFrequency'] as num).toInt(),
+      syncFrequency: const DurationConverter()
+          .fromJson((json['syncFrequency'] as num).toInt()),
     );
 
 Map<String, dynamic> _$$CoinImplToJson(_$CoinImpl instance) =>
@@ -30,5 +31,5 @@ Map<String, dynamic> _$$CoinImplToJson(_$CoinImpl instance) =>
       'priceUSD': instance.priceUSD,
       'symbol': instance.symbol,
       'symbolGroup': instance.symbolGroup,
-      'syncFrequency': instance.syncFrequency,
+      'syncFrequency': const DurationConverter().toJson(instance.syncFrequency),
     };

--- a/packages/ion_identity_client/lib/src/coins/models/coins_response.c.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coins_response.c.dart
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:ion_identity_client/src/coins/models/coin.c.dart';
+
+part 'coins_response.c.freezed.dart';
+part 'coins_response.c.g.dart';
+
+@freezed
+class CoinsResponse with _$CoinsResponse {
+  const factory CoinsResponse({
+    required List<Coin> coins,
+    required int version,
+  }) = _CoinsResponse;
+
+  factory CoinsResponse.fromJson(Map<String, dynamic> json) => _$CoinsResponseFromJson(json);
+}

--- a/packages/ion_identity_client/lib/src/coins/models/coins_response.c.freezed.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coins_response.c.freezed.dart
@@ -1,0 +1,191 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'coins_response.c.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+CoinsResponse _$CoinsResponseFromJson(Map<String, dynamic> json) {
+  return _CoinsResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$CoinsResponse {
+  List<Coin> get coins => throw _privateConstructorUsedError;
+  int get version => throw _privateConstructorUsedError;
+
+  /// Serializes this CoinsResponse to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of CoinsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CoinsResponseCopyWith<CoinsResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CoinsResponseCopyWith<$Res> {
+  factory $CoinsResponseCopyWith(
+          CoinsResponse value, $Res Function(CoinsResponse) then) =
+      _$CoinsResponseCopyWithImpl<$Res, CoinsResponse>;
+  @useResult
+  $Res call({List<Coin> coins, int version});
+}
+
+/// @nodoc
+class _$CoinsResponseCopyWithImpl<$Res, $Val extends CoinsResponse>
+    implements $CoinsResponseCopyWith<$Res> {
+  _$CoinsResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CoinsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? coins = null,
+    Object? version = null,
+  }) {
+    return _then(_value.copyWith(
+      coins: null == coins
+          ? _value.coins
+          : coins // ignore: cast_nullable_to_non_nullable
+              as List<Coin>,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$CoinsResponseImplCopyWith<$Res>
+    implements $CoinsResponseCopyWith<$Res> {
+  factory _$$CoinsResponseImplCopyWith(
+          _$CoinsResponseImpl value, $Res Function(_$CoinsResponseImpl) then) =
+      __$$CoinsResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<Coin> coins, int version});
+}
+
+/// @nodoc
+class __$$CoinsResponseImplCopyWithImpl<$Res>
+    extends _$CoinsResponseCopyWithImpl<$Res, _$CoinsResponseImpl>
+    implements _$$CoinsResponseImplCopyWith<$Res> {
+  __$$CoinsResponseImplCopyWithImpl(
+      _$CoinsResponseImpl _value, $Res Function(_$CoinsResponseImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of CoinsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? coins = null,
+    Object? version = null,
+  }) {
+    return _then(_$CoinsResponseImpl(
+      coins: null == coins
+          ? _value._coins
+          : coins // ignore: cast_nullable_to_non_nullable
+              as List<Coin>,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$CoinsResponseImpl implements _CoinsResponse {
+  const _$CoinsResponseImpl(
+      {required final List<Coin> coins, required this.version})
+      : _coins = coins;
+
+  factory _$CoinsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CoinsResponseImplFromJson(json);
+
+  final List<Coin> _coins;
+  @override
+  List<Coin> get coins {
+    if (_coins is EqualUnmodifiableListView) return _coins;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_coins);
+  }
+
+  @override
+  final int version;
+
+  @override
+  String toString() {
+    return 'CoinsResponse(coins: $coins, version: $version)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CoinsResponseImpl &&
+            const DeepCollectionEquality().equals(other._coins, _coins) &&
+            (identical(other.version, version) || other.version == version));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_coins), version);
+
+  /// Create a copy of CoinsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CoinsResponseImplCopyWith<_$CoinsResponseImpl> get copyWith =>
+      __$$CoinsResponseImplCopyWithImpl<_$CoinsResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$CoinsResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _CoinsResponse implements CoinsResponse {
+  const factory _CoinsResponse(
+      {required final List<Coin> coins,
+      required final int version}) = _$CoinsResponseImpl;
+
+  factory _CoinsResponse.fromJson(Map<String, dynamic> json) =
+      _$CoinsResponseImpl.fromJson;
+
+  @override
+  List<Coin> get coins;
+  @override
+  int get version;
+
+  /// Create a copy of CoinsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CoinsResponseImplCopyWith<_$CoinsResponseImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/ion_identity_client/lib/src/coins/models/coins_response.c.g.dart
+++ b/packages/ion_identity_client/lib/src/coins/models/coins_response.c.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'coins_response.c.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$CoinsResponseImpl _$$CoinsResponseImplFromJson(Map<String, dynamic> json) =>
+    _$CoinsResponseImpl(
+      coins: (json['coins'] as List<dynamic>)
+          .map((e) => Coin.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      version: (json['version'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$CoinsResponseImplToJson(_$CoinsResponseImpl instance) =>
+    <String, dynamic>{
+      'coins': instance.coins.map((e) => e.toJson()).toList(),
+      'version': instance.version,
+    };

--- a/packages/ion_identity_client/lib/src/coins/services/data_sources/get_coins_data_source.dart
+++ b/packages/ion_identity_client/lib/src/coins/services/data_sources/get_coins_data_source.dart
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/ion_identity.dart';
+import 'package:ion_identity_client/src/coins/models/coins_response.c.dart';
+import 'package:ion_identity_client/src/core/network/network_client.dart';
+import 'package:ion_identity_client/src/core/storage/token_storage.dart';
+import 'package:ion_identity_client/src/core/types/request_headers.dart';
+
+class GetCoinsDataSource {
+  GetCoinsDataSource({
+    required TokenStorage tokenStorage,
+    required NetworkClient networkClient,
+  })  : _tokenStorage = tokenStorage,
+        _networkClient = networkClient;
+
+  final TokenStorage _tokenStorage;
+  final NetworkClient _networkClient;
+
+  Future<CoinsResponse> getCoins({
+    required String username,
+    required String userId,
+    required int currentVersion,
+  }) async {
+    final token = _tokenStorage.getToken(username: username)?.token;
+    if (token == null) {
+      throw const UnauthenticatedException();
+    }
+
+    final response = await _networkClient.get(
+      '/v1/users/$userId/coins',
+      queryParams: {
+        'version': currentVersion,
+      },
+      headers: {
+        ...RequestHeaders.getAuthorizationHeaders(
+          token: token,
+          username: username,
+        ),
+      },
+      decoder: (response) {
+        if (response.isEmpty) {
+          return const CoinsResponse(coins: [], version: 0);
+        }
+
+        return CoinsResponse.fromJson(response);
+      },
+    );
+    return response;
+  }
+}

--- a/packages/ion_identity_client/lib/src/coins/services/get_coins_service.dart
+++ b/packages/ion_identity_client/lib/src/coins/services/get_coins_service.dart
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/src/coins/models/coins_response.c.dart';
+import 'package:ion_identity_client/src/coins/services/data_sources/get_coins_data_source.dart';
+
+class GetCoinsService {
+  GetCoinsService({
+    required GetCoinsDataSource getCoinsDataSource,
+  }) : _getCoinsDataSource = getCoinsDataSource;
+
+  final GetCoinsDataSource _getCoinsDataSource;
+
+  Future<CoinsResponse> getCoins({
+    required String username,
+    required String userId,
+    required int currentVersion,
+  }) async {
+    return _getCoinsDataSource.getCoins(
+      username: username,
+      userId: userId,
+      currentVersion: currentVersion,
+    );
+  }
+}

--- a/packages/ion_identity_client/lib/src/core/service_locator/clients_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/clients_service_locator.dart
@@ -2,6 +2,7 @@
 
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:ion_identity_client/src/core/service_locator/ion_identity_clients/auth_client_service_locator.dart';
+import 'package:ion_identity_client/src/core/service_locator/ion_identity_clients/coin_client_service_locator.dart';
 import 'package:ion_identity_client/src/core/service_locator/ion_identity_clients/users_client_service_locator.dart';
 import 'package:ion_identity_client/src/core/service_locator/ion_identity_clients/wallets_client_service_locator.dart';
 import 'package:ion_identity_client/src/signer/identity_signer.dart';
@@ -36,6 +37,10 @@ class ClientsServiceLocator {
           identitySigner: identitySigner,
         ),
         users: UsersClientServiceLocator().users(
+          username: username,
+          config: config,
+        ),
+        coins: CoinsClientServiceLocator().coins(
           username: username,
           config: config,
         ),

--- a/packages/ion_identity_client/lib/src/core/service_locator/ion_identity_clients/coin_client_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/ion_identity_clients/coin_client_service_locator.dart
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion_identity_client/ion_identity.dart';
+import 'package:ion_identity_client/src/coins/ion_identity_coins.dart';
+import 'package:ion_identity_client/src/coins/services/data_sources/get_coins_data_source.dart';
+import 'package:ion_identity_client/src/coins/services/get_coins_service.dart';
+import 'package:ion_identity_client/src/core/service_locator/ion_identity_clients/auth_client_service_locator.dart';
+import 'package:ion_identity_client/src/core/service_locator/ion_identity_service_locator.dart';
+
+class CoinsClientServiceLocator {
+  factory CoinsClientServiceLocator() {
+    return _instance;
+  }
+
+  CoinsClientServiceLocator._internal();
+
+  static final CoinsClientServiceLocator _instance = CoinsClientServiceLocator._internal();
+
+  IONIdentityCoins coins({
+    required String username,
+    required IONIdentityConfig config,
+  }) {
+    return IONIdentityCoins(
+      username: username,
+      getCoinsService: getCoins(username: username, config: config),
+      extractUserIdService: AuthClientServiceLocator().extractUserId(),
+    );
+  }
+
+  GetCoinsService getCoins({
+    required String username,
+    required IONIdentityConfig config,
+  }) {
+    return GetCoinsService(
+      getCoinsDataSource: GetCoinsDataSource(
+        networkClient: IONIdentityServiceLocator.networkClient(config: config),
+        tokenStorage: IONIdentityServiceLocator.tokenStorage(),
+      ),
+    );
+  }
+}

--- a/packages/ion_identity_client/lib/src/core/service_locator/network_service_locator.dart
+++ b/packages/ion_identity_client/lib/src/core/service_locator/network_service_locator.dart
@@ -63,8 +63,10 @@ mixin _Dio {
     );
     final dio = Dio(dioOptions);
 
-    final interceptors = NetworkServiceLocator().loggerInterceptor();
-    dio.interceptors.add(interceptors);
+    final interceptors = [
+      if (config.logging) NetworkServiceLocator().loggerInterceptor(),
+    ];
+    dio.interceptors.addAll(interceptors);
 
     return dio;
   }
@@ -75,7 +77,7 @@ mixin _Interceptors {
     required IONIdentityConfig config,
   }) {
     return <Interceptor>[
-      loggerInterceptor(),
+      if (config.logging) loggerInterceptor(),
       authInterceptor(config: config),
     ];
   }

--- a/packages/ion_identity_client/lib/src/ion_identity_client.dart
+++ b/packages/ion_identity_client/lib/src/ion_identity_client.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:ion_identity_client/ion_identity.dart';
+import 'package:ion_identity_client/src/coins/ion_identity_coins.dart';
 import 'package:ion_identity_client/src/users/ion_identity_users.dart';
 import 'package:ion_identity_client/src/wallets/ion_identity_wallets.dart';
 
@@ -14,6 +15,7 @@ final class IONIdentityClient {
     required this.auth,
     required this.wallets,
     required this.users,
+    required this.coins,
   });
 
   /// Provides access to authentication-related operations for the user, such as registering
@@ -26,4 +28,7 @@ final class IONIdentityClient {
 
   /// Provides access to user-related operations for the user, such as getting user details.
   final IONIdentityUsers users;
+
+  /// Provides access to coins-related operations, such as getting coins information.
+  final IONIdentityCoins coins;
 }

--- a/packages/ion_identity_client/lib/src/ion_identity_config.dart
+++ b/packages/ion_identity_client/lib/src/ion_identity_config.dart
@@ -8,6 +8,7 @@ class IONIdentityConfig {
   IONIdentityConfig({
     required this.appId,
     required this.origin,
+    this.logging = false,
   });
 
   /// The application identifier used to uniquely identify the app within the ION Identity API.
@@ -17,6 +18,9 @@ class IONIdentityConfig {
   /// and securing API requests.
   final String origin;
 
+  /// Whether to enable logging for the ION Identity client.
+  final bool logging;
+
   @override
-  String toString() => 'IONIdentityConfig(appId: $appId, origin: $origin)';
+  String toString() => 'IONIdentityConfig(appId: $appId, origin: $origin, logging: $logging)';
 }

--- a/packages/ion_identity_client/lib/src/signer/dtos/user_registration_challenge.c.g.dart
+++ b/packages/ion_identity_client/lib/src/signer/dtos/user_registration_challenge.c.g.dart
@@ -6,7 +6,8 @@ part of 'user_registration_challenge.c.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-UserRegistrationChallenge _$UserRegistrationChallengeFromJson(Map<String, dynamic> json) =>
+UserRegistrationChallenge _$UserRegistrationChallengeFromJson(
+        Map<String, dynamic> json) =>
     UserRegistrationChallenge(
       json['temporaryAuthenticationToken'] as String?,
       RelyingParty.fromJson(json['rp'] as Map<String, dynamic>),
@@ -23,17 +24,21 @@ UserRegistrationChallenge _$UserRegistrationChallengeFromJson(Map<String, dynami
               json['authenticatorSelection'] as Map<String, dynamic>),
       json['attestation'] as String,
       (json['pubKeyCredParams'] as List<dynamic>)
-          .map((e) => PublicKeyCredentialParameters.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              PublicKeyCredentialParameters.fromJson(e as Map<String, dynamic>))
           .toList(),
       (json['excludeCredentials'] as List<dynamic>)
-          .map((e) => PublicKeyCredentialDescriptor.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              PublicKeyCredentialDescriptor.fromJson(e as Map<String, dynamic>))
           .toList(),
       (json['allowedRecoveryCredentials'] as List<dynamic>?)
-          ?.map((e) => AllowedRecoveryCredential.fromJson(e as Map<String, dynamic>))
+          ?.map((e) =>
+              AllowedRecoveryCredential.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$UserRegistrationChallengeToJson(UserRegistrationChallenge instance) =>
+Map<String, dynamic> _$UserRegistrationChallengeToJson(
+        UserRegistrationChallenge instance) =>
     <String, dynamic>{
       'temporaryAuthenticationToken': instance.temporaryAuthenticationToken,
       'rp': instance.rp.toJson(),
@@ -43,8 +48,10 @@ Map<String, dynamic> _$UserRegistrationChallengeToJson(UserRegistrationChallenge
       'challenge': instance.challenge,
       'authenticatorSelection': instance.authenticatorSelection?.toJson(),
       'attestation': instance.attestation,
-      'pubKeyCredParams': instance.pubKeyCredParams.map((e) => e.toJson()).toList(),
-      'excludeCredentials': instance.excludeCredentials.map((e) => e.toJson()).toList(),
+      'pubKeyCredParams':
+          instance.pubKeyCredParams.map((e) => e.toJson()).toList(),
+      'excludeCredentials':
+          instance.excludeCredentials.map((e) => e.toJson()).toList(),
       'allowedRecoveryCredentials':
           instance.allowedRecoveryCredentials?.map((e) => e.toJson()).toList(),
     };


### PR DESCRIPTION
## Description
- This PR adds coins sync once per 24 hours
- Coins are saved to the DB
- The synchronization happens only if a user is logged in and the app is in resumed state
- The timer starts in `CoinsSyncWrapper`, which wraps the `MateriaApp`
- The `ion_identity_client` package is also updated to provide API interaction code
- Also, this PR adds code to load the initial state of the coins from assets

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
