### PR TITLE
fix: increase main modal performance, fix janks when swipe to dismiss

### DIFF
--- a/lib/app/features/chat/views/pages/chat_main_modal/chat_main_modal_page.dart
+++ b/lib/app/features/chat/views/pages/chat_main_modal/chat_main_modal_page.dart
@@ -28,6 +28,7 @@ class ChatMainModalPage extends StatelessWidget {
           ),
           ListView.separated(
             shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
             separatorBuilder: (_, __) => const HorizontalSeparator(),
             itemCount: menuItems.length,
             itemBuilder: (BuildContext context, int index) {

--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -33,6 +33,7 @@ class FeedMainModalPage extends StatelessWidget {
           ),
           ListView.separated(
             shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
             separatorBuilder: (_, __) => const HorizontalSeparator(),
             itemCount: feedTypeValues.length,
             itemBuilder: (BuildContext context, int index) {

--- a/lib/app/router/base_route_data.dart
+++ b/lib/app/router/base_route_data.dart
@@ -20,6 +20,7 @@ abstract class BaseRouteData extends GoRouteData {
     required this.child,
     this.type = IceRouteType.single,
   });
+
   final IceRouteType type;
 
   final Widget child;
@@ -107,12 +108,17 @@ class MainModalSheetPage extends ModalSheetPage<void> {
           swipeDismissible: true,
           barrierColor: context.theme.appColors.backgroundSheet,
           key: state.pageKey,
+          swipeDismissSensitivity: const SwipeDismissSensitivity(
+            minDragDistance: 100,
+            minFlingVelocityRatio: 1.5,
+          ),
           // DraggableSheet does not work with scrollable widgets.
           // If you want to use a scrollable widget as its content,
           // use ScrollableSheet instead.
           // See example in smooth_sheets package.
           child: DraggableSheet(
             controller: DefaultSheetController.of(context),
+            physics: const ClampingSheetPhysics(),
             child: MainModalContent(
               state: state,
               child: child,

--- a/lib/app/router/components/sheet_content/main_modal_content.dart
+++ b/lib/app/router/components/sheet_content/main_modal_content.dart
@@ -19,7 +19,7 @@ class MainModalContent extends StatelessWidget {
       canPop: false,
       onPopInvokedWithResult: (didPop, result) {
         if (!didPop) {
-          final metrics = controller.value;
+          final metrics = controller.metrics;
 
           if (metrics.hasDimensions) {
             context.go(state.currentTab.baseRouteLocation);

--- a/lib/app/router/components/sheet_content/sheet_content.dart
+++ b/lib/app/router/components/sheet_content/sheet_content.dart
@@ -28,7 +28,6 @@ class SheetContent extends StatelessWidget {
       backgroundColor: Colors.transparent,
       primary: true,
       extendBody: true,
-      bottomBar: const SizedBox.shrink(),
       appBar: SheetDragHandle(topPadding: topPadding),
       body: SheetShape(
         backgroundColor: backgroundColor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2013,10 +2013,10 @@ packages:
     dependency: "direct main"
     description:
       name: smooth_sheets
-      sha256: abc620d6d7e12dab2fbff02e04810feb192ceec2a5dfd4640c3d8a2d7617f789
+      sha256: "78b8ab2439ffca44ad36ff767353887bded6f2df4dbd0a44afadb945cb9a1477"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-f324.0.9.4"
+    version: "1.0.0-f324.0.10.2"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,7 +89,7 @@ dependencies:
   share_plus: ^10.0.2
   shared_preferences: ^2.2.2
   shimmer: ^3.0.0
-  smooth_sheets: ^1.0.0-f324.0.9.4
+  smooth_sheets: ^1.0.0-f324.0.10.2
   timeago: ^3.6.1
   timeago_flutter: ^3.6.0
   uri_to_file: ^1.0.0


### PR DESCRIPTION
## Description
This PR:
- upgrades smooth_sheets library to the latest version which contains a fix for janks during modals swipe to dismiss
- improves swipe to dismiss experience by changing required swipe distance and velocity
- sets all main modals scrollviews as non scrollable to allow swipe to dismiss by swiping the content of the modal

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
