### PR TITLE
fix: feed post gesture detecting issue

### DIFF
--- a/lib/app/components/list_item/list_item.dart
+++ b/lib/app/components/list_item/list_item.dart
@@ -123,6 +123,8 @@ class ListItem extends StatelessWidget {
 
   static BoxConstraints get defaultConstraints => BoxConstraints(minHeight: 60.0.s);
 
+  static double get defaultAvatarSize => 30.0.s;
+
   @override
   Widget build(BuildContext context) {
     final child = Container(

--- a/lib/app/components/list_item/variants/list_item_user.dart
+++ b/lib/app/components/list_item/variants/list_item_user.dart
@@ -32,7 +32,7 @@ class _ListItemUser extends ListItem {
   }) : super(
           leading: leading ??
               Avatar(
-                size: avatarSize ?? defaultAvatarSize,
+                size: avatarSize ?? ListItem.defaultAvatarSize,
                 imageUrl: profilePicture,
                 badge: showProfilePictureIceBadge ? const _IceBadge() : null,
                 imageWidget: profilePictureWidget,
@@ -65,8 +65,6 @@ class _ListItemUser extends ListItem {
             ],
           ),
         );
-
-  static double get defaultAvatarSize => 30.0.s;
 
   static double get defaultBadgeSize => 16.0.s;
 

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -13,6 +13,7 @@ import 'package:ion/app/features/feed/views/components/user_info/user_info.dart'
 import 'package:ion/app/features/feed/views/components/user_info_menu/user_info_menu.dart';
 import 'package:ion/app/features/nostr/model/event_reference.c.dart';
 import 'package:ion/app/features/nostr/providers/nostr_entity_provider.c.dart';
+import 'package:ion/app/router/app_routes.c.dart';
 
 class Post extends ConsumerWidget {
   const Post({
@@ -82,10 +83,17 @@ class _FramedEvent extends StatelessWidget {
     return Padding(
       padding: EdgeInsets.only(top: 6.0.s),
       child: QuotedPostFrame(
-        child: Post(
-          eventReference: eventReference,
-          header: UserInfo(pubkey: eventReference.pubkey),
-          footer: const SizedBox.shrink(),
+        child: GestureDetector(
+          // Open a post by clicking on any part of the widget, including the author's avatar or name.
+          onTap: () =>
+              PostDetailsRoute(eventReference: eventReference.toString()).push<void>(context),
+          child: AbsorbPointer(
+            child: Post(
+              eventReference: eventReference,
+              header: UserInfo(pubkey: eventReference.pubkey),
+              footer: const SizedBox.shrink(),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/app/features/feed/views/components/user_info/user_info.dart
+++ b/lib/app/features/feed/views/components/user_info/user_info.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/components/avatar/avatar.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/components/skeleton/skeleton.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
@@ -23,6 +24,7 @@ class UserInfo extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userMetadata = ref.watch(userMetadataProvider(pubkey));
+    void openProfile() => ProfileRoute(pubkey: pubkey).push<void>(context);
 
     return userMetadata.maybeWhen(
       data: (userMetadataEntity) {
@@ -30,16 +32,27 @@ class UserInfo extends HookConsumerWidget {
           return const SizedBox.shrink();
         }
         return ListItem.user(
-          onTap: () => ProfileRoute(pubkey: pubkey).push<void>(context),
-          title: Text(
-            userMetadataEntity.data.displayName,
-            style: textStyle,
+          title: GestureDetector(
+            onTap: openProfile,
+            child: Text(
+              userMetadataEntity.data.displayName,
+              style: textStyle,
+            ),
           ),
-          subtitle: Text(
-            prefixUsername(username: userMetadataEntity.data.name, context: context),
-            style: textStyle,
+          subtitle: GestureDetector(
+            onTap: openProfile,
+            child: Text(
+              prefixUsername(username: userMetadataEntity.data.name, context: context),
+              style: textStyle,
+            ),
           ),
-          profilePicture: userMetadataEntity.data.picture,
+          profilePictureWidget: GestureDetector(
+            onTap: openProfile,
+            child: Avatar(
+              size: ListItem.defaultAvatarSize,
+              imageUrl: userMetadataEntity.data.picture,
+            ),
+          ),
           trailing: trailing,
         );
       },


### PR DESCRIPTION
## Issue Description
If user presses on red area, it should open profile
if user presses on any other area (in blue one for example), it  should open post page. because right now the white area on right of the profile opens the profile,  and is confusing
Pressing on the quoted post (in any position, including the author of quoted post), should open the quoted post page

![IMG_1190](https://github.com/user-attachments/assets/553a16c4-4e20-4a4d-b83e-7e6a37ce9671)

## Notes
Please, note, that `GestureDetector`s were added for each user artifact (name, username, avatar) separately in the `UserInfo` to avoid corruption of other `ListItem.user` usages, since this widget/constructor is used in many places.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
https://github.com/user-attachments/assets/f62c2ced-7019-4fc6-ab4e-1c3ae3d84344


