### PR TITLE
feat: 2FA reactive signer

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -366,7 +366,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
-  audio_waveforms: cd736909ebc6b6a164eb74701d8c705ce3241e1c
+  audio_waveforms: a6dde7fe7c0ea05f06ffbdb0f7c1b2b2ba6cedcf
   BanubaARCloudSDK: 40da62afeea642301ca8092600c9bb9cf67fe30e
   BanubaAudioBrowserSDK: 3a92807e60daa70dcaa1e76920abab97e7a73bf4
   BanubaLicenseServicingSDK: f2b51a4288d6b9796063855f5db6dc227819de22
@@ -377,7 +377,7 @@ SPEC CHECKSUMS:
   BanubaUtilities: 4ca45fcd7a6b5d246b75f02fd3f36b43d2dbebd3
   BanubaVideoEditorGallerySDK: 6d775728f14ab78e210d86058166e3deb3fc3814
   BanubaVideoEditorSDK: 1b8d56004f147c0ed96077f8171247efbc0511e7
-  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
+  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
   BNBAcneEyebagsRemoval: 9ad2c2351d57231add905c5bff6117faff87b712
   BNBBackground: 1e88cbaa9c447c1aa46506b0d74b1bd833494c72
   BNBEffectPlayer: 05f74da227a9ece5dd52bcdd8aa996e076793e6b
@@ -390,48 +390,48 @@ SPEC CHECKSUMS:
   BNBSdkApi: f773621958cf0f7776e18f90b96ace13b29d84e2
   BNBSdkCore: cc7711127dbcaf392d0a25f4a858d98ffc5c9213
   BNBSkin: 3a741bbba57a2a860fe4a69dbd597d7d9aea5793
-  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  camera_avfoundation: 04b44aeb14070126c6529e5ab82cc7c9fca107cf
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  external_app_launcher: ad55ac844aa21f2d2197d7cec58ff0d0dc40bbc0
+  external_app_launcher: 3411245965270a74040a3de17e27bd02b8abb905
   ffmpeg-kit-ios-full-gpl: 80adc341962e55ef709e36baa8ed9a70cf4ea62b
-  ffmpeg_kit_flutter_full_gpl: 8d15c14c0c3aba616fac04fe44b3d27d02e3c330
-  file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
-  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
+  ffmpeg_kit_flutter_full_gpl: ce18b888487c05c46ed252cd2e7956812f2e3bd1
+  file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
+  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
-  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  ion_screenshot_detector: bd85296e1347b5bf5acf71407a6d9b7933bfe604
-  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
+  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  ion_screenshot_detector: 6981b7ec0add023ce57337882e28dc4b80caad4b
+  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
-  passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
-  qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  quill_native_bridge: e5afa7d49c08cf68c52a5e23bc272eba6925c622
+  package_info_plus: 566e1b7a2f3900e4b0020914ad3fc051dcc95596
+  passkeys_ios: 939d7d44f825048c8dffd4644f52444164c80ecd
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  photo_manager: d2fbcc0f2d82458700ee6256a15018210a81d413
+  qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
+  quill_native_bridge: fd2819cf6da02fb6cbf9de37835f96e798e145eb
   SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
-  shake_gesture_ios: 64f1f579f314c58445761992a123111b3d7b3492
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
+  shake_gesture_ios: 85dce5e26785da11cf73e0234a5f4028f69afeef
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite: c35dad70033b8862124f8337cc994a809fcd9fa3
   sqlite3: 7559e33dae4c78538df563795af3a86fc887ee71
-  sqlite3_flutter_libs: 1b4e98da20ebd4e9b1240269b78cdcf492dbe9f3
+  sqlite3_flutter_libs: f0b59f6bb2a18597d0796558725007e5a7428397
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  ua_client_hints: 3b617011e47bea4b1ea65647efa12860b7280ad5
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  ve_sdk_flutter: c90ec3fc424953a7b82cd1edd5143bc756899e92
+  ua_client_hints: ef4ddde0e2b2be5f0731a31721c4cbbb889b1aa4
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  ve_sdk_flutter: e23c4a6f1b84eeacee1daf2a81ba0f0694ed76f1
   VEEffectsSDK: 40dca6a76aeff8630ce1b49ef7643d2a2655dd0f
   VEExportSDK: 32e97cf98ecbf86aed563fbd4c9131d7bbddbe92
   VEPlaybackSDK: 65bb7377c9c8524557d7b5d6723e321fc16fc4a1
-  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
+  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
   VideoEditor: b3e55fe6a6589e715365da822172f54b6fea8169
 
 PODFILE CHECKSUM: f19afb20048b05a04dbc809ad7d199f1df053e9a

