### PR TITLE
fix: add multiselection for the account notifications

### DIFF
--- a/lib/app/features/user/model/user_notifications_type.dart
+++ b/lib/app/features/user/model/user_notifications_type.dart
@@ -35,4 +35,28 @@ enum UserNotificationsType {
         return context.i18n.profile_articles;
     }
   }
+
+  static Set<UserNotificationsType> toggleNotificationType(
+    Set<UserNotificationsType> currentSet,
+    UserNotificationsType option,
+  ) {
+    final newSet = {...currentSet};
+    if (option == UserNotificationsType.none) {
+      newSet
+        ..clear()
+        ..add(UserNotificationsType.none);
+    } else {
+      if (newSet.contains(UserNotificationsType.none)) {
+        newSet.remove(UserNotificationsType.none);
+      }
+
+      if (!newSet.add(option)) {
+        newSet.remove(option);
+        if (newSet.isEmpty) {
+          newSet.add(UserNotificationsType.none);
+        }
+      }
+    }
+    return newSet;
+  }
 }

--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/components/user/follow_user_button/follow_user_button.dart';
 import 'package:ion/app/features/user/model/user_notifications_type.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_action.dart';
 import 'package:ion/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart';
+import 'package:ion/app/features/user/pages/profile_page/providers/user_notifications_provider.c.dart';
 import 'package:ion/app/features/user/providers/follow_list_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
