### PR TITLE
fix: stories section bottom divider height

### DIFF
--- a/lib/app/features/feed/views/pages/feed_page/components/stories/stories.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/stories.dart
@@ -49,7 +49,7 @@ class Stories extends ConsumerWidget {
             },
           ),
         SizedBox(height: 16.0.s),
-        FeedListSeparator(height: 16.0.s),
+        FeedListSeparator(height: 12.0.s),
       ],
     );
   }


### PR DESCRIPTION
## Description
Fix Stories bottom divider height on feed to match other feed cells.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![ScreenShot 2025-02-05 at 12 14 13@2x](https://github.com/user-attachments/assets/94f9e59b-29e0-4b35-a368-9f9acf0d7408)
