### PR TITLE
fix: getCoins exception with empty string response

### DIFF
--- a/packages/ion_identity_client/lib/src/core/network/utils.dart
+++ b/packages/ion_identity_client/lib/src/core/network/utils.dart
@@ -14,8 +14,11 @@ T parseJsonObject<T>(
   dynamic input, {
   required T Function(Map<String, dynamic>) fromJson,
 }) {
+  const emptyResponse = <String, dynamic>{};
+
   return switch (input) {
-    null => fromJson({}),
+    null => fromJson(emptyResponse),
+    final String stringInput when stringInput.isEmpty => fromJson(emptyResponse),
     Map<String, dynamic>() => fromJson(input),
     _ => throw FormatException(
         'Expected a Map<String, dynamic>, but got: ${input.runtimeType}',


### PR DESCRIPTION
## Description
Add an empty string handing to the `parseJsonObject` method.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
