### PR TITLE
fix: default close button

### DIFF
--- a/lib/app/features/auth/views/components/identity_key_name_input/identity_info.dart
+++ b/lib/app/features/auth/views/components/identity_key_name_input/identity_info.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/build_context.dart';
@@ -23,7 +22,7 @@ class IdentityInfo extends StatelessWidget {
         NavigationAppBar.modal(
           showBackButton: false,
           title: Text(context.i18n.common_information),
-          actions: [NavigationCloseButton(onPressed: () => context.pop())],
+          actions: const [NavigationCloseButton()],
         ),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 24.0.s),

--- a/lib/app/features/auth/views/pages/recover_user_page/recover_user_success_page.dart
+++ b/lib/app/features/auth/views/pages/recover_user_page/recover_user_success_page.dart
@@ -27,9 +27,7 @@ class RecoverUserSuccessPage extends StatelessWidget {
       body: AuthScrollContainer(
         showBackButton: false,
         actions: [
-          NavigationCloseButton(
-            onPressed: onLogin,
-          ),
+          NavigationCloseButton(onPressed: onLogin),
         ],
         title: context.i18n.two_fa_title,
         description: context.i18n.two_fa_desc,

--- a/lib/app/features/chat/recent_chats/providers/conversations_provider.c.dart
+++ b/lib/app/features/chat/recent_chats/providers/conversations_provider.c.dart
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:ion/app/features/chat/model/channel_data.c.dart';
-import 'package:ion/app/features/chat/model/chat_type.dart';
 import 'package:ion/app/features/chat/model/entities/private_direct_message_data.c.dart';
 import 'package:ion/app/features/chat/model/group.c.dart';
-import 'package:ion/app/features/chat/model/message_author.c.dart';
-import 'package:ion/app/features/chat/providers/mock.dart';
 import 'package:ion/app/services/database/conversation_db_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -44,19 +41,11 @@ class Conversations extends _$Conversations {
 
   void addChannelConversation(ChannelData channelData) {
     update((currentData) {
-      final newConversation = RecentChatDataModel(
-        MessageAuthor(
-          name: channelData.name,
-          imageUrl: 'https://x.com/ice_blockchain/photo',
-          isApproved: true,
-        ),
-        1,
-        TextRecentChatMessage(
-          'The channel has been created',
-          DateTime.now(),
-        ),
-        channelData.id,
-        type: ChatType.channel,
+      final newConversation = PrivateDirectMessageEntity(
+        id: 'id',
+        pubkey: 'pubKey',
+        createdAt: DateTime.now(),
+        data: const PrivateDirectMessageData(content: [], media: {}),
       );
       final newData = [
         newConversation,
@@ -68,19 +57,11 @@ class Conversations extends _$Conversations {
 
   void addGroupConversation(Group group) {
     update((currentData) {
-      final newConversation = RecentChatDataModel(
-        MessageAuthor(
-          name: group.name,
-          imageUrl: 'https://x.com/ice_blockchain/photo',
-          isApproved: true,
-        ),
-        1,
-        TextRecentChatMessage(
-          'The group has been created',
-          DateTime.now(),
-        ),
-        group.id,
-        type: ChatType.group,
+      final newConversation = PrivateDirectMessageEntity(
+        id: group.id,
+        pubkey: 'pubKey',
+        createdAt: DateTime.now(),
+        data: const PrivateDirectMessageData(content: [], media: {}),
       );
       final newData = [
         newConversation,

--- a/lib/app/features/chat/views/components/selectable_user_list.dart
+++ b/lib/app/features/chat/views/components/selectable_user_list.dart
@@ -63,10 +63,8 @@ class SelectableUserList extends HookConsumerWidget {
           primary: false,
           flexibleSpace: NavigationAppBar.modal(
             showBackButton: false,
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
             title: Text(title),
           ),

--- a/lib/app/features/chat/views/components/type_selection_modal.dart
+++ b/lib/app/features/chat/views/components/type_selection_modal.dart
@@ -35,10 +35,8 @@ class TypeSelectionModal<T extends SelectableType> extends HookConsumerWidget {
       children: [
         NavigationAppBar.modal(
           showBackButton: false,
-          actions: [
-            NavigationCloseButton(
-              onPressed: Navigator.of(context, rootNavigator: true).pop,
-            ),
+          actions: const [
+            NavigationCloseButton(),
           ],
           title: Text(title),
         ),

--- a/lib/app/features/chat/views/pages/chat_learn_more_modal/chat_learn_more_modal.dart
+++ b/lib/app/features/chat/views/pages/chat_learn_more_modal/chat_learn_more_modal.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
@@ -23,7 +22,7 @@ class ChatLearnMoreModal extends ConsumerWidget {
           NavigationAppBar.modal(
             showBackButton: false,
             title: Text(context.i18n.common_information),
-            actions: [NavigationCloseButton(onPressed: () => context.pop())],
+            actions: const [NavigationCloseButton()],
           ),
           ScreenSideOffset.medium(
             child: Padding(

--- a/lib/app/features/chat/views/pages/new_channel_modal/new_channel_modal.dart
+++ b/lib/app/features/chat/views/pages/new_channel_modal/new_channel_modal.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/controllers/hooks/use_text_editing_with_highlights_controller.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
@@ -49,7 +48,7 @@ class NewChannelModal extends HookConsumerWidget {
             NavigationAppBar.modal(
               showBackButton: false,
               title: Text(context.i18n.channel_create_title),
-              actions: [NavigationCloseButton(onPressed: () => context.pop())],
+              actions: const [NavigationCloseButton()],
             ),
             SizedBox(
               height: 30.0.s,

--- a/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
+++ b/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/inputs/search_input/search_input.dart';
@@ -30,7 +29,7 @@ class NewChatModal extends HookConsumerWidget {
           NavigationAppBar.modal(
             showBackButton: false,
             title: Text(context.i18n.new_chat_modal_title),
-            actions: [NavigationCloseButton(onPressed: () => context.pop())],
+            actions: const [NavigationCloseButton()],
           ),
           SizedBox(height: 9.0.s),
           Expanded(

--- a/lib/app/features/chat/views/pages/new_group_modal/pages/create_group_modal.dart
+++ b/lib/app/features/chat/views/pages/new_group_modal/pages/create_group_modal.dart
@@ -58,10 +58,8 @@ class CreateGroupModal extends HookConsumerWidget {
           NavigationAppBar.modal(
             showBackButton: false,
             title: Text(context.i18n.group_create_title),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           SizedBox(height: 27.0.s),

--- a/lib/app/features/chat/views/pages/new_group_modal/pages/group_type_selection_modal.dart
+++ b/lib/app/features/chat/views/pages/new_group_modal/pages/group_type_selection_modal.dart
@@ -30,10 +30,8 @@ class GroupTypeSelectionModal extends HookConsumerWidget {
       children: [
         NavigationAppBar.modal(
           showBackButton: false,
-          actions: [
-            NavigationCloseButton(
-              onPressed: Navigator.of(context, rootNavigator: true).pop,
-            ),
+          actions: const [
+            NavigationCloseButton(),
           ],
           title: Text(context.i18n.group_create_type_title),
         ),

--- a/lib/app/features/dapps/views/pages/dapp_details/dapp_details_modal.dart
+++ b/lib/app/features/dapps/views/pages/dapp_details/dapp_details_modal.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/read_more_text/read_more_text.dart';
@@ -48,7 +47,7 @@ class DAppDetailsModal extends HookConsumerWidget {
           NavigationAppBar.modal(
             showBackButton: false,
             title: Text(app.title),
-            actions: [NavigationCloseButton(onPressed: context.pop)],
+            actions: const [NavigationCloseButton()],
           ),
           Flexible(
             child: ScreenSideOffset.small(

--- a/lib/app/features/feed/views/pages/repost_options_modal/repost_options_modal.dart
+++ b/lib/app/features/feed/views/pages/repost_options_modal/repost_options_modal.dart
@@ -42,7 +42,7 @@ class RepostOptionsModal extends HookConsumerWidget {
             NavigationAppBar.modal(
               showBackButton: false,
               title: Text(context.i18n.feed_repost_type),
-              actions: [NavigationCloseButton(onPressed: context.pop)],
+              actions: const [NavigationCloseButton()],
             ),
             SizedBox(height: 6.0.s),
             ScreenSideOffset.small(

--- a/lib/app/features/feed/views/pages/schedule_modal/schedule_modal.dart
+++ b/lib/app/features/feed/views/pages/schedule_modal/schedule_modal.dart
@@ -29,7 +29,7 @@ class ScheduleModal extends HookWidget {
       children: [
         NavigationAppBar.modal(
           title: Text(context.i18n.schedule_modal_nav_title),
-          actions: [NavigationCloseButton(onPressed: () => context.pop())],
+          actions: const [NavigationCloseButton()],
           onBackPress: () => context.pop(),
         ),
         Padding(

--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_code_confirm_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_code_confirm_page.dart
@@ -42,10 +42,8 @@ class AuthenticatorSetupCodeConfirmPage extends HookConsumerWidget {
           SliverAppBar(
             primary: false,
             flexibleSpace: NavigationAppBar.modal(
-              actions: [
-                NavigationCloseButton(
-                  onPressed: Navigator.of(context, rootNavigator: true).pop,
-                ),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
             automaticallyImplyLeading: false,

--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_instructions_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_instructions_page.dart
@@ -56,10 +56,8 @@ class AuthenticatorSetupInstructionsPage extends HookConsumerWidget {
           SliverAppBar(
             primary: false,
             flexibleSpace: NavigationAppBar.modal(
-              actions: [
-                NavigationCloseButton(
-                  onPressed: Navigator.of(context, rootNavigator: true).pop,
-                ),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
             automaticallyImplyLeading: false,

--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_options_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_options_page.dart
@@ -31,10 +31,8 @@ class AuthenticatorSetupOptionsPage extends StatelessWidget {
           SliverAppBar(
             primary: false,
             flexibleSpace: NavigationAppBar.modal(
-              actions: [
-                NavigationCloseButton(
-                  onPressed: Navigator.of(context, rootNavigator: true).pop,
-                ),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
             automaticallyImplyLeading: false,

--- a/lib/app/features/protect_account/backup/views/components/errors/secure_account_error_alert.dart
+++ b/lib/app/features/protect_account/backup/views/components/errors/secure_account_error_alert.dart
@@ -25,10 +25,8 @@ class SecureAccountErrorAlert extends ConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(locale.protect_account_header_security),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           SizedBox(height: 16.0.s),

--- a/lib/app/features/protect_account/backup/views/pages/backup_options_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/backup_options_page.dart
@@ -27,10 +27,8 @@ class BackupOptionsPage extends ConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(locale.protect_account_header_security),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           SizedBox(height: 16.0.s),

--- a/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
+++ b/lib/app/features/protect_account/backup/views/pages/create_recover_key_page/create_recovery_key_page.dart
@@ -40,10 +40,8 @@ class _NavBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return NavigationAppBar.modal(
-      actions: [
-        NavigationCloseButton(
-          onPressed: Navigator.of(context, rootNavigator: true).pop,
-        ),
+      actions: const [
+        NavigationCloseButton(),
       ],
     );
   }

--- a/lib/app/features/protect_account/components/delete_twofa_step_scaffold.dart
+++ b/lib/app/features/protect_account/components/delete_twofa_step_scaffold.dart
@@ -34,10 +34,8 @@ class DeleteTwoFAStepScaffold extends ConsumerWidget {
           AppBar(
             primary: false,
             flexibleSpace: NavigationAppBar.modal(
-              actions: [
-                NavigationCloseButton(
-                  onPressed: Navigator.of(context, rootNavigator: true).pop,
-                ),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
             toolbarHeight: NavigationAppBar.modalHeaderHeight,

--- a/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_page.dart
+++ b/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_page.dart
@@ -33,10 +33,8 @@ class EmailSetupPage extends ConsumerWidget {
                   primary: false,
                   flexibleSpace: NavigationAppBar.modal(
                     showBackButton: step != EmailSetupSteps.success,
-                    actions: [
-                      NavigationCloseButton(
-                        onPressed: Navigator.of(context, rootNavigator: true).pop,
-                      ),
+                    actions: const [
+                      NavigationCloseButton(),
                     ],
                   ),
                   toolbarHeight: NavigationAppBar.modalHeaderHeight,

--- a/lib/app/features/protect_account/phone/views/components/countries/select_country_page.dart
+++ b/lib/app/features/protect_account/phone/views/components/countries/select_country_page.dart
@@ -25,10 +25,8 @@ class SelectCountryPage extends HookConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(context.i18n.select_countries_nav_title),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           Expanded(

--- a/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_page.dart
+++ b/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_page.dart
@@ -33,10 +33,8 @@ class PhoneSetupPage extends ConsumerWidget {
                   primary: false,
                   flexibleSpace: NavigationAppBar.modal(
                     showBackButton: step != PhoneSetupSteps.success,
-                    actions: [
-                      NavigationCloseButton(
-                        onPressed: Navigator.of(context, rootNavigator: true).pop,
-                      ),
+                    actions: const [
+                      NavigationCloseButton(),
                     ],
                   ),
                   toolbarHeight: NavigationAppBar.modalHeaderHeight,

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_modal.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_modal.dart
@@ -25,10 +25,8 @@ class SecureAccountModal extends ConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(locale.protect_account_header_security),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           SizedBox(height: 16.0.s),

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
@@ -39,10 +39,8 @@ class SecureAccountOptionsPage extends HookConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(locale.protect_account_header_security),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           SizedBox(height: 36.0.s),

--- a/lib/app/features/settings/views/privacy_settings_modal.dart
+++ b/lib/app/features/settings/views/privacy_settings_modal.dart
@@ -34,10 +34,8 @@ class PrivacySettingsModal extends HookWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(context.i18n.settings_privacy),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           ScreenSideOffset.small(

--- a/lib/app/features/settings/views/profile_settings_modal.dart
+++ b/lib/app/features/settings/views/profile_settings_modal.dart
@@ -29,10 +29,8 @@ class ProfileSettingsModal extends ConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(context.i18n.common_profile),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           ScreenSideOffset.small(

--- a/lib/app/features/settings/views/push_notifications_settings.dart
+++ b/lib/app/features/settings/views/push_notifications_settings.dart
@@ -55,10 +55,8 @@ class PushNotificationsSettings extends HookConsumerWidget {
         children: [
           NavigationAppBar.modal(
             title: Text(context.i18n.settings_push_notifications),
-            actions: [
-              NavigationCloseButton(
-                onPressed: Navigator.of(context, rootNavigator: true).pop,
-              ),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
           Expanded(

--- a/lib/app/features/user/pages/profile_page/pages/follow_list_modal/components/follow_app_bar.dart
+++ b/lib/app/features/user/pages/profile_page/pages/follow_list_modal/components/follow_app_bar.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 
@@ -15,7 +14,7 @@ class FollowAppBar extends StatelessWidget {
     return SliverAppBar(
       primary: false,
       flexibleSpace: NavigationAppBar.modal(
-        actions: [NavigationCloseButton(onPressed: context.pop)],
+        actions: const [NavigationCloseButton()],
         title: Text(title),
       ),
       automaticallyImplyLeading: false,

--- a/lib/app/features/user/pages/switch_account_modal/switch_account_modal.dart
+++ b/lib/app/features/user/pages/switch_account_modal/switch_account_modal.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/modal_action_button/modal_action_button.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
@@ -32,9 +31,7 @@ class SwitchAccountModal extends ConsumerWidget {
               NavigationAppBar.modal(
                 showBackButton: false,
                 title: Text(context.i18n.profile_switch_user_header),
-                actions: [
-                  NavigationCloseButton(onPressed: context.pop),
-                ],
+                actions: const [NavigationCloseButton()],
               ),
               ModalActionButton(
                 icon: Assets.svg.iconChannelType.icon(color: context.theme.appColors.primaryAccent),

--- a/lib/app/features/wallet/components/coins_list/coins_list_view.dart
+++ b/lib/app/features/wallet/components/coins_list/coins_list_view.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/inputs/search_input/search_input.dart';
 import 'package:ion/app/components/list_items_loading_state/list_items_loading_state.dart';
@@ -36,8 +35,8 @@ class CoinsListView extends ConsumerWidget {
           child: NavigationAppBar.screen(
             title: Text(title),
             showBackButton: showBackButton,
-            actions: [
-              NavigationCloseButton(onPressed: () => context.pop()),
+            actions: const [
+              NavigationCloseButton(),
             ],
           ),
         ),

--- a/lib/app/features/wallets/pages/manage_wallets_modal/manage_wallets_modal.dart
+++ b/lib/app/features/wallets/pages/manage_wallets_modal/manage_wallets_modal.dart
@@ -27,10 +27,8 @@ class ManageWalletsModal extends StatelessWidget {
           children: [
             NavigationAppBar.modal(
               title: Text(context.i18n.wallet_manage_wallets),
-              actions: [
-                NavigationCloseButton(
-                  onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-                ),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
             SizedBox(

--- a/lib/app/features/wallets/pages/wallets_modal/wallets_modal.dart
+++ b/lib/app/features/wallets/pages/wallets_modal/wallets_modal.dart
@@ -26,10 +26,8 @@ class WalletsModal extends StatelessWidget {
           children: [
             NavigationAppBar.modal(
               title: Text(context.i18n.wallet_wallets),
-              actions: [
-                NavigationCloseButton(
-                  onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-                ),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
             ScreenSideOffset.small(

--- a/lib/app/router/components/app_router_builder.dart
+++ b/lib/app/router/components/app_router_builder.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/components/app_update_handler/hooks/use_app_update.dart';
 import 'package:ion/app/components/global_notification_bar/global_notification_bar.dart';
 import 'package:ion/app/components/global_notification_bar/providers/global_notification_provider.c.dart';
 import 'package:ion/app/extensions/extensions.dart';
@@ -19,7 +18,7 @@ class AppRouterBuilder extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final notification = ref.watch(globalNotificationProvider);
     final isShowSafeArea = useState(false);
-    useAppUpdate(ref);
+    // useAppUpdate(ref);
 
     if (notification.isShow) {
       isShowSafeArea.value = true;

--- a/lib/app/router/components/navigation_app_bar/navigation_close_button.dart
+++ b/lib/app/router/components/navigation_app_bar/navigation_close_button.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:ion/app/constants/ui.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -17,13 +16,7 @@ class NavigationCloseButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextButton(
-      onPressed: onPressed ??
-          () {
-            /// TODO(@ion-endymion): replace it with [Navigator.of(context, rootNavigator: true).pop()]
-            /// after test this approach with other modals
-            final state = GoRouterState.of(context);
-            context.go(state.currentTab.baseRouteLocation);
-          },
+      onPressed: onPressed ?? () => Navigator.of(context, rootNavigator: true).pop(),
       child: Padding(
         padding: EdgeInsets.all(UiConstants.hitSlop),
         child: Assets.svg.iconSheetClose.icon(


### PR DESCRIPTION
## Description
Fix the bottom sheet close button

## Additional Notes
Now `NavigationCloseButton` has default `onPressed` that pops to the screen from which the bottom sheet was opened.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
