### PR TITLE
fix: remove listener for scroll metrics causing too many loadMores

### DIFF
--- a/lib/app/components/scroll_view/load_more_builder.dart
+++ b/lib/app/components/scroll_view/load_more_builder.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ion/app/extensions/extensions.dart';
 
 class LoadMoreBuilder extends HookWidget {
   const LoadMoreBuilder({
@@ -27,27 +28,21 @@ class LoadMoreBuilder extends HookWidget {
   Widget build(BuildContext context) {
     final loading = useState(false);
 
-    // A ScrollMetricsNotification allows listeners to be notified for an
-    // initial state, as well as if the content dimensions change without
-    // scrolling.
-    return NotificationListener<ScrollMetricsNotification>(
-      onNotification: (notification) => _onMetricsChanged(notification.asScrollUpdate(), loading),
-      child: NotificationListener<ScrollNotification>(
-        onNotification: (notification) => _onMetricsChanged(notification, loading),
-        child: builder(
-          context,
-          loading.value
-              ? [
-                  ...slivers,
-                  const SliverToBoxAdapter(
-                    child: Padding(
-                      padding: EdgeInsets.only(top: 8),
-                      child: Center(child: CircularProgressIndicator.adaptive()),
-                    ),
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) => _onMetricsChanged(notification, loading),
+      child: builder(
+        context,
+        loading.value
+            ? [
+                ...slivers,
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 8.0.s),
+                    child: const Center(child: CircularProgressIndicator.adaptive()),
                   ),
-                ]
-              : slivers,
-        ),
+                ),
+              ]
+            : slivers,
       ),
     );
   }

--- a/lib/app/features/auth/views/pages/discover_creators/discover_creators.dart
+++ b/lib/app/features/auth/views/pages/discover_creators/discover_creators.dart
@@ -83,7 +83,7 @@ class DiscoverCreators extends HookConsumerWidget {
             child: LoadMoreBuilder(
               slivers: slivers,
               onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-              hasMore: entitiesPagedData?.hasMore ?? true,
+              hasMore: entitiesPagedData?.hasMore ?? false,
               builder: (context, slivers) {
                 return AuthScrollContainer(
                   title: context.i18n.discover_creators_title,

--- a/lib/app/features/user/pages/profile_page/components/tabs/tab_entities_list.dart
+++ b/lib/app/features/user/pages/profile_page/components/tabs/tab_entities_list.dart
@@ -63,7 +63,7 @@ class TabEntitiesList extends ConsumerWidget {
           builder != null ? builder!(entities.toList()) : EntitiesList(entities: entities.toList()),
       ],
       onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-      hasMore: entitiesPagedData?.hasMore ?? true,
+      hasMore: entitiesPagedData?.hasMore ?? false,
       builder: (context, slivers) => CustomScrollView(slivers: slivers),
     );
   }

--- a/lib/app/features/user/pages/user_picker_sheet/components/follower_users.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/follower_users.dart
@@ -54,7 +54,7 @@ class FollowerUsers extends ConsumerWidget {
         slivers: slivers,
       ),
       onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-      hasMore: entitiesPagedData?.hasMore ?? true,
+      hasMore: entitiesPagedData?.hasMore ?? false,
     );
   }
 }

--- a/lib/app/features/user/pages/user_picker_sheet/components/searched_users.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/searched_users.dart
@@ -52,7 +52,7 @@ class SearchedUsers extends ConsumerWidget {
         slivers: slivers,
       ),
       onLoadMore: ref.read(entitiesPagedDataProvider(dataSource).notifier).fetchEntities,
-      hasMore: entitiesPagedData?.hasMore ?? true,
+      hasMore: entitiesPagedData?.hasMore ?? false,
     );
   }
 }


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
