### PR TITLE
fix: upgrade quill to 11, fix link popup menu popping the entire post/article create flow

### DIFF
--- a/lib/app/components/text_editor/components/custom_blocks/text_editor_code_block/text_editor_code_block.dart
+++ b/lib/app/components/text_editor/components/custom_blocks/text_editor_code_block/text_editor_code_block.dart
@@ -39,13 +39,9 @@ class TextEditorCodeBuilder extends EmbedBuilder {
   @override
   Widget build(
     BuildContext context,
-    QuillController controller,
-    Embed node,
-    bool readOnly,
-    bool inline,
-    TextStyle textStyle,
+    EmbedContext embedContext,
   ) {
-    final content = node.value.data as String? ?? '';
+    final content = embedContext.node.value.data as String? ?? '';
 
     return Container(
       padding: EdgeInsets.only(top: 12.0.s),
@@ -58,11 +54,11 @@ class TextEditorCodeBuilder extends EmbedBuilder {
       ),
       child: Column(
         children: [
-          if (!this.readOnly) const CodeBlockTypesToolbar(),
+          if (!readOnly) const CodeBlockTypesToolbar(),
           CodeBlockContent(
             content: content,
-            readOnly: this.readOnly,
-            onRemoveBlock: () => removeBlock(controller, node),
+            readOnly: readOnly,
+            onRemoveBlock: () => removeBlock(embedContext.controller, embedContext.node),
           ),
         ],
       ),

--- a/lib/app/components/text_editor/components/custom_blocks/text_editor_poll_block/text_editor_poll_block.dart
+++ b/lib/app/components/text_editor/components/custom_blocks/text_editor_poll_block/text_editor_poll_block.dart
@@ -31,17 +31,13 @@ class TextEditorPollBuilder extends EmbedBuilder {
   @override
   Widget build(
     BuildContext context,
-    QuillController controller,
-    Embed node,
-    bool readOnly,
-    bool inline,
-    TextStyle textStyle,
+    EmbedContext embedContext,
   ) {
     return Padding(
       padding: EdgeInsets.only(right: 23.0.s),
       child: Poll(
         onRemove: () {
-          removeBlock(controller, node);
+          removeBlock(embedContext.controller, embedContext.node);
         },
       ),
     );

--- a/lib/app/components/text_editor/components/custom_blocks/text_editor_separator_block/text_editor_separator_block.dart
+++ b/lib/app/components/text_editor/components/custom_blocks/text_editor_separator_block/text_editor_separator_block.dart
@@ -30,16 +30,12 @@ class TextEditorSeparatorBuilder extends EmbedBuilder {
   @override
   Widget build(
     BuildContext context,
-    QuillController controller,
-    Embed node,
-    bool readOnly,
-    bool inline,
-    TextStyle textStyle,
+    EmbedContext embedContext,
   ) {
     return TextEditorSeparator(
       readOnly: readOnly,
       onRemove: () => {
-        removeBlock(controller, node),
+        removeBlock(embedContext.controller, embedContext.node),
       },
     );
   }

--- a/lib/app/components/text_editor/components/custom_blocks/text_editor_single_image_block/text_editor_single_image_block.dart
+++ b/lib/app/components/text_editor/components/custom_blocks/text_editor_single_image_block/text_editor_single_image_block.dart
@@ -35,13 +35,9 @@ class TextEditorSingleImageBuilder extends EmbedBuilder {
   @override
   Widget build(
     BuildContext context,
-    QuillController controller,
-    Embed node,
-    bool readOnly,
-    bool inline,
-    TextStyle textStyle,
+    EmbedContext embedContext,
   ) {
-    final path = node.value.data as String;
+    final path = embedContext.node.value.data as String;
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/app/components/text_editor/hooks/use_quill_controller.dart
+++ b/lib/app/components/text_editor/hooks/use_quill_controller.dart
@@ -4,7 +4,15 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 
 QuillController useQuillController() {
-  final textEditorController = useRef(QuillController.basic());
+  final textEditorController = useRef(
+    QuillController.basic(
+      config: const QuillControllerConfig(
+        clipboardConfig: QuillClipboardConfig(
+          enableExternalRichPaste: false,
+        ),
+      ),
+    ),
+  );
 
   useEffect(() => textEditorController.value.dispose, []);
 

--- a/lib/app/components/text_editor/text_editor.dart
+++ b/lib/app/components/text_editor/text_editor.dart
@@ -66,7 +66,7 @@ class TextEditorState extends ConsumerState<TextEditor> {
     return QuillEditor.basic(
       controller: widget.controller,
       focusNode: _focusNode,
-      configurations: QuillEditorConfigurations(
+      config: QuillEditorConfig(
         embedBuilders: [
           TextEditorSingleImageBuilder(),
           TextEditorPollBuilder(

--- a/lib/app/components/text_editor/text_editor_preview.dart
+++ b/lib/app/components/text_editor/text_editor_preview.dart
@@ -44,7 +44,7 @@ class TextEditorPreview extends HookWidget {
 
     return QuillEditor.basic(
       controller: controller.value,
-      configurations: QuillEditorConfigurations(
+      config: QuillEditorConfig(
         enableSelectionToolbar: false,
         floatingCursorDisabled: true,
         showCursor: false,

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
@@ -95,7 +95,6 @@ class CreateArticleModal extends HookConsumerWidget {
                           autofocus: true,
                           textInputAction: TextInputAction.next,
                           onSubmitted: (_) {
-                            // articleState.textEditorController.editorFocusNode?.requestFocus();
                             articleState.editorFocusNotifier.value = true;
                           },
                           style: context.theme.appTextThemes.headline2.copyWith(

--- a/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/create_article_modal/create_article_modal.dart
@@ -95,7 +95,7 @@ class CreateArticleModal extends HookConsumerWidget {
                           autofocus: true,
                           textInputAction: TextInputAction.next,
                           onSubmitted: (_) {
-                            articleState.textEditorController.editorFocusNode?.requestFocus();
+                            // articleState.textEditorController.editorFocusNode?.requestFocus();
                             articleState.editorFocusNotifier.value = true;
                           },
                           style: context.theme.appTextThemes.headline2.copyWith(

--- a/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
+++ b/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
@@ -115,7 +115,7 @@ class ReplyInputField extends HookConsumerWidget {
                                   ).push<Object?>(context);
                                   if (content is Document) {
                                     textEditorController
-                                      ..setContents(content.toDelta())
+                                      ..document = content
                                       ..moveCursorToEnd();
                                   } else {
                                     _clear(

--- a/lib/app/features/feed/create_post/views/pages/create_post_modal/hooks/use_post_quill_controller.dart
+++ b/lib/app/features/feed/create_post/views/pages/create_post_modal/hooks/use_post_quill_controller.dart
@@ -23,11 +23,17 @@ QuillController? usePostQuillController(
 
   return useMemoized(
     () {
+      const defaultConfig = QuillControllerConfig(
+        clipboardConfig: QuillClipboardConfig(
+          enableExternalRichPaste: false,
+        ),
+      );
       if (content != null) {
         final document = Document.fromDelta(Delta.fromJson(jsonDecode(content) as List<dynamic>));
         return QuillController(
           document: document,
           selection: TextSelection.collapsed(offset: document.length - 1),
+          config: defaultConfig,
         );
       }
       if (modifiedEntity != null) {
@@ -37,11 +43,12 @@ QuillController? usePostQuillController(
           return QuillController(
             document: document,
             selection: TextSelection.collapsed(offset: document.length - 1),
+            config: defaultConfig,
           );
         }
         return null;
       }
-      return QuillController.basic();
+      return QuillController.basic(config: defaultConfig);
     },
     [content, modifiedEntity],
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:flutter_quill/translations.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/providers/app_locale_provider.c.dart';
 import 'package:ion/app/features/core/providers/template_provider.c.dart';

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import local_auth_darwin
 import package_info_plus
 import path_provider_foundation
 import photo_manager
+import quill_native_bridge_macos
 import screen_retriever
 import share_plus
 import shared_preferences_foundation
@@ -35,6 +36,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
+  QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1444,9 +1444,11 @@ packages:
   markdown_quill:
     dependency: "direct main"
     description:
-      path: "../markdown_quill"
-      relative: true
-    source: path
+      path: "."
+      ref: master
+      resolved-ref: "832259d48e7f37be8dc55c390a266bfb1daa25fc"
+      url: "https://github.com/ice-blockchain/markdown_quill"
+    source: git
     version: "4.2.0"
   matcher:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -884,6 +884,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  flutter_keyboard_visibility_temp_fork:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_temp_fork
+      sha256: cecc44a350a8a369efbc960bb2126386af53cb0597ca6789607cbfb88081b9f4
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   flutter_keyboard_visibility_web:
     dependency: transitive
     description:
@@ -925,10 +933,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: "90da4f3866ea4ca1b0d4055f0d3a514c7e45276b82b71a62d97389e742fe9b54"
+      sha256: "3765d057bb63e6e5b7d5aba7c8fb048ec1b38c8a3428ded8c22e57cf2682a580"
       url: "https://pub.dev"
     source: hosted
-    version: "10.7.5"
+    version: "11.0.0"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -1436,11 +1444,9 @@ packages:
   markdown_quill:
     dependency: "direct main"
     description:
-      path: "."
-      ref: master
-      resolved-ref: "8e146340a6e0e24fdf46abdfee0f677217ad46b3"
-      url: "https://github.com/ice-blockchain/markdown_quill"
-    source: git
+      path: "../markdown_quill"
+      relative: true
+    source: path
     version: "4.2.0"
   matcher:
     dependency: transitive
@@ -1898,10 +1904,66 @@ packages:
     dependency: transitive
     description:
       name: quill_native_bridge
-      sha256: "80cc180a6e5cc625c5431b61e2fbc056d36654964337f497c5990e34925844fe"
+      sha256: bda0f0ad9bc160dcdd4bd2b378a7ae8bdb55c3d4b7301bf739d5e3b065ee5e82
       url: "https://pub.dev"
     source: hosted
-    version: "10.5.16"
+    version: "11.0.0"
+  quill_native_bridge_android:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_android
+      sha256: b75c7e6ede362a7007f545118e756b1f19053994144ec9eda932ce5e54a57569
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1+2"
+  quill_native_bridge_ios:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_ios
+      sha256: d23de3cd7724d482fe2b514617f8eedc8f296e120fb297368917ac3b59d8099f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_linux:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_linux
+      sha256: "5fcc60cab2ab9079e0746941f05c5ca5fec85cc050b738c8c8b9da7c09da17eb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_macos:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_macos
+      sha256: "1c0631bd1e2eee765a8b06017c5286a4e829778f4585736e048eb67c97af8a77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_platform_interface:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_platform_interface
+      sha256: ea48bd12bf426741747ec8a575b122350971f338a75049099b349c63447582a2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1+1"
+  quill_native_bridge_web:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_web
+      sha256: e7e55047d68f1a88574c26dbe3f12988f49d07740590d8fc6280028bbde5b908
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_windows:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_windows
+      sha256: "60e50d74238f22ceb43113d9a42b6627451dab9fc27f527b979a32051cf1da45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   quiver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,9 @@ dependencies:
   lottie: ^3.1.0
   markdown: ^7.3.0
   markdown_quill:
-    path: ../markdown_quill
+    git:
+      url: https://github.com/ice-blockchain/markdown_quill
+      ref: master
   meta: ^1.15.0
   mime: ^2.0.0
   mocktail: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   flutter_keyboard_visibility: ^6.0.0
   flutter_localizations:
     sdk: flutter
-  flutter_quill: ^10.7.5
+  flutter_quill: ^11.0.0
   flutter_screenutil: ^5.9.0
   flutter_secure_storage: ^9.2.4
   flutter_svg: ^2.0.16
@@ -63,9 +63,7 @@ dependencies:
   lottie: ^3.1.0
   markdown: ^7.3.0
   markdown_quill:
-    git:
-      url: https://github.com/ice-blockchain/markdown_quill
-      ref: master
+    path: ../markdown_quill
   meta: ^1.15.0
   mime: ^2.0.0
   mocktail: ^1.0.4


### PR DESCRIPTION
## Description
This PR upgrades Quill dependency to 11.0.0 and fixes all the breaking changes, ensuring everything works.
It should be merged in addition to: https://github.com/ice-blockchain/markdown_quill/pull/1

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/2e8e0a41-0569-4680-9760-70e04a2399e4

