### PR TITLE
fix: receive coins filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ fastlane/keys
 
 assets/ion_identity/coins.json
 assets/ion_identity/coins_version.txt
+.aider*
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,3 @@ fastlane/keys
 assets/ion_identity/coins.json
 assets/ion_identity/coins_version.txt
 .aider*
-.env

--- a/lib/app/features/core/providers/main_wallet_provider.c.dart
+++ b/lib/app/features/core/providers/main_wallet_provider.c.dart
@@ -11,7 +11,7 @@ part 'main_wallet_provider.c.g.dart';
 
 @Riverpod(keepAlive: true)
 Future<Wallet> mainWallet(Ref ref) async {
-  final wallets = await ref.watch(walletsProvider.future);
+  final wallets = await ref.watch(walletsNotifierProvider.future);
   final mainWallet = wallets.firstWhereOrNull((wallet) => wallet.name == 'main');
 
   if (mainWallet == null) {

--- a/lib/app/features/core/providers/wallets_provider.c.dart
+++ b/lib/app/features/core/providers/wallets_provider.c.dart
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_client_provider.c.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -17,18 +16,11 @@ class WalletsNotifier extends _$WalletsNotifier {
 
   Future<void> addWallet(Wallet wallet) async {
     final currentWallets = state.valueOrNull ?? [];
-    
+
     // Only add if not already present
     if (!currentWallets.any((w) => w.id == wallet.id)) {
       state = AsyncData([...currentWallets, wallet]);
     }
-  }
-
-  Future<void> removeWallet(String walletId) async {
-    final currentWallets = state.valueOrNull ?? [];
-    state = AsyncData(
-      currentWallets.where((wallet) => wallet.id != walletId).toList(),
-    );
   }
 
   Future<void> refresh() async {

--- a/lib/app/features/core/providers/wallets_provider.c.dart
+++ b/lib/app/features/core/providers/wallets_provider.c.dart
@@ -22,10 +22,4 @@ class WalletsNotifier extends _$WalletsNotifier {
       state = AsyncData([...currentWallets, wallet]);
     }
   }
-
-  Future<void> refresh() async {
-    state = const AsyncLoading();
-    final ionIdentity = await ref.read(ionIdentityClientProvider.future);
-    state = AsyncData(await ionIdentity.wallets.getWallets());
-  }
 }

--- a/lib/app/features/core/providers/wallets_provider.c.dart
+++ b/lib/app/features/core/providers/wallets_provider.c.dart
@@ -8,7 +8,32 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'wallets_provider.c.g.dart';
 
 @Riverpod(keepAlive: true)
-Future<List<Wallet>> wallets(Ref ref) async {
-  final ionIdentity = await ref.watch(ionIdentityClientProvider.future);
-  return ionIdentity.wallets.getWallets();
+class WalletsNotifier extends _$WalletsNotifier {
+  @override
+  Future<List<Wallet>> build() async {
+    final ionIdentity = await ref.watch(ionIdentityClientProvider.future);
+    return ionIdentity.wallets.getWallets();
+  }
+
+  Future<void> addWallet(Wallet wallet) async {
+    final currentWallets = state.valueOrNull ?? [];
+    
+    // Only add if not already present
+    if (!currentWallets.any((w) => w.id == wallet.id)) {
+      state = AsyncData([...currentWallets, wallet]);
+    }
+  }
+
+  Future<void> removeWallet(String walletId) async {
+    final currentWallets = state.valueOrNull ?? [];
+    state = AsyncData(
+      currentWallets.where((wallet) => wallet.id != walletId).toList(),
+    );
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    final ionIdentity = await ref.read(ionIdentityClientProvider.future);
+    state = AsyncData(await ionIdentity.wallets.getWallets());
+  }
 }

--- a/lib/app/features/wallets/data/coins/database/coins_dao.c.dart
+++ b/lib/app/features/wallets/data/coins/database/coins_dao.c.dart
@@ -45,10 +45,6 @@ class CoinsDao extends DatabaseAccessor<CoinsDatabase> with _$CoinsDaoMixin {
     return (select(coinsTable)..where((row) => row.id.isIn(coinIds!))).get();
   }
 
-  Future<List<Coin>> getBySymbolGroup(String symbolGroup) {
-    return (select(coinsTable)..where((row) => row.symbolGroup.equals(symbolGroup))).get();
-  }
-
   Future<List<Coin>> search(String query) {
     final formattedQuery = '%${query.trim().toLowerCase()}%';
 
@@ -58,5 +54,16 @@ class CoinsDao extends DatabaseAccessor<CoinsDatabase> with _$CoinsDaoMixin {
                 row.symbol.lower().like(formattedQuery) | row.name.lower().like(formattedQuery),
           ))
         .get();
+  }
+
+  Future<List<Coin>> getByFilters({String? symbolGroup, String? symbol}) {
+    final query = select(coinsTable);
+    if (symbolGroup != null) {
+      query.where((row) => row.symbolGroup.lower().equals(symbolGroup.toLowerCase()));
+    }
+    if (symbol != null) {
+      query.where((row) => row.symbol.lower().equals(symbol.toLowerCase()));
+    }
+    return query.get();
   }
 }

--- a/lib/app/features/wallets/data/coins/repository/coins_repository.c.dart
+++ b/lib/app/features/wallets/data/coins/repository/coins_repository.c.dart
@@ -63,8 +63,11 @@ class CoinsRepository {
   /// If the [coins] list is not provided, all coins will be returned.
   Future<List<Coin>> getCoins([Iterable<String>? coinIds]) => _coinsDao.get(coinIds);
 
-  Future<List<Coin>> getCoinsBySymbolGroup(String symbolGroup) =>
-      _coinsDao.getBySymbolGroup(symbolGroup);
+  Future<List<Coin>> getCoinsByFilters({
+    String? symbolGroup,
+    String? symbol,
+  }) =>
+      _coinsDao.getByFilters(symbolGroup: symbolGroup, symbol: symbol);
 
   int? getLastSyncTime() => _localStorage.getInt(_lastSyncTimeKey);
 

--- a/lib/app/features/wallets/domain/coins/coins_service.c.dart
+++ b/lib/app/features/wallets/domain/coins/coins_service.c.dart
@@ -25,9 +25,12 @@ class CoinsService {
     return _coinsRepository.watchCoins(coinIds).map((coins) => coins.map(CoinData.fromDB));
   }
 
-  Future<Iterable<CoinData>> getCoinsBySymbolGroup(String symbolGroup) async {
+  Future<Iterable<CoinData>> getCoinsByFilters({
+    String? symbolGroup,
+    String? symbol,
+  }) async {
     return _coinsRepository
-        .getCoinsBySymbolGroup(symbolGroup)
+        .getCoinsByFilters(symbolGroup: symbolGroup, symbol: symbol)
         .then((result) => result.map(CoinData.fromDB));
   }
 }

--- a/lib/app/features/wallets/domain/wallet_views/wallet_views_service.c.dart
+++ b/lib/app/features/wallets/domain/wallet_views/wallet_views_service.c.dart
@@ -24,7 +24,7 @@ part 'wallet_views_service.c.g.dart';
 Future<WalletViewsService> walletViewsService(Ref ref) async {
   return WalletViewsService(
     await ref.watch(ionIdentityClientProvider.future),
-    await ref.watch(walletsProvider.future),
+    await ref.watch(walletsNotifierProvider.future),
     await ref.watch(mainWalletProvider.future),
   );
 }

--- a/lib/app/features/wallets/model/network.dart
+++ b/lib/app/features/wallets/model/network.dart
@@ -4,6 +4,7 @@ import 'package:ion/generated/assets.gen.dart';
 
 enum Network {
   ion,
+  ionTestnet,
   algorand,
   algorandTestnet,
   aptos,
@@ -53,6 +54,7 @@ enum Network {
 
   static const Map<Network, String> _serverNames = {
     Network.ion: 'ION',
+    Network.ionTestnet: 'IONTestnet',
     Network.algorand: 'Algorand',
     Network.algorandTestnet: 'AlgorandTestnet',
     Network.aptos: 'Aptos',
@@ -103,7 +105,7 @@ enum Network {
 
   String get svgIconAsset {
     return switch (this) {
-      Network.ion => Assets.svg.networks.walletIce,
+      Network.ion || Network.ionTestnet => Assets.svg.networks.walletIce,
       Network.algorand || Network.algorandTestnet => Assets.svg.networks.walletAlgorand,
       Network.aptos || Network.aptosTetnet => Assets.svg.networks.walletAptos,
       Network.arbitrumOne || Network.arbitrumSepolia => Assets.svg.networks.walletArbitrumone,

--- a/lib/app/features/wallets/providers/coins_by_filters_provider.c.dart
+++ b/lib/app/features/wallets/providers/coins_by_filters_provider.c.dart
@@ -7,15 +7,21 @@ import 'package:ion/app/features/wallets/model/coin_in_wallet_data.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'coins_by_symbol_group_provider.c.g.dart';
+part 'coins_by_filters_provider.c.g.dart';
 
 @riverpod
-Future<List<CoinInWalletData>> coinsBySymbolGroup(
+Future<List<CoinInWalletData>> coinsByFilters(
   Ref ref, {
-  required String symbolGroup,
+  String? symbolGroup,
+  String? symbol,
 }) async {
+  assert(
+    symbolGroup != null || symbol != null,
+    'Either symbolGroup or symbol must be provided.',
+  );
+
   final service = await ref.watch(coinsServiceProvider.future);
-  final allCoins = await service.getCoinsBySymbolGroup(symbolGroup);
+  final allCoins = await service.getCoinsByFilters(symbolGroup: symbolGroup, symbol: symbol);
   final walletViewCoins =
       await ref.watch(currentWalletViewDataProvider.future).then((walletView) => walletView.coins);
   final result = <CoinInWalletData>[];

--- a/lib/app/features/wallets/providers/coins_by_filters_provider.c.dart
+++ b/lib/app/features/wallets/providers/coins_by_filters_provider.c.dart
@@ -17,7 +17,7 @@ Future<List<CoinInWalletData>> coinsByFilters(
 }) async {
   assert(
     symbolGroup != null || symbol != null,
-    'Either symbolGroup or symbol must be provided.',
+    'At least one of symbolGroup or symbol must be provided.',
   );
 
   final service = await ref.watch(coinsServiceProvider.future);

--- a/lib/app/features/wallets/providers/nfts_provider.c.dart
+++ b/lib/app/features/wallets/providers/nfts_provider.c.dart
@@ -4,8 +4,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/wallets/model/network_type.dart';
 import 'package:ion/app/features/wallets/model/nft_data.c.dart';
-import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
-import 'package:ion/app/services/ion_identity/ion_identity_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'nfts_provider.c.g.dart';
@@ -16,34 +14,31 @@ Future<List<NftData>> nftsData(Ref ref) async {
   if (currentUser == null) {
     return [];
   }
-  final currentWalletId = await ref.watch(currentWalletViewIdProvider.future);
+  // TODO: Not implemented
+  // final currentWalletId = await ref.watch(currentWalletViewIdProvider.future);
+  // final ionIdentity = await ref.watch(ionIdentityProvider.future);
+  // final walletNfts =
+  //     await ionIdentity(username: currentUser).wallets.getWalletNfts(currentWalletId);
 
-  final ionIdentity = await ref.watch(ionIdentityProvider.future);
-  final walletNfts =
-      await ionIdentity(username: currentUser).wallets.getWalletNfts(currentWalletId);
-
-  final coins = [
-    // ignore: unused_local_variable
-    for (final (index, nft) in walletNfts.nfts.indexed)
-      // TODO: get actual NFT data
-      const NftData(
-        collectionName: 'COLLECTION NULL',
-        identifier: 0,
-        price: 0,
-        currency: 'CURRENCY NULL',
-        iconUrl: 'ICONURL NULL',
-        networkType: NetworkType.all,
-        currencyIconUrl: 'CURRENCYICONURL NULL',
-        description: 'DESCRIPTION NULL',
-        network: 'NETWORK NULL',
-        tokenStandard: 'TOKENSTANDARD NULL',
-        contractAddress: 'CONTRACTADDRESS NULL',
-        rank: 0,
-        asset: 'ASSET NULL',
-      ),
-  ];
-
-  return coins;
+  final nfts = List.generate(
+    5,
+    (_) => const NftData(
+      collectionName: 'COLLECTION NULL',
+      identifier: 0,
+      price: 0,
+      currency: 'CURRENCY NULL',
+      iconUrl: 'ICONURL NULL',
+      networkType: NetworkType.all,
+      currencyIconUrl: 'CURRENCYICONURL NULL',
+      description: 'DESCRIPTION NULL',
+      network: 'NETWORK NULL',
+      tokenStandard: 'TOKENSTANDARD NULL',
+      contractAddress: 'CONTRACTADDRESS NULL',
+      rank: 0,
+      asset: 'ASSET NULL',
+    ),
+  );
+  return nfts;
 }
 
 @riverpod

--- a/lib/app/features/wallets/views/pages/coins_flow/network_list/network_list_view.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/network_list/network_list_view.dart
@@ -9,7 +9,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/model/coin_data.c.dart';
 import 'package:ion/app/features/wallets/model/coin_in_wallet_data.c.dart';
 import 'package:ion/app/features/wallets/model/network.dart';
-import 'package:ion/app/features/wallets/providers/coins_by_symbol_group_provider.c.dart';
+import 'package:ion/app/features/wallets/providers/coins_by_filters_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/coins_flow/network_list/network_item.dart';
 import 'package:ion/app/features/wallets/views/pages/coins_flow/receive_coins/providers/receive_coins_form_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
@@ -32,7 +32,12 @@ class NetworkListView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final coinsGroup = ref.watch(receiveCoinsFormControllerProvider).selectedCoin!;
-    final coinsState = ref.watch(coinsBySymbolGroupProvider(symbolGroup: coinsGroup.symbolGroup));
+    final coinsState = ref.watch(
+      coinsByFiltersProvider(
+        symbol: coinsGroup.abbreviation,
+        symbolGroup: coinsGroup.symbolGroup,
+      ),
+    );
 
     void onTap(Network network) {
       if (onSelectReturnType) {

--- a/lib/app/features/wallets/views/pages/coins_flow/receive_coins/providers/wallet_address_notifier_provider.c.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/receive_coins/providers/wallet_address_notifier_provider.c.dart
@@ -32,11 +32,11 @@ class WalletAddressNotifier extends _$WalletAddressNotifier {
         walletViewId: walletView.id,
         onVerifyIdentity: onVerifyIdentity,
       );
+
+      await ref.read(walletsNotifierProvider.notifier).addWallet(result);
+
       walletAddress = result.address;
     });
-
-    // TODO: Improve the walletsProvider to be able to add a wallet to the already loaded list.
-    ref.invalidate(walletsProvider);
 
     return walletAddress;
   }
@@ -53,7 +53,7 @@ class WalletAddressNotifier extends _$WalletAddressNotifier {
 
     // Attempt to get address from existed wallets
     if (address == null && coin?.walletId != null) {
-      final wallets = await ref.read(walletsProvider.future);
+      final wallets = await ref.read(walletsNotifierProvider.future);
       address = wallets.firstWhereOrNull((wallet) => wallet.id == coin?.walletId)?.address;
     }
 


### PR DESCRIPTION
## Description
1. Replace `getCoinsBySymbolGroup` with `getCoinsByFilters` to use the different number of filters in the future.
2. Commented receive NFTs call to avoid 404 response in the logs, since we use mocked data in any way.
3. Added ION testnet to networks.
4. Refactored wallets provider, so now it can handle added wallet without reloading.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore