### PR TITLE
fix(wallet): show friends only if more than 3

### DIFF
--- a/lib/app/features/user/providers/should_show_friends_selector_provider.c.dart
+++ b/lib/app/features/user/providers/should_show_friends_selector_provider.c.dart
@@ -4,10 +4,14 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/user/providers/follow_list_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'has_friends_selector_provider.c.g.dart';
+part 'should_show_friends_selector_provider.c.g.dart';
+
+const _friendsCountThreshold = 3;
 
 @riverpod
-Future<bool?> hasFriendsSelector(Ref ref) async {
+Future<bool> shouldShowFriendsSelector(Ref ref) async {
   final followList = await ref.watch(currentUserFollowListProvider.future);
-  return followList?.pubkeys.isNotEmpty;
+  final friendsCount = followList?.pubkeys.length ?? 0;
+
+  return friendsCount >= _friendsCountThreshold;
 }

--- a/lib/app/features/wallets/views/pages/wallet_page.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page.dart
@@ -60,8 +60,10 @@ class WalletPage extends HookConsumerWidget {
             child: Column(
               children: [
                 const Balance(),
-                const Delimiter(),
-                if (showFriends) const ContactsList(),
+                if (showFriends) ...[
+                  const Delimiter(),
+                  const ContactsList(),
+                ],
                 const Delimiter(),
                 WalletTabsHeader(
                   activeTab: activeTab.value,

--- a/lib/app/features/wallets/views/pages/wallet_page.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/feed_controls/feed_controls.dart';
-import 'package:ion/app/features/user/providers/has_friends_selector_provider.c.dart';
+import 'package:ion/app/features/user/providers/should_show_friends_selector_provider.c.dart';
 import 'package:ion/app/features/wallets/model/nft_layout_type.dart';
 import 'package:ion/app/features/wallets/providers/filtered_assets_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/user_preferences_selectors.c.dart';
@@ -46,7 +46,7 @@ class WalletPage extends HookConsumerWidget {
       return const NftsTab();
     }
 
-    final hasFriends = ref.watch(hasFriendsSelectorProvider).valueOrNull ?? true;
+    final showFriends = ref.watch(shouldShowFriendsSelectorProvider).valueOrNull ?? true;
 
     return Scaffold(
       body: CustomScrollView(
@@ -61,7 +61,7 @@ class WalletPage extends HookConsumerWidget {
               children: [
                 const Balance(),
                 const Delimiter(),
-                if (hasFriends) const ContactsList(),
+                if (showFriends) const ContactsList(),
                 const Delimiter(),
                 WalletTabsHeader(
                   activeTab: activeTab.value,


### PR DESCRIPTION
## Description
This PR hides Friends section on Wallet page if a user has <3 (less than 3) friends.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore