### PR TITLE
fix: Enable follow button interaction in article feed view

### DIFF
--- a/lib/app/features/feed/views/pages/article_details_page/components/article_details_header.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/article_details_header.dart
@@ -2,9 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/components/button/follow_button.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/components/user/follow_user_button/follow_user_button.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.c.dart';
 import 'package:ion/app/features/feed/views/components/article/components/article_image/article_image.dart';
 import 'package:ion/app/features/feed/views/components/user_info/user_info.dart';
@@ -40,7 +40,7 @@ class ArticleDetailsHeader extends ConsumerWidget {
             SizedBox(height: 12.0.s),
             UserInfo(
               pubkey: article.masterPubkey,
-              trailing: FollowButton(onPressed: () {}, following: false),
+              trailing: FollowUserButton(pubkey: article.masterPubkey),
             ),
           ],
         ),


### PR DESCRIPTION
## Description
Fixed an issue where the "Follow" button in the article feed view was inactive and users were unable to interact with it. The button is now properly responding to click events and allows users to follow/unfollow article author as expected.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
N/A
