### PR TITLE
feat: show post text above the media in post feed

### DIFF
--- a/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
@@ -35,10 +35,16 @@ class PostBody extends HookConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (postMedia.isNotEmpty) PostMedia(media: postMedia),
         Text.rich(
           postText,
         ),
+        if (postMedia.isNotEmpty)
+          Padding(
+            padding: EdgeInsets.only(
+              top: 10.0.s,
+            ),
+            child: PostMedia(media: postMedia),
+          ),
       ],
     );
   }


### PR DESCRIPTION
## Description
Reorders post content to display text before media and adds 10dp top spacing between them.
## Additional Notes
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/55b893ee-ae02-4721-9c16-7d3864cfcfa9"> 

