### PR TITLE
fix: change keyboard type for identity key name

### DIFF
--- a/lib/app/features/auth/views/components/identity_key_name_input/identity_key_name_input.dart
+++ b/lib/app/features/auth/views/components/identity_key_name_input/identity_key_name_input.dart
@@ -32,7 +32,7 @@ class IdentityKeyNameInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextInput(
       isLive: true,
-      keyboardType: TextInputType.name,
+      keyboardType: TextInputType.text,
       prefixIcon: TextInputIcons(
         hasRightDivider: true,
         icons: [Assets.svg.iconIdentitykey.icon()],


### PR DESCRIPTION
## Description
Change keyboard type for identity key name field to make it possible to type symbols.

## Type of Change
- [x] Bug fix

## Screenshots 
Before:
![CleanShot 2025-02-18 at 15 28 42](https://github.com/user-attachments/assets/76553052-101a-440c-8a0f-211b39083da6)
After:
![CleanShot 2025-02-18 at 15 31 45](https://github.com/user-attachments/assets/fcb92fd7-3ad8-44de-975c-561a5bd051ee)

