### PR TITLE
fix(wallet): close modal on wallet selected

### DIFF
--- a/lib/app/features/wallets/views/components/wallet_tile.dart
+++ b/lib/app/features/wallets/views/components/wallet_tile.dart
@@ -35,6 +35,7 @@ class WalletTile extends ConsumerWidget {
           if (!isSelected) {
             ref.read(selectedWalletViewIdNotifierProvider.notifier).selectedWalletId =
                 walletData.id;
+            Navigator.of(context).pop();
           }
         },
         leading: const WalletIcon(),


### PR DESCRIPTION
## Description
Closes the modal when a user selects a wallet

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore