### PR TITLE
fix: close modal stack after successful video post creation

### DIFF
--- a/lib/app/features/feed/create_post/views/components/post_submit_button/post_submit_button.dart
+++ b/lib/app/features/feed/create_post/views/components/post_submit_button/post_submit_button.dart
@@ -93,7 +93,7 @@ class PostSubmitButton extends HookConsumerWidget {
         if (onSubmitted != null) {
           onSubmitted!();
         } else if (context.mounted) {
-          ref.context.pop();
+          ref.context.pop(true);
         }
       },
     );

--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -76,8 +76,12 @@ class FeedMainModalPage extends StatelessWidget {
 
                         final shouldShowPicker = !postWasCreated;
 
-                        if (shouldShowPicker && context.mounted) {
+                        if (!context.mounted) return;
+
+                        if (shouldShowPicker) {
                           await showMediaPickerAndCreatePost();
+                        } else {
+                          context.go(GoRouterState.of(context).currentTab.baseRouteLocation);
                         }
                       }
                     }


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
automatically closing the modal sheets after successful video post-creation 

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
