### PR TITLE
fix: preventing post details page to be popped after reply is added using bottom textfield on that page

### DIFF
--- a/lib/app/features/feed/create_post/views/components/post_submit_button/post_submit_button.dart
+++ b/lib/app/features/feed/create_post/views/components/post_submit_button/post_submit_button.dart
@@ -28,6 +28,7 @@ class PostSubmitButton extends HookConsumerWidget {
     this.parentEvent,
     this.quotedEvent,
     this.mediaFiles = const [],
+    this.onSubmitted,
   });
 
   final QuillController textEditorController;
@@ -39,6 +40,8 @@ class PostSubmitButton extends HookConsumerWidget {
   final List<MediaFile> mediaFiles;
 
   final CreatePostOption createOption;
+
+  final VoidCallback? onSubmitted;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -87,7 +90,9 @@ class PostSubmitButton extends HookConsumerWidget {
               ),
         );
 
-        if (context.mounted) {
+        if (onSubmitted != null) {
+          onSubmitted!();
+        } else if (context.mounted) {
           ref.context.pop();
         }
       },

--- a/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
+++ b/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
@@ -123,6 +123,19 @@ class ReplyInputField extends HookConsumerWidget {
                 parentEvent: eventReference,
                 mediaFiles: attachedMediaNotifier.value,
                 createOption: CreatePostOption.reply,
+                onSubmitted: () {
+                  focusNode.unfocus();
+                  attachedMediaNotifier.value = [];
+
+                  /// calling `.replaceText` instead of `.clear` due to missing `ignoreFocus` parameter.
+                  textEditorController.replaceText(
+                    0,
+                    textEditorController.plainTextEditingValue.text.length - 1,
+                    '',
+                    const TextSelection.collapsed(offset: 0),
+                    ignoreFocus: true,
+                  );
+                },
               ),
             ),
         ],


### PR DESCRIPTION
## Description
Fixes a problem where pop to feed happens after replying to a post inside post details page using text field at the bottom of the page.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
