### PR TITLE
fix: send funds network selection

### DIFF
--- a/lib/app/features/user/pages/profile_page/pages/request_coins_form_modal/request_coins_form_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/request_coins_form_modal/request_coins_form_modal.dart
@@ -25,13 +25,13 @@ import 'package:ion/generated/assets.gen.dart';
 class RequestCoinsFormModal extends HookConsumerWidget {
   const RequestCoinsFormModal({
     required this.pubkey,
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.networkType,
     super.key,
   });
 
   final String pubkey;
-  final String coinId;
+  final String coinAbbreviation;
   final NetworkType networkType;
 
   @override
@@ -41,7 +41,7 @@ class RequestCoinsFormModal extends HookConsumerWidget {
     final locale = context.i18n;
 
     final selectedNetworkType = useState(networkType);
-    final selectedCoinId = useState(coinId);
+    final selectedCoinAbbreviation = useState(coinAbbreviation);
     final amountController = useTextEditingController(text: '');
     useListenable(amountController);
 
@@ -69,15 +69,15 @@ class RequestCoinsFormModal extends HookConsumerWidget {
                   child: Column(
                     children: [
                       CoinIdButton(
-                        coinId: selectedCoinId.value,
+                        coinId: selectedCoinAbbreviation.value,
                         onTap: () async {
-                          final newCoinId = await SelectCoinRoute(
+                          final newCoinAbbreviation = await SelectCoinRoute(
                             paymentType: PaymentType.receive,
                             pubkey: pubkey,
                             selectCoinModalType: SelectCoinModalType.update,
                           ).push<String>(context);
-                          if (newCoinId != null && context.mounted) {
-                            selectedCoinId.value = newCoinId;
+                          if (newCoinAbbreviation != null && context.mounted) {
+                            selectedCoinAbbreviation.value = newCoinAbbreviation;
                           }
                         },
                       ),
@@ -88,7 +88,7 @@ class RequestCoinsFormModal extends HookConsumerWidget {
                           final newNetworkType = await SelectNetworkRoute(
                             paymentType: PaymentType.receive,
                             pubkey: pubkey,
-                            coinId: selectedCoinId.value,
+                            coinAbbreviation: selectedCoinAbbreviation.value,
                             selectNetworkModalType: SelectNetworkModalType.update,
                           ).push<NetworkType>(context);
                           if (newNetworkType != null && context.mounted) {
@@ -103,7 +103,7 @@ class RequestCoinsFormModal extends HookConsumerWidget {
                       SizedBox(height: 16.0.s),
                       CoinAmountInput(
                         controller: amountController,
-                        coinId: selectedCoinId.value,
+                        coinAbbreviation: selectedCoinAbbreviation.value,
                         showApproximateInUsd: false,
                         showMaxAction: false,
                       ),

--- a/lib/app/features/user/pages/profile_page/pages/select_coin_modal/select_coin_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/select_coin_modal/select_coin_modal.dart
@@ -42,7 +42,7 @@ class SelectCoinModal extends ConsumerWidget {
               SelectNetworkRoute(
                 paymentType: paymentType,
                 pubkey: pubkey,
-                coinId: group.abbreviation,
+                coinAbbreviation: group.abbreviation,
                 selectNetworkModalType: SelectNetworkModalType.select,
               ).replace(context);
             case SelectCoinModalType.update:

--- a/lib/app/features/user/pages/profile_page/pages/select_network_modal/select_network_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/select_network_modal/select_network_modal.dart
@@ -19,14 +19,14 @@ class SelectNetworkModal extends StatelessWidget {
   const SelectNetworkModal({
     required this.pubkey,
     required this.type,
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.paymentType,
     super.key,
   });
 
   final String pubkey;
   final SelectNetworkModalType type;
-  final String coinId;
+  final String coinAbbreviation;
   final PaymentType paymentType;
 
   @override
@@ -40,13 +40,13 @@ class SelectNetworkModal extends StatelessWidget {
                 case PaymentType.send:
                   SendCoinsFormRoute(
                     pubkey: pubkey,
-                    coinId: coinId,
+                    coinAbbreviation: coinAbbreviation,
                     networkType: networkType,
                   ).replace(context);
                 case PaymentType.receive:
                   RequestCoinsFormRoute(
                     pubkey: pubkey,
-                    coinId: coinId,
+                    coinId: coinAbbreviation,
                     networkType: networkType,
                   ).replace(context);
               }
@@ -54,7 +54,7 @@ class SelectNetworkModal extends StatelessWidget {
               context.pop(networkType);
           }
         },
-        coinId: coinId,
+        coinAbbreviation: coinAbbreviation,
         title: context.i18n.wallet_choose_network,
       ),
       backgroundColor: context.theme.appColors.secondaryBackground,

--- a/lib/app/features/user/pages/profile_page/pages/send_coins_form_modal/send_coin_form_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/send_coins_form_modal/send_coin_form_modal.dart
@@ -26,13 +26,13 @@ import 'package:ion/generated/assets.gen.dart';
 class SendCoinFormModal extends HookConsumerWidget {
   const SendCoinFormModal({
     required this.pubkey,
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.networkType,
     super.key,
   });
 
   final String pubkey;
-  final String coinId;
+  final String coinAbbreviation;
   final NetworkType networkType;
 
   @override
@@ -42,7 +42,7 @@ class SendCoinFormModal extends HookConsumerWidget {
     final locale = context.i18n;
 
     final selectedNetworkType = useState(networkType);
-    final selectedCoinId = useState(coinId);
+    final selectedCoinAbbreviation = useState(coinAbbreviation);
     final arrivalTimeInMinutes = useState(0);
 
     final amountController = useTextEditingController(text: '');
@@ -72,15 +72,15 @@ class SendCoinFormModal extends HookConsumerWidget {
                   child: Column(
                     children: [
                       CoinIdButton(
-                        coinId: selectedCoinId.value,
+                        coinId: selectedCoinAbbreviation.value,
                         onTap: () async {
-                          final newCoinId = await SelectCoinRoute(
+                          final newCoinAbbreviation = await SelectCoinRoute(
                             paymentType: PaymentType.send,
                             pubkey: pubkey,
                             selectCoinModalType: SelectCoinModalType.update,
                           ).push<String>(context);
-                          if (newCoinId != null && context.mounted) {
-                            selectedCoinId.value = newCoinId;
+                          if (newCoinAbbreviation != null && context.mounted) {
+                            selectedCoinAbbreviation.value = newCoinAbbreviation;
                           }
                         },
                       ),
@@ -91,7 +91,7 @@ class SendCoinFormModal extends HookConsumerWidget {
                           final newNetworkType = await SelectNetworkRoute(
                             paymentType: PaymentType.send,
                             pubkey: pubkey,
-                            coinId: selectedCoinId.value,
+                            coinAbbreviation: selectedCoinAbbreviation.value,
                             selectNetworkModalType: SelectNetworkModalType.update,
                           ).push<NetworkType>(context);
                           if (newNetworkType != null && context.mounted) {
@@ -106,7 +106,7 @@ class SendCoinFormModal extends HookConsumerWidget {
                       SizedBox(height: 16.0.s),
                       CoinAmountInput(
                         controller: amountController,
-                        coinId: selectedCoinId.value,
+                        coinAbbreviation: selectedCoinAbbreviation.value,
                       ),
                       SizedBox(height: 16.0.s),
                       ArrivalTimeSelector(

--- a/lib/app/features/wallets/providers/coins_provider.c.dart
+++ b/lib/app/features/wallets/providers/coins_provider.c.dart
@@ -20,12 +20,15 @@ Future<List<CoinsGroup>> coinsInWallet(Ref ref) async {
 }
 
 @riverpod
-Future<CoinInWalletData?> coinInWalletById(Ref ref, {required String coinId}) async {
+Future<CoinInWalletData?> coinInWalletByAbbreviation(
+  Ref ref, {
+  required String coinAbbreviation,
+}) async {
   // TODO (1) Recheck this provider. Looks like nullability here is extra.
   final coinGroups = await ref.watch(coinsInWalletProvider.future);
   for (final group in coinGroups) {
     for (final coin in group.coins) {
-      if (coin.coin.id == coinId) {
+      if (coin.coin.abbreviation == coinAbbreviation) {
         return coin;
       }
     }

--- a/lib/app/features/wallets/views/components/coin_networks_list/coin_network_item.dart
+++ b/lib/app/features/wallets/views/components/coin_networks_list/coin_network_item.dart
@@ -4,24 +4,29 @@ part of 'coin_networks_list_view.dart';
 
 class _CoinNetworkItem extends ConsumerWidget {
   const _CoinNetworkItem({
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.networkType,
     required this.onTap,
   });
 
-  final String coinId;
+  final String coinAbbreviation;
   final NetworkType networkType;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final coinDataResult = ref.watch(coinInWalletByIdProvider(coinId: coinId));
+    final coinDataResult =
+        ref.watch(coinInWalletByAbbreviationProvider(coinAbbreviation: coinAbbreviation));
     final isBalanceVisible = ref.watch(isBalanceVisibleSelectorProvider);
 
     return coinDataResult.maybeWhen(
       data: (coinInWallet) {
-        // TODO: Check nullability
-        final coinData = coinInWallet!.coin;
+        if (coinInWallet == null) {
+          return ItemLoadingState(
+            itemHeight: 60.0.s,
+          );
+        }
+        final coinData = coinInWallet.coin;
         return ListItem(
           title: Row(
             children: [

--- a/lib/app/features/wallets/views/components/coin_networks_list/coin_networks_list_view.dart
+++ b/lib/app/features/wallets/views/components/coin_networks_list/coin_networks_list_view.dart
@@ -20,13 +20,13 @@ part 'coin_network_item.dart';
 class CoinNetworksListView extends StatelessWidget {
   const CoinNetworksListView({
     required this.onItemTap,
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.title,
     super.key,
   });
 
   final void Function(NetworkType networkType) onItemTap;
-  final String coinId;
+  final String coinAbbreviation;
   final String title;
 
   static final List<NetworkType> networkTypeValues =
@@ -56,7 +56,7 @@ class CoinNetworksListView extends StatelessWidget {
           itemBuilder: (BuildContext context, int index) {
             return ScreenSideOffset.small(
               child: _CoinNetworkItem(
-                coinId: coinId,
+                coinAbbreviation: coinAbbreviation,
                 networkType: networkTypeValues[index],
                 onTap: () => onItemTap(networkTypeValues[index]),
               ),

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -13,7 +13,7 @@ import 'package:ion/app/utils/validators.dart';
 class CoinAmountInput extends ConsumerWidget {
   const CoinAmountInput({
     required this.controller,
-    required this.coinId,
+    required this.coinAbbreviation,
     this.showMaxAction = true,
     this.showApproximateInUsd = true,
     super.key,
@@ -22,7 +22,7 @@ class CoinAmountInput extends ConsumerWidget {
   final TextEditingController controller;
   final bool showMaxAction;
   final bool showApproximateInUsd;
-  final String coinId;
+  final String coinAbbreviation;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -31,7 +31,9 @@ class CoinAmountInput extends ConsumerWidget {
     final locale = context.i18n;
 
     final walletBalance = ref.watch(currentWalletViewDataProvider).valueOrNull?.usdBalance;
-    final coinInWallet = ref.watch(coinInWalletByIdProvider(coinId: coinId)).valueOrNull;
+    final coinInWallet = ref
+        .watch(coinInWalletByAbbreviationProvider(coinAbbreviation: coinAbbreviation))
+        .valueOrNull;
 
     return Column(
       children: [

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_id_button.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_id_button.dart
@@ -19,7 +19,7 @@ class CoinIdButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final coinDataResult = ref.watch(coinInWalletByIdProvider(coinId: coinId));
+    final coinDataResult = ref.watch(coinInWalletByAbbreviationProvider(coinAbbreviation: coinId));
 
     return coinDataResult.maybeWhen(
       data: (coinInWallet) => CoinButton(

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -88,7 +88,7 @@ class SendCoinsForm extends HookConsumerWidget {
                     SizedBox(height: 12.0.s),
                     CoinAmountInput(
                       controller: amountController,
-                      coinId: formController.selectedCoin!.coin.abbreviation,
+                      coinAbbreviation: formController.selectedCoin!.coin.abbreviation,
                       showApproximateInUsd: false,
                     ),
                     SizedBox(height: 17.0.s),

--- a/lib/app/router/profile_routes.dart
+++ b/lib/app/router/profile_routes.dart
@@ -103,13 +103,13 @@ class SelectCoinRoute extends BaseRouteData {
 class SelectNetworkRoute extends BaseRouteData {
   SelectNetworkRoute({
     required this.paymentType,
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.pubkey,
     required this.selectNetworkModalType,
   }) : super(
           child: SelectNetworkModal(
             pubkey: pubkey,
-            coinId: coinId,
+            coinAbbreviation: coinAbbreviation,
             paymentType: paymentType,
             type: selectNetworkModalType,
           ),
@@ -117,7 +117,7 @@ class SelectNetworkRoute extends BaseRouteData {
         );
 
   final PaymentType paymentType;
-  final String coinId;
+  final String coinAbbreviation;
   final String pubkey;
   final SelectNetworkModalType selectNetworkModalType;
 }
@@ -125,19 +125,19 @@ class SelectNetworkRoute extends BaseRouteData {
 class SendCoinsFormRoute extends BaseRouteData {
   SendCoinsFormRoute({
     required this.networkType,
-    required this.coinId,
+    required this.coinAbbreviation,
     required this.pubkey,
   }) : super(
           child: SendCoinFormModal(
             pubkey: pubkey,
-            coinId: coinId,
+            coinAbbreviation: coinAbbreviation,
             networkType: networkType,
           ),
           type: IceRouteType.bottomSheet,
         );
 
   final NetworkType networkType;
-  final String coinId;
+  final String coinAbbreviation;
   final String pubkey;
 }
 
@@ -149,7 +149,7 @@ class RequestCoinsFormRoute extends BaseRouteData {
   }) : super(
           child: RequestCoinsFormModal(
             pubkey: pubkey,
-            coinId: coinId,
+            coinAbbreviation: coinId,
             networkType: networkType,
           ),
           type: IceRouteType.bottomSheet,


### PR DESCRIPTION
## Description
This PR fixes an issue for a dialog `SelectNetworkModal`.

What was the issue: `coinInWalletByIdProvider(ref, coinId)` actually looked for a coin by _abbreviation_, not _id_.
The main fix is in the `coins_provider.c.dart`. All other code is just a renaming to make it look more consistent.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
