### PR TITLE
fix: system phone navigation is present on the chat window

### DIFF
--- a/lib/app/features/chat/community/channel/views/pages/channel_page/channel_messaging_page.dart
+++ b/lib/app/features/chat/community/channel/views/pages/channel_page/channel_messaging_page.dart
@@ -58,10 +58,6 @@ class ChannelMessagingPage extends HookConsumerWidget {
     return Scaffold(
       backgroundColor: context.theme.appColors.secondaryBackground,
       body: SafeArea(
-        minimum: EdgeInsets.only(
-          bottom: MediaQuery.paddingOf(context).bottom > 0 ? 17.0.s : 0,
-        ),
-        bottom: false,
         child: Column(
           children: [
             MessagingHeader(

--- a/lib/app/features/chat/e2ee/views/pages/group_mesages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/group_mesages_page.dart
@@ -46,10 +46,6 @@ class GroupMessagesPage extends HookConsumerWidget {
     return Scaffold(
       backgroundColor: context.theme.appColors.secondaryBackground,
       body: SafeArea(
-        minimum: EdgeInsets.only(
-          bottom: MediaQuery.of(context).padding.bottom > 0 ? 17.0.s : 0,
-        ),
-        bottom: false,
         child: Column(
           children: [
             _Header(lastMessage: lastMessage),

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -64,10 +64,6 @@ class OneToOneMessagesPage extends HookConsumerWidget {
     return Scaffold(
       backgroundColor: context.theme.appColors.secondaryBackground,
       body: SafeArea(
-        minimum: EdgeInsets.only(
-          bottom: MediaQuery.of(context).padding.bottom > 0 ? 17.0.s : 0,
-        ),
-        bottom: false,
         child: Column(
           children: [
             _Header(receiverMasterPubKey: receiverPubKey),

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/recording_overlay.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/recording_overlay.dart
@@ -28,10 +28,6 @@ class RecordingOverlay extends ConsumerWidget {
       bottom: MediaQuery.of(context).viewInsets.bottom + 8.0.s,
       right: 14.0.s,
       child: SafeArea(
-        minimum: EdgeInsets.only(
-          bottom: MediaQuery.of(context).padding.bottom > 0 ? 17.0.s : 0,
-        ),
-        bottom: false,
         child: Container(
           width: 32.0.s,
           decoration: BoxDecoration(

--- a/lib/app/features/chat/views/pages/chat_learn_more_modal/chat_learn_more_modal.dart
+++ b/lib/app/features/chat/views/pages/chat_learn_more_modal/chat_learn_more_modal.dart
@@ -16,6 +16,7 @@ class ChatLearnMoreModal extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return SheetContent(
       topPadding: 0,
+      bottomPadding: MediaQuery.paddingOf(context).bottom,
       body: Column(
         mainAxisSize: MainAxisSize.min,
         children: [


### PR DESCRIPTION
## Description
iInstead of applying a custom bottom padding based on the device’s bottom inset, the chat bar should respect the safe area and be rendered above it.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->

<img width="180" alt="image" src="https://github.com/user-attachments/assets/04975a3f-c3f4-4a0f-8be5-2369b0cc4bb9">
<img width="180" alt="image" src="https://github.com/user-attachments/assets/1ca06efd-a602-4f55-8602-60b840045aa1">