@@ -23,9 +23,8 @@ class ProfileActions extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userNotificationsTypes =
-        useState<List<UserNotificationsType>>([UserNotificationsType.none]);
-    final notificationsEnabled = !userNotificationsTypes.value.contains(UserNotificationsType.none);
+    final userNotificationsTypes = ref.watch(userNotificationsNotifierProvider);
+    final notificationsEnabled = !userNotificationsTypes.contains(UserNotificationsType.none);
     final isCurrentUserFollowed = ref.watch(isCurrentUserFollowedProvider(pubkey));
 
     return Row(
@@ -49,17 +48,13 @@ class ProfileActions extends HookConsumerWidget {
         ),
         SizedBox(width: 8.0.s),
         ProfileAction(
-          onPressed: () async {
-            final newUserNotificationsTypes =
-                await showSimpleBottomSheet<List<UserNotificationsType>>(
+          onPressed: () {
+            showSimpleBottomSheet<void>(
               context: context,
               child: AccountNotificationsModal(
-                selectedUserNotificationsTypes: userNotificationsTypes.value,
+                selectedUserNotificationsTypes: userNotificationsTypes,
               ),
             );
-            if (newUserNotificationsTypes != null) {
-              userNotificationsTypes.value = newUserNotificationsTypes;
-            }
           },
           isAccent: notificationsEnabled,
           assetName: notificationsEnabled

--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -23,8 +23,9 @@ class ProfileActions extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userNotificationsType = useState(UserNotificationsType.none);
-    final notificationsEnabled = userNotificationsType.value != UserNotificationsType.none;
+    final userNotificationsTypes =
+        useState<List<UserNotificationsType>>([UserNotificationsType.none]);
+    final notificationsEnabled = !userNotificationsTypes.value.contains(UserNotificationsType.none);
     final isCurrentUserFollowed = ref.watch(isCurrentUserFollowedProvider(pubkey));
 
     return Row(
@@ -49,14 +50,15 @@ class ProfileActions extends HookConsumerWidget {
         SizedBox(width: 8.0.s),
         ProfileAction(
           onPressed: () async {
-            final newUserNotificationsType = await showSimpleBottomSheet<UserNotificationsType>(
+            final newUserNotificationsTypes =
+                await showSimpleBottomSheet<List<UserNotificationsType>>(
               context: context,
               child: AccountNotificationsModal(
-                selectedUserNotificationsType: userNotificationsType.value,
+                selectedUserNotificationsTypes: userNotificationsTypes.value,
               ),
             );
-            if (newUserNotificationsType != null) {
-              userNotificationsType.value = newUserNotificationsType;
+            if (newUserNotificationsTypes != null) {
+              userNotificationsTypes.value = newUserNotificationsTypes;
             }
           },
           isAccent: notificationsEnabled,

--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -13,7 +13,7 @@ import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-class ProfileActions extends HookConsumerWidget {
+class ProfileActions extends ConsumerWidget {
   const ProfileActions({
     required this.pubkey,
     super.key,

--- a/lib/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/user/model/user_notifications_type.dart';
+import 'package:ion/app/features/user/pages/profile_page/providers/user_notifications_provider.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -27,30 +28,37 @@ class AccountNotificationsModal extends HookConsumerWidget {
       selectedUserNotificationsTypes.toSet(),
     );
 
-    void handleOptionSelection(UserNotificationsType option) {
-      final newSelected = {...selectedOptions.value};
+    final handleOptionSelection = useCallback(
+      (UserNotificationsType option) {
+        final newSelected = {...selectedOptions.value};
 
-      if (option == UserNotificationsType.none) {
-        newSelected
-          ..clear()
-          ..add(UserNotificationsType.none);
-      } else {
-        if (newSelected.contains(UserNotificationsType.none)) {
-          newSelected.remove(UserNotificationsType.none);
-        }
-
-        if (newSelected.contains(option)) {
-          newSelected.remove(option);
-          if (newSelected.isEmpty) {
-            newSelected.add(UserNotificationsType.none);
-          }
+        if (option == UserNotificationsType.none) {
+          newSelected
+            ..clear()
+            ..add(UserNotificationsType.none);
         } else {
-          newSelected.add(option);
-        }
-      }
+          if (newSelected.contains(UserNotificationsType.none)) {
+            newSelected.remove(UserNotificationsType.none);
+          }
 
-      selectedOptions.value = newSelected;
-    }
+          if (newSelected.contains(option)) {
+            newSelected.remove(option);
+            if (newSelected.isEmpty) {
+              newSelected.add(UserNotificationsType.none);
+            }
+          } else {
+            newSelected.add(option);
+          }
+        }
+
+        selectedOptions.value = newSelected;
+
+        ref
+            .read(userNotificationsNotifierProvider.notifier)
+            .updateNotifications(newSelected.toList());
+      },
+      [selectedOptions, ref],
+    );
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart
@@ -30,32 +30,14 @@ class AccountNotificationsModal extends HookConsumerWidget {
 
     final handleOptionSelection = useCallback(
       (UserNotificationsType option) {
-        final newSelected = {...selectedOptions.value};
-
-        if (option == UserNotificationsType.none) {
-          newSelected
-            ..clear()
-            ..add(UserNotificationsType.none);
-        } else {
-          if (newSelected.contains(UserNotificationsType.none)) {
-            newSelected.remove(UserNotificationsType.none);
-          }
-
-          if (newSelected.contains(option)) {
-            newSelected.remove(option);
-            if (newSelected.isEmpty) {
-              newSelected.add(UserNotificationsType.none);
-            }
-          } else {
-            newSelected.add(option);
-          }
-        }
-
-        selectedOptions.value = newSelected;
+        selectedOptions.value = UserNotificationsType.toggleNotificationType(
+          selectedOptions.value,
+          option,
+        );
 
         ref
             .read(userNotificationsNotifierProvider.notifier)
-            .updateNotifications(newSelected.toList());
+            .updateNotifications(selectedOptions.value.toList());
       },
       [selectedOptions, ref],
     );

--- a/lib/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/account_notifications_modal/account_notifications_modal.dart
@@ -13,21 +13,44 @@ import 'package:ion/generated/assets.gen.dart';
 
 class AccountNotificationsModal extends HookConsumerWidget {
   const AccountNotificationsModal({
-    required this.selectedUserNotificationsType,
+    required this.selectedUserNotificationsTypes,
     super.key,
   });
 
-  final UserNotificationsType selectedUserNotificationsType;
+  final List<UserNotificationsType> selectedUserNotificationsTypes;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.theme.appColors;
     final textStyles = context.theme.appTextThemes;
-    final selectedOption = useState(selectedUserNotificationsType);
-
-    final iconBorderSize = Border.fromBorderSide(
-      BorderSide(color: colors.onTerararyFill, width: 1.0.s),
+    final selectedOptions = useState<Set<UserNotificationsType>>(
+      selectedUserNotificationsTypes.toSet(),
     );
+
+    void handleOptionSelection(UserNotificationsType option) {
+      final newSelected = {...selectedOptions.value};
+
+      if (option == UserNotificationsType.none) {
+        newSelected
+          ..clear()
+          ..add(UserNotificationsType.none);
+      } else {
+        if (newSelected.contains(UserNotificationsType.none)) {
+          newSelected.remove(UserNotificationsType.none);
+        }
+
+        if (newSelected.contains(option)) {
+          newSelected.remove(option);
+          if (newSelected.isEmpty) {
+            newSelected.add(UserNotificationsType.none);
+          }
+        } else {
+          newSelected.add(option);
+        }
+      }
+
+      selectedOptions.value = newSelected;
+    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -41,10 +64,7 @@ class AccountNotificationsModal extends HookConsumerWidget {
           Column(
             children: [
               MenuItemButton(
-                onPressed: () {
-                  selectedOption.value = option;
-                  Navigator.of(context).pop(selectedOption.value);
-                },
+                onPressed: () => handleOptionSelection(option),
                 leadingIcon: ButtonIconFrame(
                   containerSize: 36.0.s,
                   borderRadius: BorderRadius.circular(10.0.s),
@@ -53,9 +73,11 @@ class AccountNotificationsModal extends HookConsumerWidget {
                     size: 24.0.s,
                     color: colors.primaryAccent,
                   ),
-                  border: iconBorderSize,
+                  border: Border.fromBorderSide(
+                    BorderSide(color: colors.onTerararyFill, width: 1.0.s),
+                  ),
                 ),
-                trailingIcon: selectedOption.value == option
+                trailingIcon: selectedOptions.value.contains(option)
                     ? Assets.svg.iconBlockCheckboxOnblue.icon(
                         color: colors.success,
                       )

--- a/lib/app/features/user/pages/profile_page/providers/user_notifications_provider.c.dart
+++ b/lib/app/features/user/pages/profile_page/providers/user_notifications_provider.c.dart
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
+import 'package:ion/app/features/user/model/user_notifications_type.dart';
+import 'package:ion/app/services/storage/user_preferences_service.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_notifications_provider.c.g.dart';
+
+@Riverpod(keepAlive: true)
+class UserNotificationsNotifier extends _$UserNotificationsNotifier {
+  static const userNotificationsKey = 'UserPreferences:notifications';
+
+  @override
+  List<UserNotificationsType> build() {
+    final currentIdentityKeyName = ref.watch(currentIdentityKeyNameSelectorProvider) ?? '';
+    final userPreferencesService =
+        ref.watch(userPreferencesServiceProvider(identityKeyName: currentIdentityKeyName));
+
+    final savedTypes =
+        userPreferencesService.getValue<List<String>>(userNotificationsKey) ?? ['none'];
+
+    return savedTypes
+        .map(
+          (type) => UserNotificationsType.values.firstWhere(
+            (t) => t.name == type,
+            orElse: () => UserNotificationsType.none,
+          ),
+        )
+        .toList();
+  }
+
+  void updateNotifications(List<UserNotificationsType> types) {
+    final currentIdentityKeyName = ref.read(currentIdentityKeyNameSelectorProvider) ?? '';
+    final userPreferencesService =
+        ref.read(userPreferencesServiceProvider(identityKeyName: currentIdentityKeyName));
+
+    state = types;
+
+    userPreferencesService.setValue(
+      userNotificationsKey,
+      types.map((type) => type.name).toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

Choosing `none` should unmark the rest of the options.
`None` can’t be chosen with any other option together.
`None` should be chosen by default for all other users.


https://github.com/user-attachments/assets/efbbb87b-e6a7-49ca-98c7-08ba34abec01



## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
