### PR TITLE
fix: chat text field issues

### DIFF
--- a/lib/app/features/chat/e2ee/views/components/one_to_one_messages_list.dart
+++ b/lib/app/features/chat/e2ee/views/components/one_to_one_messages_list.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
@@ -8,7 +9,7 @@ import 'package:ion/app/features/chat/views/components/message_items/chat_date_h
 import 'package:ion/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 
-class OneToOneMessageList extends ConsumerWidget {
+class OneToOneMessageList extends HookConsumerWidget {
   const OneToOneMessageList(
     this.messages, {
     super.key,
@@ -20,10 +21,27 @@ class OneToOneMessageList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final scrollController = useScrollController();
+
+    useEffect(
+      () {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          scrollController.animateTo(
+            scrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          );
+        });
+        return null;
+      },
+      [messages],
+    );
+
     return ColoredBox(
       color: context.theme.appColors.primaryBackground,
       child: ScreenSideOffset.small(
         child: CustomScrollView(
+          controller: scrollController,
           slivers: [
             for (final entry in messages.entries) ...[
               SliverToBoxAdapter(

--- a/lib/app/features/chat/e2ee/views/components/one_to_one_messages_list.dart
+++ b/lib/app/features/chat/e2ee/views/components/one_to_one_messages_list.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/views/components/message_items/chat_date_header_text/chat_date_header_text.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 
 class OneToOneMessageList extends HookConsumerWidget {
   const OneToOneMessageList(
@@ -23,16 +24,13 @@ class OneToOneMessageList extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final scrollController = useScrollController();
 
-    useEffect(
+    useOnInit(
       () {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          scrollController.animateTo(
-            scrollController.position.maxScrollExtent,
-            duration: const Duration(milliseconds: 300),
-            curve: Curves.easeInOut,
-          );
-        });
-        return null;
+        scrollController.animateTo(
+          scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeInOut,
+        );
       },
       [messages],
     );

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
@@ -20,22 +20,20 @@ class BottomBarInitialView extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bottomBarState = ref.watch(messagingBottomBarActiveStateProvider);
 
-    useEffect(
-      () {
-        void listener() {
-          if (controller.text.isEmpty) {
-            ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
-          } else {
+    final onTextChanged = useCallback(
+      (String text) {
+        if (controller.text.isEmpty) {
+          ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
+        } else {
+          final text = controller.text.trim();
+          if (text.isNotEmpty) {
             ref.read(messagingBottomBarActiveStateProvider.notifier).setHasText();
+          } else {
+            controller.clear();
           }
         }
-
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          controller.addListener(listener);
-        });
-        return () => controller.removeListener(listener);
       },
-      [],
+      [controller],
     );
 
     useEffect(
@@ -59,6 +57,7 @@ class BottomBarInitialView extends HookConsumerWidget {
           ),
           padding: EdgeInsets.fromLTRB(8.0.s, 8.0.s, 44.0.s, 8.0.s),
           child: Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               if (bottomBarState.isMore)
                 GestureDetector(
@@ -96,9 +95,13 @@ class BottomBarInitialView extends HookConsumerWidget {
                     color: context.theme.appColors.primaryText,
                   ),
                   onTap: () {
-                    ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
+                    if (controller.text.isEmpty) {
+                      ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
+                    }
                   },
-                  maxLines: null,
+                  onChanged: onTextChanged,
+                  maxLines: 5,
+                  minLines: 1,
                   textInputAction: TextInputAction.newline,
                   decoration: InputDecoration(
                     isDense: true,
@@ -121,17 +124,14 @@ class BottomBarInitialView extends HookConsumerWidget {
                 ),
               ),
               SizedBox(width: 6.0.s),
-              AnimatedPadding(
-                duration: const Duration(milliseconds: 200),
-                padding: bottomBarState.isHasText ? EdgeInsets.only(right: 4.0.s) : EdgeInsets.zero,
-                child: Padding(
-                  padding: EdgeInsets.all(4.0.s),
+              if (!bottomBarState.isHasText)
+                Padding(
+                  padding: EdgeInsets.fromLTRB(0.0.s, 4.0.s, 4.0.s, 4.0.s),
                   child: Assets.svg.iconCameraOpen.icon(
                     color: context.theme.appColors.primaryText,
                     size: 24.0.s,
                   ),
                 ),
-              ),
             ],
           ),
         ),

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/providers/messaging_bottom_bar_state_provider.c.dart';
 import 'package:ion/app/features/chat/views/components/message_items/messaging_bottom_bar/components/components.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class BottomBarInitialView extends HookConsumerWidget {
@@ -36,14 +37,11 @@ class BottomBarInitialView extends HookConsumerWidget {
       [controller],
     );
 
-    useEffect(
+    useOnInit(
       () {
         if (bottomBarState.isText) {
-          WidgetsBinding.instance.addPostFrameCallback((_) async {
-            controller.clear();
-          });
+          controller.clear();
         }
-        return null;
       },
       [bottomBarState.isText],
     );


### PR DESCRIPTION
## Description
- Prevent enter/space at the beginning of the message 
- After entering text and then trying to select it, it deletes everything
- the text field should extend to a maximum 5 lines, and then scroll should be available inside (like whatsapp)
- Change position of the attachment file icon

## Additional Notes
- When user send a message, scroll automatically to show it
- Hide camera icon when user type a text

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/fb5d49e0-7eaa-465a-a109-3594e628ce11

