### PR TITLE
fix: nullable symbolGroup handling

### DIFF
--- a/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/short_wallet_view.c.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/short_wallet_view.c.dart
@@ -11,11 +11,12 @@ class ShortWalletView with _$ShortWalletView {
   const factory ShortWalletView({
     required String name,
     required List<WalletViewCoinData> coins,
-    required List<String> symbolGroups,
     required String createdAt,
     required String updatedAt,
     required String userId,
     required String id,
+    @JsonKey(defaultValue: [])
+    required List<String> symbolGroups,
   }) = _ShortWalletView;
 
   factory ShortWalletView.fromJson(Map<String, dynamic> json) => _$ShortWalletViewFromJson(json);

--- a/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/short_wallet_view.c.freezed.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/short_wallet_view.c.freezed.dart
@@ -22,11 +22,12 @@ ShortWalletView _$ShortWalletViewFromJson(Map<String, dynamic> json) {
 mixin _$ShortWalletView {
   String get name => throw _privateConstructorUsedError;
   List<WalletViewCoinData> get coins => throw _privateConstructorUsedError;
-  List<String> get symbolGroups => throw _privateConstructorUsedError;
   String get createdAt => throw _privateConstructorUsedError;
   String get updatedAt => throw _privateConstructorUsedError;
   String get userId => throw _privateConstructorUsedError;
   String get id => throw _privateConstructorUsedError;
+  @JsonKey(defaultValue: [])
+  List<String> get symbolGroups => throw _privateConstructorUsedError;
 
   /// Serializes this ShortWalletView to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -47,11 +48,11 @@ abstract class $ShortWalletViewCopyWith<$Res> {
   $Res call(
       {String name,
       List<WalletViewCoinData> coins,
-      List<String> symbolGroups,
       String createdAt,
       String updatedAt,
       String userId,
-      String id});
+      String id,
+      @JsonKey(defaultValue: []) List<String> symbolGroups});
 }
 
 /// @nodoc
@@ -71,11 +72,11 @@ class _$ShortWalletViewCopyWithImpl<$Res, $Val extends ShortWalletView>
   $Res call({
     Object? name = null,
     Object? coins = null,
-    Object? symbolGroups = null,
     Object? createdAt = null,
     Object? updatedAt = null,
     Object? userId = null,
     Object? id = null,
+    Object? symbolGroups = null,
   }) {
     return _then(_value.copyWith(
       name: null == name
@@ -86,10 +87,6 @@ class _$ShortWalletViewCopyWithImpl<$Res, $Val extends ShortWalletView>
           ? _value.coins
           : coins // ignore: cast_nullable_to_non_nullable
               as List<WalletViewCoinData>,
-      symbolGroups: null == symbolGroups
-          ? _value.symbolGroups
-          : symbolGroups // ignore: cast_nullable_to_non_nullable
-              as List<String>,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -106,6 +103,10 @@ class _$ShortWalletViewCopyWithImpl<$Res, $Val extends ShortWalletView>
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
+      symbolGroups: null == symbolGroups
+          ? _value.symbolGroups
+          : symbolGroups // ignore: cast_nullable_to_non_nullable
+              as List<String>,
     ) as $Val);
   }
 }
@@ -121,11 +122,11 @@ abstract class _$$ShortWalletViewImplCopyWith<$Res>
   $Res call(
       {String name,
       List<WalletViewCoinData> coins,
-      List<String> symbolGroups,
       String createdAt,
       String updatedAt,
       String userId,
-      String id});
+      String id,
+      @JsonKey(defaultValue: []) List<String> symbolGroups});
 }
 
 /// @nodoc
@@ -143,11 +144,11 @@ class __$$ShortWalletViewImplCopyWithImpl<$Res>
   $Res call({
     Object? name = null,
     Object? coins = null,
-    Object? symbolGroups = null,
     Object? createdAt = null,
     Object? updatedAt = null,
     Object? userId = null,
     Object? id = null,
+    Object? symbolGroups = null,
   }) {
     return _then(_$ShortWalletViewImpl(
       name: null == name
@@ -158,10 +159,6 @@ class __$$ShortWalletViewImplCopyWithImpl<$Res>
           ? _value._coins
           : coins // ignore: cast_nullable_to_non_nullable
               as List<WalletViewCoinData>,
-      symbolGroups: null == symbolGroups
-          ? _value._symbolGroups
-          : symbolGroups // ignore: cast_nullable_to_non_nullable
-              as List<String>,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -178,6 +175,10 @@ class __$$ShortWalletViewImplCopyWithImpl<$Res>
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
+      symbolGroups: null == symbolGroups
+          ? _value._symbolGroups
+          : symbolGroups // ignore: cast_nullable_to_non_nullable
+              as List<String>,
     ));
   }
 }
