### PR TITLE
fix: remove onTap in toolbar send button when disabled

### DIFF
--- a/lib/app/features/feed/views/components/toolbar_buttons/toolbar_send_button.dart
+++ b/lib/app/features/feed/views/components/toolbar_buttons/toolbar_send_button.dart
@@ -20,7 +20,7 @@ class ToolbarSendButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onPressed,
+      onTap: enabled ? onPressed : null,
       child: Container(
         width: 48.0.s,
         height: 28.0.s,


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