--- a/lib/app/features/auth/views/pages/two_fa/twofa_input_step.dart
+++ b/lib/app/features/auth/views/pages/two_fa/twofa_input_step.dart
@@ -16,10 +16,8 @@ import 'package:ion/app/features/auth/views/components/auth_footer/auth_footer.d
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_scrolled_body.dart';
 import 'package:ion/app/features/auth/views/pages/recover_user_twofa_page/components/twofa_code_input.dart';
 import 'package:ion/app/features/auth/views/pages/recover_user_twofa_page/components/twofa_try_again_page.dart';
-import 'package:ion/app/features/components/verify_identity/hooks/use_on_get_password.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/request_twofa_code_notifier.c.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/selected_two_fa_types_provider.c.dart';
-import 'package:ion/app/features/user/providers/user_verify_identity_provider.c.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
@@ -51,10 +49,9 @@ class TwoFAInputStep extends HookConsumerWidget {
     _listenRequestTwoFaErrorResult(context, ref);
 
     final twoFaTypes = ref.watch(selectedTwoFaOptionsProvider);
-    final onGetPassword = useOnGetPassword();
 
     useOnInit(
-      () => _requestRecoveryCodes(ref, twoFaTypes, onGetPassword),
+      () => _requestRecoveryCodes(ref, twoFaTypes),
       [twoFaTypes],
     );
 
@@ -85,8 +82,7 @@ class TwoFAInputStep extends HookConsumerWidget {
                             child: TwoFaCodeInput(
                               controller: controllers[twoFaType]!,
                               twoFaType: twoFaType,
-                              onRequestCode: () =>
-                                  _requestRecoveryCode(ref, twoFaType, onGetPassword),
+                              onRequestCode: () => _requestRecoveryCode(ref, twoFaType),
                               isSending: isRequesting,
                             ),
                           ),
@@ -142,37 +138,21 @@ class TwoFAInputStep extends HookConsumerWidget {
   Future<void> _requestRecoveryCodes(
     WidgetRef ref,
     Set<TwoFaType> twoFaTypes,
-    Future<T> Function<T>(OnPasswordFlow<T> onPasswordFlow) onGetPassword,
   ) async {
     for (final twoFaType in twoFaTypes) {
-      await _requestRecoveryCode(ref, twoFaType, onGetPassword);
+      await _requestRecoveryCode(ref, twoFaType);
     }
   }
 
   Future<void> _requestRecoveryCode(
     WidgetRef ref,
     TwoFaType twoFaType,
-    Future<T> Function<T>(OnPasswordFlow<T> onPasswordFlow) onGetPassword,
   ) async {
     if (twoFaType == TwoFaType.auth) {
       return;
     }
     await ref
         .read(requestTwoFaCodeNotifierProvider.notifier)
-        .requestRecoveryTwoFaCode(twoFaType, identityKeyName, ({
-      required OnPasswordFlow<GenerateSignatureResponse> onPasswordFlow,
-      required OnPasskeyFlow<GenerateSignatureResponse> onPasskeyFlow,
-      required OnBiometricsFlow<GenerateSignatureResponse> onBiometricsFlow,
-    }) {
-      return ref.read(
-        verifyUserIdentityProvider(
-          onGetPassword: onGetPassword,
-          onPasswordFlow: onPasswordFlow,
-          onPasskeyFlow: onPasskeyFlow,
-          onBiometricsFlow: onBiometricsFlow,
-          localisedReasonForBiometricsDialog: ref.context.i18n.verify_with_biometrics_title,
-        ).future,
-      );
-    });
+        .requestRecoveryTwoFaCode(twoFaType, identityKeyName);
   }
 }

--- a/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_instructions_page.dart
+++ b/lib/app/features/protect_account/authenticator/views/pages/setup_authenticator/authenticator_setup_instructions_page.dart
@@ -10,7 +10,6 @@ import 'package:ion/app/features/auth/data/models/twofa_type.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header_icon.dart';
 import 'package:ion/app/features/components/verify_identity/hooks/use_on_get_password.dart';
-import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/protect_account/authenticator/views/pages/setup_authenticator/components/authenticator_setup_instructions_error_state.dart';
 import 'package:ion/app/features/protect_account/authenticator/views/pages/setup_authenticator/components/authenticator_setup_instructions_success_state.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/request_twofa_code_notifier.c.dart';
@@ -19,7 +18,6 @@ import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
-import 'package:ion_identity_client/ion_identity.dart';
 
 class AuthenticatorSetupInstructionsPage extends HookConsumerWidget {
   const AuthenticatorSetupInstructionsPage({super.key});
@@ -32,20 +30,7 @@ class AuthenticatorSetupInstructionsPage extends HookConsumerWidget {
     ref.displayErrors(requestTwoFaCodeNotifierProvider);
 
     final requestCode = useCallback(() {
-      guardPasskeyDialog(
-        ref.context,
-        (child) => RiverpodVerifyIdentityRequestBuilder(
-          provider: requestTwoFaCodeNotifierProvider,
-          requestWithVerifyIdentity:
-              (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) {
-            ref.read(requestTwoFaCodeNotifierProvider.notifier).requestTwoFaCode(
-                  TwoFaType.auth,
-                  onVerifyIdentity,
-                );
-          },
-          child: child,
-        ),
-      );
+      ref.read(requestTwoFaCodeNotifierProvider.notifier).requestTwoFaCode(TwoFaType.auth);
     });
 
     useOnInit(requestCode, [onGetPassword]);

--- a/lib/app/features/protect_account/common/two_fa_utils.dart
+++ b/lib/app/features/protect_account/common/two_fa_utils.dart
@@ -1,15 +1,22 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/protect_account/secure_account/providers/two_fa_signature_wrapper_notifier.c.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_client_provider.c.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 
 Future<String?> requestTwoFACode(
   WidgetRef ref,
   TwoFAType twoFAType,
-  OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
 ) async {
   final ionIdentityClient = await ref.read(ionIdentityClientProvider.future);
-  return ionIdentityClient.auth
-      .requestTwoFACode(twoFAType: twoFAType, onVerifyIdentity: onVerifyIdentity);
+  final twoFaWrapper = ref.read(twoFaSignatureWrapperNotifierProvider.notifier);
+  String? code;
+  await twoFaWrapper.wrapWithSignature((signature) async {
+    code = await ionIdentityClient.auth.requestTwoFACode(
+      twoFAType: twoFAType,
+      signature: signature,
+    );
+  });
+  return code;
 }

--- a/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_confirm_page.dart
+++ b/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_confirm_page.dart
@@ -11,7 +11,6 @@ import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/data/models/twofa_type.dart';
 import 'package:ion/app/features/auth/views/pages/recover_user_twofa_page/components/twofa_code_input.dart';
-import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/protect_account/common/two_fa_utils.dart';
 import 'package:ion/app/features/protect_account/email/data/model/email_steps.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/security_account_provider.c.dart';
@@ -55,18 +54,9 @@ class EmailSetupConfirmPage extends HookConsumerWidget {
                   child: TwoFaCodeInput(
                     controller: codeController,
                     twoFaType: TwoFaType.email,
-                    onRequestCode: () => guardPasskeyDialog(
-                      context,
-                      (child) => HookVerifyIdentityRequestBuilder(
-                        requestWithVerifyIdentity:
-                            (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) =>
-                                requestTwoFACode(
-                          ref,
-                          TwoFAType.email(email),
-                          onVerifyIdentity,
-                        ),
-                        child: child,
-                      ),
+                    onRequestCode: () => requestTwoFACode(
+                      ref,
+                      TwoFAType.email(email),
                     ),
                   ),
                 ),

--- a/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_input_page.dart
+++ b/lib/app/features/protect_account/email/views/pages/setup_email/email_setup_input_page.dart
@@ -12,7 +12,6 @@ import 'package:ion/app/components/inputs/text_input/text_input.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/data/models/twofa_type.dart';
-import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/protect_account/common/two_fa_utils.dart';
 import 'package:ion/app/features/protect_account/email/data/model/email_steps.dart';
 import 'package:ion/app/router/app_routes.c.dart';
@@ -63,19 +62,7 @@ class EmailSetupInputPage extends HookConsumerWidget {
                       return;
                     }
 
-                    await guardPasskeyDialog(
-                      context,
-                      (child) => HookVerifyIdentityRequestBuilder(
-                        requestWithVerifyIdentity:
-                            (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) =>
-                                requestTwoFACode(
-                          ref,
-                          TwoFAType.email(emailController.text),
-                          onVerifyIdentity,
-                        ),
-                        child: child,
-                      ),
-                    );
+                    await requestTwoFACode(ref, TwoFAType.email(emailController.text));
 
                     if (!context.mounted) {
                       return;

--- a/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_confirm_page.dart
+++ b/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_confirm_page.dart
@@ -12,7 +12,6 @@ import 'package:ion/app/components/inputs/text_input/text_input.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/views/pages/recover_user_twofa_page/components/twofa_code_input.dart';
-import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/protect_account/common/two_fa_utils.dart';
 import 'package:ion/app/features/protect_account/phone/models/phone_steps.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/security_account_provider.c.dart';
@@ -70,19 +69,7 @@ class PhoneSetupConfirmPage extends HookConsumerWidget {
                     scrollPadding: EdgeInsets.only(bottom: 200.0.s),
                     keyboardType: TextInputType.number,
                     suffixIcon: SendButton(
-                      onRequestCode: () => guardPasskeyDialog(
-                        context,
-                        (child) => HookVerifyIdentityRequestBuilder(
-                          requestWithVerifyIdentity:
-                              (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) =>
-                                  requestTwoFACode(
-                            ref,
-                            TwoFAType.sms(phone),
-                            onVerifyIdentity,
-                          ),
-                          child: child,
-                        ),
-                      ),
+                      onRequestCode: () => requestTwoFACode(ref, TwoFAType.sms(phone)),
                     ),
                   ),
                 ),

--- a/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_input_page.dart
+++ b/lib/app/features/protect_account/phone/views/pages/setup_phone/phone_setup_input_page.dart
@@ -13,7 +13,6 @@ import 'package:ion/app/components/inputs/text_input/text_input.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/constants/countries.c.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/protect_account/common/two_fa_utils.dart';
 import 'package:ion/app/features/protect_account/phone/models/phone_steps.dart';
 import 'package:ion/app/features/protect_account/phone/provider/country_provider.c.dart';
@@ -95,18 +94,9 @@ class PhoneSetupInputPage extends HookConsumerWidget {
                       phoneController.text.trim(),
                     );
 
-                    await guardPasskeyDialog(
-                      context,
-                      (child) => HookVerifyIdentityRequestBuilder(
-                        requestWithVerifyIdentity:
-                            (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) =>
-                                requestTwoFACode(
-                          ref,
-                          TwoFAType.sms(phoneNumber),
-                          onVerifyIdentity,
-                        ),
-                        child: child,
-                      ),
+                    await requestTwoFACode(
+                      ref,
+                      TwoFAType.sms(phoneNumber),
                     );
 
                     if (!context.mounted) {

--- a/lib/app/features/protect_account/secure_account/providers/delete_twofa_notifier.c.dart
+++ b/lib/app/features/protect_account/secure_account/providers/delete_twofa_notifier.c.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:ion/app/features/protect_account/secure_account/providers/two_fa_signature_wrapper_notifier.c.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_client_provider.c.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -13,14 +14,20 @@ class DeleteTwoFANotifier extends _$DeleteTwoFANotifier {
 
   Future<void> deleteTwoFa(
     TwoFAType twoFAType,
-    OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
     List<TwoFAType> verificationCodes,
   ) async {
     state = const AsyncLoading();
 
     state = await AsyncValue.guard(() async {
       final client = await ref.read(ionIdentityClientProvider.future);
-      await client.auth.deleteTwoFA(twoFAType, onVerifyIdentity, verificationCodes);
+      final twoFaWrapper = ref.read(twoFaSignatureWrapperNotifierProvider.notifier);
+      await twoFaWrapper.wrapWithSignature(
+        (signature) => client.auth.deleteTwoFA(
+          twoFAType: twoFAType,
+          signature: signature,
+          verificationCodes: verificationCodes,
+        ),
+      );
     });
   }
 }

--- a/lib/app/features/protect_account/secure_account/providers/request_twofa_code_notifier.c.dart
+++ b/lib/app/features/protect_account/secure_account/providers/request_twofa_code_notifier.c.dart
@@ -45,7 +45,6 @@ class RequestTwoFaCodeNotifier extends _$RequestTwoFaCodeNotifier {
   Future<void> requestRecoveryTwoFaCode(
     TwoFaType twoFaType,
     String recoveryIdentityKeyName,
-    OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
   ) async {
     if (state.isLoading) {
       return;

--- a/lib/app/features/protect_account/secure_account/providers/two_fa_signature_notifier.c.dart
+++ b/lib/app/features/protect_account/secure_account/providers/two_fa_signature_notifier.c.dart
@@ -1,0 +1,13 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'two_fa_signature_notifier.c.g.dart';
+
+@Riverpod(keepAlive: true)
+class TwoFaSignatureNotifier extends _$TwoFaSignatureNotifier {
+  @override
+  String? build() => null;
+
+  Future<void> setSignature(String? signature) async {
+    state = signature;
+  }
+}

--- a/lib/app/features/protect_account/secure_account/providers/two_fa_signature_notifier.c.dart
+++ b/lib/app/features/protect_account/secure_account/providers/two_fa_signature_notifier.c.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'two_fa_signature_notifier.c.g.dart';

--- a/lib/app/features/protect_account/secure_account/providers/two_fa_signature_wrapper_notifier.c.dart
+++ b/lib/app/features/protect_account/secure_account/providers/two_fa_signature_wrapper_notifier.c.dart
@@ -1,0 +1,53 @@
+import 'package:ion/app/features/protect_account/secure_account/providers/two_fa_signature_notifier.c.dart';
+import 'package:ion/app/services/ion_identity/ion_identity_client_provider.c.dart';
+import 'package:ion_identity_client/ion_identity.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'two_fa_signature_wrapper_notifier.c.g.dart';
+
+typedef SignedAction = Future<void> Function(String? signature);
+
+@Riverpod(keepAlive: true)
+class TwoFaSignatureWrapperNotifier extends _$TwoFaSignatureWrapperNotifier {
+  @override
+  FutureOr<SignedAction?> build() async => null;
+
+  Future<void> wrapWithSignature(SignedAction action, [String? twoFaSignature]) async {
+    state = const AsyncLoading();
+
+    try {
+      state = await AsyncValue.guard(
+        () async {
+          final signature = twoFaSignature ?? ref.read(twoFaSignatureNotifierProvider);
+          await action(signature);
+          return null;
+        },
+        (error) {
+          // return error is! InvalidSignatureException;
+          return true;
+        },
+      );
+      // } on InvalidSignatureException catch (e) {
+    } catch (e) {
+      // if invalid signature error, set state with failed action to retry
+      // state = AsyncValue(action);
+    }
+  }
+
+  Future<void> retryWithVerifyIdentity(
+    SignedAction action,
+    OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
+  ) async {
+    state = const AsyncLoading();
+
+    state = await AsyncValue.guard(() async {
+      final client = await ref.read(ionIdentityClientProvider.future);
+      final signature = await client.auth.generateSignature(onVerifyIdentity);
+      await ref.read(twoFaSignatureNotifierProvider.notifier).setSignature(signature);
+
+      await wrapWithSignature(action, signature);
+
+      return null;
+    });
+  }
+}

--- a/lib/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart
+++ b/lib/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/two_fa_signature_wrapper_notifier.c.dart';
+import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 
 class TwoFaSignatureWrapper extends HookConsumerWidget {
@@ -21,7 +22,7 @@ class TwoFaSignatureWrapper extends HookConsumerWidget {
         if (failedAction == null) return;
 
         guardPasskeyDialog(
-          context,
+          rootNavigatorKey.currentContext!,
           (child) => HookVerifyIdentityRequestBuilder(
             requestWithVerifyIdentity:
                 (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) => ref

--- a/lib/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart
+++ b/lib/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
+import 'package:ion/app/features/protect_account/secure_account/providers/two_fa_signature_wrapper_notifier.c.dart';
+import 'package:ion_identity_client/ion_identity.dart';
+
+class TwoFaSignatureWrapper extends HookConsumerWidget {
+  const TwoFaSignatureWrapper({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen(
+      twoFaSignatureWrapperNotifierProvider,
+      (_, next) {
+        if (next.isLoading || next.hasError || !next.hasValue || !context.mounted) return;
+        final failedAction = next.valueOrNull;
+        if (failedAction == null) return;
+
+        guardPasskeyDialog(
+          context,
+          (child) => HookVerifyIdentityRequestBuilder(
+            requestWithVerifyIdentity:
+                (OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity) => ref
+                    .read(twoFaSignatureWrapperNotifierProvider.notifier)
+                    .retryWithVerifyIdentity(
+                      failedAction,
+                      onVerifyIdentity,
+                    ),
+            child: child,
+          ),
+        );
+      },
+    );
+
+    return child;
+  }
+}

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
@@ -12,6 +12,7 @@ import 'package:ion/app/features/protect_account/phone/models/phone_steps.dart';
 import 'package:ion/app/features/protect_account/secure_account/data/models/security_methods.c.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/security_account_provider.c.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/user_details_provider.c.dart';
+import 'package:ion/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
@@ -34,72 +35,74 @@ class SecureAccountOptionsPage extends HookConsumerWidget {
     });
 
     return SheetContent(
-      body: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          NavigationAppBar.modal(
-            title: Text(locale.protect_account_header_security),
-            actions: const [
-              NavigationCloseButton(),
-            ],
-          ),
-          SizedBox(height: 36.0.s),
-          ScreenSideOffset.small(
-            child: Column(
-              children: [
-                Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 24.0.s),
-                  child: InfoCard(
-                    iconAsset: Assets.svg.actionWalletSecureaccount,
-                    title: locale.protect_account_title_secure_account,
-                    description: locale.protect_account_description_secure_account_2fa,
-                  ),
-                ),
-                SizedBox(height: 32.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_backup,
-                  icon: Assets.svg.iconProtectwalletIcloud.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  onTap: () => BackupOptionsRoute().push<void>(context),
-                  isEnabled: securityMethods?.isBackupEnabled ?? false,
-                  isLoading: isLoading,
-                ),
-                SizedBox(height: 12.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_email,
-                  icon: Assets.svg.iconFieldEmail.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  onTap: () => _onEmailPressed(context, securityMethods),
-                  isEnabled: securityMethods?.isEmailEnabled ?? false,
-                  isLoading: isLoading,
-                ),
-                SizedBox(height: 12.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_authenticator,
-                  icon: Assets.svg.iconLoginAuthcode.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  isEnabled: securityMethods?.isAuthenticatorEnabled ?? false,
-                  isLoading: isLoading,
-                  onTap: () => _onAuthenticatorPressed(context, securityMethods),
-                ),
-                SizedBox(height: 12.0.s),
-                SecureAccountOption(
-                  title: locale.two_fa_option_phone,
-                  icon: Assets.svg.iconFieldPhone.icon(
-                    color: context.theme.appColors.primaryAccent,
-                  ),
-                  onTap: () => _onPhonePressed(context, securityMethods),
-                  isEnabled: securityMethods?.isPhoneEnabled ?? false,
-                  isLoading: isLoading,
-                ),
-                ScreenBottomOffset(margin: 36.0.s),
+      body: TwoFaSignatureWrapper(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            NavigationAppBar.modal(
+              title: Text(locale.protect_account_header_security),
+              actions: const [
+                NavigationCloseButton(),
               ],
             ),
-          ),
-        ],
+            SizedBox(height: 36.0.s),
+            ScreenSideOffset.small(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 24.0.s),
+                    child: InfoCard(
+                      iconAsset: Assets.svg.actionWalletSecureaccount,
+                      title: locale.protect_account_title_secure_account,
+                      description: locale.protect_account_description_secure_account_2fa,
+                    ),
+                  ),
+                  SizedBox(height: 32.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_backup,
+                    icon: Assets.svg.iconProtectwalletIcloud.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    onTap: () => BackupOptionsRoute().push<void>(context),
+                    isEnabled: securityMethods?.isBackupEnabled ?? false,
+                    isLoading: isLoading,
+                  ),
+                  SizedBox(height: 12.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_email,
+                    icon: Assets.svg.iconFieldEmail.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    onTap: () => _onEmailPressed(context, securityMethods),
+                    isEnabled: securityMethods?.isEmailEnabled ?? false,
+                    isLoading: isLoading,
+                  ),
+                  SizedBox(height: 12.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_authenticator,
+                    icon: Assets.svg.iconLoginAuthcode.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    isEnabled: securityMethods?.isAuthenticatorEnabled ?? false,
+                    isLoading: isLoading,
+                    onTap: () => _onAuthenticatorPressed(context, securityMethods),
+                  ),
+                  SizedBox(height: 12.0.s),
+                  SecureAccountOption(
+                    title: locale.two_fa_option_phone,
+                    icon: Assets.svg.iconFieldPhone.icon(
+                      color: context.theme.appColors.primaryAccent,
+                    ),
+                    onTap: () => _onPhonePressed(context, securityMethods),
+                    isEnabled: securityMethods?.isPhoneEnabled ?? false,
+                    isLoading: isLoading,
+                  ),
+                  ScreenBottomOffset(margin: 36.0.s),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
+++ b/lib/app/features/protect_account/secure_account/views/pages/secure_account_options_page.dart
@@ -12,7 +12,6 @@ import 'package:ion/app/features/protect_account/phone/models/phone_steps.dart';
 import 'package:ion/app/features/protect_account/secure_account/data/models/security_methods.c.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/security_account_provider.c.dart';
 import 'package:ion/app/features/protect_account/secure_account/providers/user_details_provider.c.dart';
-import 'package:ion/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
@@ -35,74 +34,72 @@ class SecureAccountOptionsPage extends HookConsumerWidget {
     });
 
     return SheetContent(
-      body: TwoFaSignatureWrapper(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            NavigationAppBar.modal(
-              title: Text(locale.protect_account_header_security),
-              actions: const [
-                NavigationCloseButton(),
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          NavigationAppBar.modal(
+            title: Text(locale.protect_account_header_security),
+            actions: const [
+              NavigationCloseButton(),
+            ],
+          ),
+          SizedBox(height: 36.0.s),
+          ScreenSideOffset.small(
+            child: Column(
+              children: [
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24.0.s),
+                  child: InfoCard(
+                    iconAsset: Assets.svg.actionWalletSecureaccount,
+                    title: locale.protect_account_title_secure_account,
+                    description: locale.protect_account_description_secure_account_2fa,
+                  ),
+                ),
+                SizedBox(height: 32.0.s),
+                SecureAccountOption(
+                  title: locale.two_fa_option_backup,
+                  icon: Assets.svg.iconProtectwalletIcloud.icon(
+                    color: context.theme.appColors.primaryAccent,
+                  ),
+                  onTap: () => BackupOptionsRoute().push<void>(context),
+                  isEnabled: securityMethods?.isBackupEnabled ?? false,
+                  isLoading: isLoading,
+                ),
+                SizedBox(height: 12.0.s),
+                SecureAccountOption(
+                  title: locale.two_fa_option_email,
+                  icon: Assets.svg.iconFieldEmail.icon(
+                    color: context.theme.appColors.primaryAccent,
+                  ),
+                  onTap: () => _onEmailPressed(context, securityMethods),
+                  isEnabled: securityMethods?.isEmailEnabled ?? false,
+                  isLoading: isLoading,
+                ),
+                SizedBox(height: 12.0.s),
+                SecureAccountOption(
+                  title: locale.two_fa_option_authenticator,
+                  icon: Assets.svg.iconLoginAuthcode.icon(
+                    color: context.theme.appColors.primaryAccent,
+                  ),
+                  isEnabled: securityMethods?.isAuthenticatorEnabled ?? false,
+                  isLoading: isLoading,
+                  onTap: () => _onAuthenticatorPressed(context, securityMethods),
+                ),
+                SizedBox(height: 12.0.s),
+                SecureAccountOption(
+                  title: locale.two_fa_option_phone,
+                  icon: Assets.svg.iconFieldPhone.icon(
+                    color: context.theme.appColors.primaryAccent,
+                  ),
+                  onTap: () => _onPhonePressed(context, securityMethods),
+                  isEnabled: securityMethods?.isPhoneEnabled ?? false,
+                  isLoading: isLoading,
+                ),
+                ScreenBottomOffset(margin: 36.0.s),
               ],
             ),
-            SizedBox(height: 36.0.s),
-            ScreenSideOffset.small(
-              child: Column(
-                children: [
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 24.0.s),
-                    child: InfoCard(
-                      iconAsset: Assets.svg.actionWalletSecureaccount,
-                      title: locale.protect_account_title_secure_account,
-                      description: locale.protect_account_description_secure_account_2fa,
-                    ),
-                  ),
-                  SizedBox(height: 32.0.s),
-                  SecureAccountOption(
-                    title: locale.two_fa_option_backup,
-                    icon: Assets.svg.iconProtectwalletIcloud.icon(
-                      color: context.theme.appColors.primaryAccent,
-                    ),
-                    onTap: () => BackupOptionsRoute().push<void>(context),
-                    isEnabled: securityMethods?.isBackupEnabled ?? false,
-                    isLoading: isLoading,
-                  ),
-                  SizedBox(height: 12.0.s),
-                  SecureAccountOption(
-                    title: locale.two_fa_option_email,
-                    icon: Assets.svg.iconFieldEmail.icon(
-                      color: context.theme.appColors.primaryAccent,
-                    ),
-                    onTap: () => _onEmailPressed(context, securityMethods),
-                    isEnabled: securityMethods?.isEmailEnabled ?? false,
-                    isLoading: isLoading,
-                  ),
-                  SizedBox(height: 12.0.s),
-                  SecureAccountOption(
-                    title: locale.two_fa_option_authenticator,
-                    icon: Assets.svg.iconLoginAuthcode.icon(
-                      color: context.theme.appColors.primaryAccent,
-                    ),
-                    isEnabled: securityMethods?.isAuthenticatorEnabled ?? false,
-                    isLoading: isLoading,
-                    onTap: () => _onAuthenticatorPressed(context, securityMethods),
-                  ),
-                  SizedBox(height: 12.0.s),
-                  SecureAccountOption(
-                    title: locale.two_fa_option_phone,
-                    icon: Assets.svg.iconFieldPhone.icon(
-                      color: context.theme.appColors.primaryAccent,
-                    ),
-                    onTap: () => _onPhonePressed(context, securityMethods),
-                    isEnabled: securityMethods?.isPhoneEnabled ?? false,
-                    isLoading: isLoading,
-                  ),
-                  ScreenBottomOffset(margin: 36.0.s),
-                ],
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/app/router/components/app_router_builder.dart
+++ b/lib/app/router/components/app_router_builder.dart
@@ -7,6 +7,7 @@ import 'package:ion/app/components/global_notification_bar/global_notification_b
 import 'package:ion/app/components/global_notification_bar/providers/global_notification_provider.c.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/debug/views/debug_shake_gesture.dart';
+import 'package:ion/app/features/protect_account/secure_account/views/components/two_fa_signature_wrapper.dart';
 import 'package:ion/app/hooks/use_interval.dart';
 import 'package:ion/app/services/ui_event_queue/ui_event_queue_listener.dart';
 
@@ -43,7 +44,9 @@ class AppRouterBuilder extends HookConsumerWidget {
             const UiEventQueueListener(),
             Expanded(
               child: DebugShakeGesture(
-                child: child ?? const SizedBox.shrink(),
+                child: TwoFaSignatureWrapper(
+                  child: child ?? const SizedBox.shrink(),
+                ),
               ),
             ),
           ],

--- a/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
+++ b/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
@@ -148,5 +148,10 @@ class IONIdentityAuth {
   ]) =>
       twoFAService.deleteTwoFA(twoFAType, onVerifyIdentity, verificationCodes);
 
+  Future<String> generateSignature(
+    OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
+  ) =>
+      twoFAService.generateSignature(onVerifyIdentity);
+
   Future<List<Credential>> getCredentialsList() => getCredentialsService.getCredentialsList();
 }

--- a/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
+++ b/packages/ion_identity_client/lib/src/auth/ion_identity_auth.dart
@@ -128,25 +128,29 @@ class IONIdentityAuth {
 
   Future<String?> requestTwoFACode({
     required TwoFAType twoFAType,
-    required OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
+    required String? signature,
     Map<String, String>? verificationCodes,
     String? recoveryIdentityKeyName,
   }) =>
       twoFAService.requestTwoFACode(
         twoFAType: twoFAType,
-        onVerifyIdentity: onVerifyIdentity,
+        signature: signature,
         verificationCodes: verificationCodes,
         recoveryIdentityKeyName: recoveryIdentityKeyName,
       );
 
   Future<void> verifyTwoFA(TwoFAType twoFAType) => twoFAService.verifyTwoFA(twoFAType);
 
-  Future<void> deleteTwoFA(
-    TwoFAType twoFAType,
-    OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity, [
+  Future<void> deleteTwoFA({
+    required TwoFAType twoFAType,
+    required String? signature,
     List<TwoFAType> verificationCodes = const [],
-  ]) =>
-      twoFAService.deleteTwoFA(twoFAType, onVerifyIdentity, verificationCodes);
+  }) =>
+      twoFAService.deleteTwoFA(
+        twoFAType: twoFAType,
+        signature: signature,
+        verificationCodes: verificationCodes,
+      );
 
   Future<String> generateSignature(
     OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,

--- a/packages/ion_identity_client/lib/src/auth/services/twofa/twofa_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/twofa/twofa_service.dart
@@ -39,7 +39,7 @@ class TwoFAService {
     }
 
     final userId = _extractUserIdService.extractUserId(username: username);
-    final base64Signature = await _generateSignature(userId, onVerifyIdentity);
+    final base64Signature = await generateSignature(onVerifyIdentity);
 
     final response = await _dataSource.requestTwoFACode(
       signature: base64Signature,
@@ -71,7 +71,7 @@ class TwoFAService {
     List<TwoFAType> verificationCodes = const [],
   ]) async {
     final userId = _extractUserIdService.extractUserId(username: username);
-    final base64Signature = await _generateSignature(userId, onVerifyIdentity);
+    final base64Signature = await generateSignature(onVerifyIdentity);
 
     await _dataSource.deleteTwoFA(
       signature: base64Signature,
@@ -82,10 +82,10 @@ class TwoFAService {
     );
   }
 
-  Future<String> _generateSignature(
-    String userId,
+  Future<String> generateSignature(
     OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
   ) async {
+    final userId = _extractUserIdService.extractUserId(username: username);
     final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final mainWallet = (await _wallets.getWallets()).first;
 

--- a/packages/ion_identity_client/lib/src/auth/services/twofa/twofa_service.dart
+++ b/packages/ion_identity_client/lib/src/auth/services/twofa/twofa_service.dart
@@ -25,7 +25,7 @@ class TwoFAService {
 
   Future<String?> requestTwoFACode({
     required TwoFAType twoFAType,
-    required OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity,
+    required String? signature,
     required Map<String, String>? verificationCodes,
     String? recoveryIdentityKeyName,
   }) async {
@@ -39,10 +39,9 @@ class TwoFAService {
     }
 
     final userId = _extractUserIdService.extractUserId(username: username);
-    final base64Signature = await generateSignature(onVerifyIdentity);
 
     final response = await _dataSource.requestTwoFACode(
-      signature: base64Signature,
+      signature: signature,
       username: username,
       userId: userId,
       twoFAOption: twoFAType.option,
@@ -65,16 +64,15 @@ class TwoFAService {
     );
   }
 
-  Future<void> deleteTwoFA(
-    TwoFAType twoFAType,
-    OnVerifyIdentity<GenerateSignatureResponse> onVerifyIdentity, [
+  Future<void> deleteTwoFA({
+    required TwoFAType twoFAType,
+    required String? signature,
     List<TwoFAType> verificationCodes = const [],
-  ]) async {
+  }) async {
     final userId = _extractUserIdService.extractUserId(username: username);
-    final base64Signature = await generateSignature(onVerifyIdentity);
 
     await _dataSource.deleteTwoFA(
-      signature: base64Signature,
+      signature: signature,
       username: username,
       userId: userId,
       twoFAType: twoFAType,

--- a/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
+++ b/packages/ion_identity_client/lib/src/core/types/ion_exception.dart
@@ -155,3 +155,21 @@ class InvalidRecoveryCredentialsException extends IONIdentityException {
     }
   }
 }
+
+class InvalidSignatureException extends IONIdentityException {
+  InvalidSignatureException() : super('Invalid signature');
+
+  static bool isMatch(DioException dioException) {
+    final responseData = dioException.response?.data;
+
+    try {
+      if (responseData is Map<String, dynamic>) {
+        final responseCode = responseData['code'] as String?;
+        return responseCode == 'INVALID_SIGNATURE';
+      }
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR introduces a reactive two fa requests signer, which only initiates a signing flow when a server error about invalid signature is returned.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