@@ -188,11 +189,11 @@ class _$ShortWalletViewImpl implements _ShortWalletView {
   const _$ShortWalletViewImpl(
       {required this.name,
       required final List<WalletViewCoinData> coins,
-      required final List<String> symbolGroups,
       required this.createdAt,
       required this.updatedAt,
       required this.userId,
-      required this.id})
+      required this.id,
+      @JsonKey(defaultValue: []) required final List<String> symbolGroups})
       : _coins = coins,
         _symbolGroups = symbolGroups;
 
@@ -209,14 +210,6 @@ class _$ShortWalletViewImpl implements _ShortWalletView {
     return EqualUnmodifiableListView(_coins);
   }
 
-  final List<String> _symbolGroups;
-  @override
-  List<String> get symbolGroups {
-    if (_symbolGroups is EqualUnmodifiableListView) return _symbolGroups;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_symbolGroups);
-  }
-
   @override
   final String createdAt;
   @override
@@ -225,10 +218,18 @@ class _$ShortWalletViewImpl implements _ShortWalletView {
   final String userId;
   @override
   final String id;
+  final List<String> _symbolGroups;
+  @override
+  @JsonKey(defaultValue: [])
+  List<String> get symbolGroups {
+    if (_symbolGroups is EqualUnmodifiableListView) return _symbolGroups;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_symbolGroups);
+  }
 
   @override
   String toString() {
-    return 'ShortWalletView(name: $name, coins: $coins, symbolGroups: $symbolGroups, createdAt: $createdAt, updatedAt: $updatedAt, userId: $userId, id: $id)';
+    return 'ShortWalletView(name: $name, coins: $coins, createdAt: $createdAt, updatedAt: $updatedAt, userId: $userId, id: $id, symbolGroups: $symbolGroups)';
   }
 
   @override
@@ -238,14 +239,14 @@ class _$ShortWalletViewImpl implements _ShortWalletView {
             other is _$ShortWalletViewImpl &&
             (identical(other.name, name) || other.name == name) &&
             const DeepCollectionEquality().equals(other._coins, _coins) &&
-            const DeepCollectionEquality()
-                .equals(other._symbolGroups, _symbolGroups) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
                 other.updatedAt == updatedAt) &&
             (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.id, id) || other.id == id));
+            (identical(other.id, id) || other.id == id) &&
+            const DeepCollectionEquality()
+                .equals(other._symbolGroups, _symbolGroups));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -254,11 +255,11 @@ class _$ShortWalletViewImpl implements _ShortWalletView {
       runtimeType,
       name,
       const DeepCollectionEquality().hash(_coins),
-      const DeepCollectionEquality().hash(_symbolGroups),
       createdAt,
       updatedAt,
       userId,
-      id);
+      id,
+      const DeepCollectionEquality().hash(_symbolGroups));
 
   /// Create a copy of ShortWalletView
   /// with the given fields replaced by the non-null parameter values.
@@ -281,11 +282,12 @@ abstract class _ShortWalletView implements ShortWalletView {
   const factory _ShortWalletView(
       {required final String name,
       required final List<WalletViewCoinData> coins,
-      required final List<String> symbolGroups,
       required final String createdAt,
       required final String updatedAt,
       required final String userId,
-      required final String id}) = _$ShortWalletViewImpl;
+      required final String id,
+      @JsonKey(defaultValue: [])
+      required final List<String> symbolGroups}) = _$ShortWalletViewImpl;
 
   factory _ShortWalletView.fromJson(Map<String, dynamic> json) =
       _$ShortWalletViewImpl.fromJson;
