### PR TITLE
fix: main modal navigation

### DIFF
--- a/lib/app/extensions/go_router_state.dart
+++ b/lib/app/extensions/go_router_state.dart
@@ -5,7 +5,7 @@ import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/main_tabs/components/tab_item.dart';
 
 extension GoRouterStateExtension on GoRouterState {
-  bool get isMainModalOpen => matchedLocation.endsWith('/main-modal');
+  bool get isMainModalOpen => uri.toString().endsWith('/main-modal');
   bool get shouldHideBottomBar => fullPath?.contains('fullstack') ?? false;
 
   TabItem get currentTab {

--- a/lib/app/router/components/sheet_content/main_modal_content.dart
+++ b/lib/app/router/components/sheet_content/main_modal_content.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:ion/app/extensions/go_router_state.dart';
 import 'package:smooth_sheets/smooth_sheets.dart';
 
 class MainModalContent extends StatelessWidget {
@@ -22,7 +21,7 @@ class MainModalContent extends StatelessWidget {
           final metrics = controller.metrics;
 
           if (metrics.hasDimensions) {
-            context.go(state.currentTab.baseRouteLocation);
+            context.pop();
           }
         }
       },

--- a/lib/app/router/main_tabs/main_tab_navigation.dart
+++ b/lib/app/router/main_tabs/main_tab_navigation.dart
@@ -57,9 +57,11 @@ class MainTabNavigation extends HookConsumerWidget {
   void _handleMainButtonTap(BuildContext context, TabItem currentTab) {
     HapticFeedback.mediumImpact();
 
-    context.go(
-      state.isMainModalOpen ? currentTab.baseRouteLocation : currentTab.mainModalLocation,
-    );
+    if (state.isMainModalOpen) {
+      context.pop();
+    } else {
+      context.push(currentTab.mainModalLocation);
+    }
   }
 
   void _navigateToTab(BuildContext context, TabItem tabItem, {required bool initialLocation}) =>


### PR DESCRIPTION
## Description
- Replace go() calls (which replaced the entire stack) with push() and pop() to properly open and close the main modal.
- Update isMainModalOpen to check the full URI instead of matchedLocation, ensuring we detect the /main-modal suffix correctly.
- This preserves the existing navigation stack and prevents multiple copies of the same modal from being pushed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
