### PR TITLE
fix: use project's flutter version on CI/CD pipeline

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -180,6 +180,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          flutter-version-file: main-repo/pubspec.yaml
           cache: true
       - run: flutter --version
       - name: Detect context and set APP environment variables
@@ -269,6 +270,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          flutter-version-file: main-repo/pubspec.yaml
           cache: true
       - run: flutter --version
       - name: Detect context and set APP environment variables


### PR DESCRIPTION
## Description
Updates GitHub Actions workflow to use flutter version from pubspec.yaml file for consistent versioning across CI/CD pipeline.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
