### PR TITLE
fix: add support for stories and videos bookmarks, refactor bookmarking method for better clarity

### DIFF
--- a/lib/app/features/components/entities_list/components/bookmark_button/bookmark_button.dart
+++ b/lib/app/features/components/entities_list/components/bookmark_button/bookmark_button.dart
@@ -3,26 +3,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/features/feed/data/models/bookmarks/bookmarks_set.c.dart';
 import 'package:ion/app/features/feed/providers/bookmarks_notifier.c.dart';
 import 'package:ion/app/features/nostr/model/event_reference.c.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class BookmarkButton extends ConsumerWidget {
-  const BookmarkButton.post({required this.eventReference, super.key})
-      : type = BookmarksSetType.posts;
-
-  const BookmarkButton.story({required this.eventReference, super.key})
-      : type = BookmarksSetType.stories;
-
-  const BookmarkButton.video({required this.eventReference, super.key})
-      : type = BookmarksSetType.videos;
-
-  const BookmarkButton.article({required this.eventReference, super.key})
-      : type = BookmarksSetType.articles;
+  const BookmarkButton({required this.eventReference, super.key});
 
   final EventReference? eventReference;
-  final BookmarksSetType type;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -37,7 +25,6 @@ class BookmarkButton extends ConsumerWidget {
       ),
       onPressed: () => ref.read(bookmarksNotifierProvider.notifier).toggleBookmark(
             eventReference!,
-            type: type,
           ),
     );
   }

--- a/lib/app/features/feed/data/models/entities/post_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/post_data.c.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/feed/data/models/who_can_reply_settings_option.dart';
 import 'package:ion/app/features/nostr/model/entity_expiration.c.dart';
 import 'package:ion/app/features/nostr/model/entity_media_data.dart';
@@ -167,6 +168,10 @@ class PostData with _$PostData, EntityMediaDataMixin implements EventSerializabl
     }
     return replyId ?? rootReplyId;
   }
+
+  bool get isStory => expiration != null;
+
+  bool get hasVideo => media.values.any((media) => media.mediaType == MediaType.video);
 }
 
 @freezed

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -67,7 +67,7 @@ class Article extends ConsumerWidget {
                     trailing: showActionButtons
                         ? Row(
                             children: [
-                              BookmarkButton.article(eventReference: eventReference),
+                              BookmarkButton(eventReference: eventReference),
                               UserInfoMenu(pubkey: eventReference.pubkey),
                             ],
                           )

--- a/lib/app/features/feed/views/pages/post_details_page/post_details_page.dart
+++ b/lib/app/features/feed/views/pages/post_details_page/post_details_page.dart
@@ -4,13 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/components/entities_list/components/bookmark_button/bookmark_button.dart';
 import 'package:ion/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart';
 import 'package:ion/app/features/feed/views/components/list_separator/list_separator.dart';
 import 'package:ion/app/features/feed/views/components/post/post.dart';
 import 'package:ion/app/features/feed/views/pages/post_details_page/components/reply_list/reply_list.dart';
 import 'package:ion/app/features/nostr/model/event_reference.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
-import 'package:ion/generated/assets.gen.dart';
 
 class PostDetailsPage extends StatelessWidget {
   const PostDetailsPage({
@@ -26,13 +26,7 @@ class PostDetailsPage extends StatelessWidget {
       appBar: NavigationAppBar.screen(
         title: Text(context.i18n.post_page_title),
         actions: [
-          IconButton(
-            icon: Assets.svg.iconBookmarks.icon(
-              size: NavigationAppBar.actionButtonSide,
-              color: context.theme.appColors.primaryText,
-            ),
-            onPressed: () {},
-          ),
+          BookmarkButton(eventReference: eventReference),
         ],
       ),
       body: Column(


### PR DESCRIPTION
## Description
- Adding bookmark button to post details page (was missing there)
- Add logic that distinguishes between stories/videos/regular posts to add them to correct bookmark group. 
- Merge bookmark button's constructors into one
- Refactor toggleBookmark method inside bookmark notifier for better clarity

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
