### PR TITLE
fix: return null WhoCanReplyEventSetting during post/article creation if all tag values are null

### DIFF
--- a/lib/app/features/feed/data/models/entities/article_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/article_data.c.dart
@@ -120,9 +120,12 @@ class ArticleData with _$ArticleData implements EventSerializable {
     List<RelatedHashtag>? relatedHashtags,
     Set<WhoCanReplySettingsOption> whoCanReplySettings = const {},
   }) {
-    final setting = whoCanReplySettings.isNotEmpty
-        ? WhoCanReplyEventSetting(values: whoCanReplySettings)
-        : null;
+    final setting = whoCanReplySettings.isEmpty ||
+            whoCanReplySettings.every(
+              (option) => option.tagValue == null,
+            )
+        ? null
+        : WhoCanReplyEventSetting(values: whoCanReplySettings);
 
     return ArticleData(
       content: content,

--- a/lib/app/features/feed/data/models/entities/post_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/post_data.c.dart
@@ -106,9 +106,12 @@ class PostData with _$PostData, EntityMediaDataMixin implements EventSerializabl
         .map((match) => RelatedHashtag(value: match.text))
         .toList();
 
-    final setting = whoCanReplySettings.isNotEmpty
-        ? WhoCanReplyEventSetting(values: whoCanReplySettings)
-        : null;
+    final setting = whoCanReplySettings.isEmpty ||
+            whoCanReplySettings.every(
+              (option) => option.tagValue == null,
+            )
+        ? null
+        : WhoCanReplyEventSetting(values: whoCanReplySettings);
 
     return PostData(
       content: parsedContent,


### PR DESCRIPTION


## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