@@ -295,8 +297,6 @@ abstract class _ShortWalletView implements ShortWalletView {
   @override
   List<WalletViewCoinData> get coins;
   @override
-  List<String> get symbolGroups;
-  @override
   String get createdAt;
   @override
   String get updatedAt;
@@ -304,6 +304,9 @@ abstract class _ShortWalletView implements ShortWalletView {
   String get userId;
   @override
   String get id;
+  @override
+  @JsonKey(defaultValue: [])
+  List<String> get symbolGroups;
 
   /// Create a copy of ShortWalletView
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/short_wallet_view.c.g.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/short_wallet_view.c.g.dart
@@ -13,13 +13,14 @@ _$ShortWalletViewImpl _$$ShortWalletViewImplFromJson(
       coins: (json['coins'] as List<dynamic>)
           .map((e) => WalletViewCoinData.fromJson(e as Map<String, dynamic>))
           .toList(),
-      symbolGroups: (json['symbolGroups'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
       createdAt: json['createdAt'] as String,
       updatedAt: json['updatedAt'] as String,
       userId: json['userId'] as String,
       id: json['id'] as String,
+      symbolGroups: (json['symbolGroups'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
     );
 
 Map<String, dynamic> _$$ShortWalletViewImplToJson(
@@ -27,9 +28,9 @@ Map<String, dynamic> _$$ShortWalletViewImplToJson(
     <String, dynamic>{
       'name': instance.name,
       'coins': instance.coins.map((e) => e.toJson()).toList(),
-      'symbolGroups': instance.symbolGroups,
       'createdAt': instance.createdAt,
       'updatedAt': instance.updatedAt,
       'userId': instance.userId,
       'id': instance.id,
+      'symbolGroups': instance.symbolGroups,
     };

--- a/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/wallet_view.c.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/wallet_view.c.dart
@@ -17,6 +17,7 @@ class WalletView with _$WalletView {
     required List<CoinInWallet> coins,
     @JsonKey(defaultValue: {})
     required Map<String, WalletViewAggregationItem> aggregation,
+    @JsonKey(defaultValue: [])
     required List<String> symbolGroups,
     required String createdAt,
     required String updatedAt,

--- a/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/wallet_view.c.freezed.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/wallet_view.c.freezed.dart
@@ -27,6 +27,7 @@ mixin _$WalletView {
   @JsonKey(defaultValue: {})
   Map<String, WalletViewAggregationItem> get aggregation =>
       throw _privateConstructorUsedError;
+  @JsonKey(defaultValue: [])
   List<String> get symbolGroups => throw _privateConstructorUsedError;
   String get createdAt => throw _privateConstructorUsedError;
   String get updatedAt => throw _privateConstructorUsedError;
@@ -54,7 +55,7 @@ abstract class $WalletViewCopyWith<$Res> {
       @CoinInWalletListConverter() List<CoinInWallet> coins,
       @JsonKey(defaultValue: {})
       Map<String, WalletViewAggregationItem> aggregation,
-      List<String> symbolGroups,
+      @JsonKey(defaultValue: []) List<String> symbolGroups,
       String createdAt,
       String updatedAt,
       String userId});
@@ -135,7 +136,7 @@ abstract class _$$WalletViewImplCopyWith<$Res>
       @CoinInWalletListConverter() List<CoinInWallet> coins,
       @JsonKey(defaultValue: {})
       Map<String, WalletViewAggregationItem> aggregation,
-      List<String> symbolGroups,
+      @JsonKey(defaultValue: []) List<String> symbolGroups,
       String createdAt,
       String updatedAt,
       String userId});
@@ -209,7 +210,7 @@ class _$WalletViewImpl implements _WalletView {
       @CoinInWalletListConverter() required final List<CoinInWallet> coins,
       @JsonKey(defaultValue: {})
       required final Map<String, WalletViewAggregationItem> aggregation,
-      required final List<String> symbolGroups,
+      @JsonKey(defaultValue: []) required final List<String> symbolGroups,
       required this.createdAt,
       required this.updatedAt,
       required this.userId})
@@ -244,6 +245,7 @@ class _$WalletViewImpl implements _WalletView {
 
   final List<String> _symbolGroups;
   @override
+  @JsonKey(defaultValue: [])
   List<String> get symbolGroups {
     if (_symbolGroups is EqualUnmodifiableListView) return _symbolGroups;
     // ignore: implicit_dynamic_type
@@ -317,7 +319,7 @@ abstract class _WalletView implements WalletView {
       @CoinInWalletListConverter() required final List<CoinInWallet> coins,
       @JsonKey(defaultValue: {})
       required final Map<String, WalletViewAggregationItem> aggregation,
-      required final List<String> symbolGroups,
+      @JsonKey(defaultValue: []) required final List<String> symbolGroups,
       required final String createdAt,
       required final String updatedAt,
       required final String userId}) = _$WalletViewImpl;
@@ -336,6 +338,7 @@ abstract class _WalletView implements WalletView {
   @JsonKey(defaultValue: {})
   Map<String, WalletViewAggregationItem> get aggregation;
   @override
+  @JsonKey(defaultValue: [])
   List<String> get symbolGroups;
   @override
   String get createdAt;

--- a/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/wallet_view.c.g.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/wallet_views/models/wallet_view.c.g.dart
@@ -16,9 +16,10 @@ _$WalletViewImpl _$$WalletViewImplFromJson(Map<String, dynamic> json) =>
                 WalletViewAggregationItem.fromJson(e as Map<String, dynamic>)),
           ) ??
           {},
-      symbolGroups: (json['symbolGroups'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
+      symbolGroups: (json['symbolGroups'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
       createdAt: json['createdAt'] as String,
       updatedAt: json['updatedAt'] as String,
       userId: json['userId'] as String,


### PR DESCRIPTION
## Description
It turns out that `symbolGroup` can be null, so we need to handle that case.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
