### PR TITLE
feat: add blocked entities hiding on all levels

### DIFF
--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -38,6 +38,7 @@ class EntitiesList extends StatelessWidget {
           entity: entities[index],
           showParent: showParent,
           separatorHeight: separatorHeight,
+          hideBlocked: hideBlocked,
         );
       },
     );
@@ -49,11 +50,13 @@ class _EntityListItem extends ConsumerWidget {
     required this.entity,
     required this.separatorHeight,
     required this.showParent,
+    required this.hideBlocked,
   });
 
   final IonConnectEntity entity;
   final double? separatorHeight;
   final bool showParent;
+  final bool hideBlocked;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -61,10 +64,9 @@ class _EntityListItem extends ConsumerWidget {
         ref.watch(userMetadataProvider(entity.masterPubkey, cacheOnly: true)).valueOrNull;
 
     final isBlockedOrBlocking =
-        ref.watch(isBlockedOrBlockingProvider(entity.masterPubkey, cacheOnly: true)).valueOrNull ??
-            true;
+        ref.watch(isEntityBlockedOrBlockingProvider(entity, cacheOnly: true)).valueOrNull ?? true;
 
-    if (userMetadata == null || isBlockedOrBlocking) {
+    if (userMetadata == null || (isBlockedOrBlocking && hideBlocked)) {
       /// When we fetch lists (e.g. feed, search or data for tabs in profiles),
       /// we don't need to fetch the user metadata or block list explicitly - it is returned as a side effect to the
       /// main request.


### PR DESCRIPTION
## Description
This PR introduces a logic to: 
1. hide any entities (posts/articles/reposts) that are created by users we block 
2. hide any entities (posts/reposts) that quote/repost other entities created by users we block

Example:
User A creates a post, user B creates the post by quoting a post from user A. Now if we block user A, we should also not see post from user B, because it contains a post from blocked user A. Any Other posts user B creates that don't contain any content from blocked user A should be still visible.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
