### PR TITLE
fix: rename Contacts section title to Friends

### DIFF
--- a/lib/app/features/wallet/views/pages/wallet_page/components/contacts/contacts_list_header.dart
+++ b/lib/app/features/wallet/views/pages/wallet_page/components/contacts/contacts_list_header.dart
@@ -26,7 +26,7 @@ class ContactListHeader extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
-            context.i18n.contacts_title,
+            context.i18n.friends_title,
             style: context.theme.appTextThemes.caption.copyWith(
               color: context.theme.appColors.primaryText,
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -370,7 +370,7 @@
   "sorting_price_asc": "Price: low to high",
   "sorting_price_desc": "Price: high to low",
   "wallet_sorting_title": "Sorting the list",
-  "contacts_title": "Contacts",
+  "friends_title": "Friends",
   "friends_modal_title": "Select friend",
   "contacts_select_title": "Select contact",
   "contacts_allow_pop_up_title": "Ice is better with friends",


### PR DESCRIPTION
## Description
A simple change of a string resource on Wallets page

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a3726be8-5b61-4189-9755-7a9600642b65">
