### PR TITLE
fix: missing media on android story preview screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -400,7 +400,7 @@ SPEC CHECKSUMS:
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   quill_native_bridge: e5afa7d49c08cf68c52a5e23bc272eba6925c622
   SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
-  share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   sqlite3: 7559e33dae4c78538df563795af3a86fc887ee71

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
@@ -9,6 +11,7 @@ import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
 import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uri_to_file/uri_to_file.dart';
 import 'package:ve_sdk_flutter/features_config.dart';
 import 'package:ve_sdk_flutter/ve_sdk_flutter.dart';
 
@@ -43,7 +46,17 @@ class BanubaService {
 
       if (result is Map) {
         final exportedPhotoFilePath = result[argExportedPhotoFile];
-        return exportedPhotoFilePath as String? ?? filePath;
+
+        if (exportedPhotoFilePath == null) {
+          return filePath;
+        }
+
+        if (Platform.isAndroid) {
+          final file = await toFile(exportedPhotoFilePath as String);
+          return file.path;
+        }
+
+        return exportedPhotoFilePath as String;
       }
       return filePath;
     } on PlatformException catch (e) {

--- a/lib/app/services/media_service/media_service.c.dart
+++ b/lib/app/services/media_service/media_service.c.dart
@@ -137,9 +137,6 @@ class MediaService {
       imageFile.path,
       title: 'Camera_${DateTime.now().millisecondsSinceEpoch}.jpg',
     );
-
-    if (asset == null) return null;
-
     final file = await asset.file;
 
     if (file == null) return null;
@@ -161,8 +158,6 @@ class MediaService {
       videoFile,
       title: 'Camera_${DateTime.now().millisecondsSinceEpoch}',
     );
-
-    if (asset == null) return null;
 
     final file = await asset.file;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1166,10 +1166,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "65d94623e15372c5c51bebbcb820848d7bcb323836e12dfdba60b5d3a8b39e50"
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   image_picker_ios:
     dependency: transitive
     description:
@@ -1425,13 +1425,13 @@ packages:
     source: hosted
     version: "1.15.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
-      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   mocktail:
     dependency: "direct main"
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: e29619443803c40385ee509abc7937835d9b5122f899940080d28b2dceed59c1
+      sha256: dc26184676b26d722d656073ca8fe29203d7631ec613aed1a9679de3aa1f52c2
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.6.3"
   photo_manager_image_provider:
     dependency: "direct main"
     description:
@@ -1912,18 +1912,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "468c43f285207c84bcabf5737f33b914ceb8eb38398b91e5e3ad1698d1b72a52"
+      sha256: "6327c3f233729374d0abaafd61f6846115b2a481b4feddd8534211dc10659400"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.2"
+    version: "10.1.3"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "6ababf341050edff57da8b6990f11f4e99eaba837865e2e6defe16d039619db5"
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -2214,6 +2214,14 @@ packages:
     description:
       name: uri
       sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  uri_to_file:
+    dependency: "direct main"
+    description:
+      name: uri_to_file
+      sha256: cbbb38f975d22311efacc9a53cdcb806708606666d8092314b81c5cb7983b700
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   lottie: ^3.1.0
   markdown_quill: ^4.1.0
   meta: ^1.15.0
+  mime: ^2.0.0
   mocktail: ^1.0.4
   nip44:
     git:
@@ -75,7 +76,7 @@ dependencies:
   path: ^1.9.0
   path_provider: ^2.1.4
   permission_handler: ^11.3.0
-  photo_manager: ^3.3.0
+  photo_manager: ^3.6.3
   photo_manager_image_provider: ^2.1.1
   pretty_dio_logger: ^1.4.0
   qr_code_scanner:
@@ -91,6 +92,7 @@ dependencies:
   smooth_sheets: ^1.0.0-f324.0.9.4
   timeago: ^3.6.1
   timeago_flutter: ^3.6.0
+  uri_to_file: ^1.0.0
   url_launcher: ^6.0.12
   uuid: ^4.5.1
   ve_sdk_flutter: ^0.9.0


### PR DESCRIPTION
## Description
This PR fixes an issue where media (photos/videos) were not displaying correctly in the Android story preview screen. The root cause was identified as improper file path handling on Android devices and missing MIME type validation for media files. 

## Additional Notes
Related issue: https://github.com/flutter/flutter/issues/148335
- Added `mime: ^2.0.0` for proper media type detection
- Added `uri_to_file: ^1.0.0` for Android Content URI conversion
- Updated `photo_manager` to `3.6.3` 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
N/A
