### PR TITLE
fix: coins sync

### DIFF
--- a/lib/app/features/core/providers/init_provider.c.dart
+++ b/lib/app/features/core/providers/init_provider.c.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/services/ion_connect/ion_connect.dart';
 import 'package:ion/app/services/ion_connect/ion_connect_logger.dart';
 import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/storage/local_storage.c.dart';
+import 'package:ion/app/utils/functions.dart';
 import 'package:ion/l10n/timeago_locales.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -34,7 +35,6 @@ Future<void> initApp(Ref ref) async {
     ref.read(sharedPreferencesProvider.future),
     ref.read(appTemplateProvider.future),
     ref.read(authProvider.future),
-    ref.read(coinsSyncProvider.future),
     ref.read(permissionsProvider.notifier).checkAllPermissions(),
     ref.read(onboardingCompleteProvider.future),
   ]);
@@ -42,6 +42,10 @@ Future<void> initApp(Ref ref) async {
   await [
     ref.read(coinInitializerProvider).initialize(),
   ].wait;
+
+  // `ref.read` lets `coinsSyncProvider` be disposed even though it's a keepAlive provider
+  // so we need to listen to it to keep it alive
+  ref.listen(coinsSyncProvider, noop);
 
   registerTimeagoLocalesForEnum();
 }

--- a/lib/app/features/wallets/domain/coins/coins_sync_service.c.dart
+++ b/lib/app/features/wallets/domain/coins/coins_sync_service.c.dart
@@ -13,7 +13,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'coins_sync_service.c.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 Future<CoinsSyncService> coinsSyncService(Ref ref) async {
   return CoinsSyncService(
     ref.watch(coinsRepositoryProvider),

--- a/lib/app/features/wallets/providers/coins_sync_provider.c.dart
+++ b/lib/app/features/wallets/providers/coins_sync_provider.c.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:ui';
+
 import 'package:ion/app/extensions/bool.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/core/providers/app_lifecycle_provider.c.dart';
@@ -13,28 +14,22 @@ part 'coins_sync_provider.c.g.dart';
 class CoinsSync extends _$CoinsSync {
   @override
   Future<void> build() async {
-    final identityKeyName = ref.watch(currentIdentityKeyNameSelectorProvider);
-
-    if (identityKeyName == null) {
-      return;
-    }
-
     final authState = await ref.watch(authProvider.future);
-    final coinSyncService = await ref.watch(coinsSyncServiceProvider.future);
     final appState = ref.watch(appLifecycleProvider);
 
-    if (appState != AppLifecycleState.resumed) {
+    if (!authState.isAuthenticated || appState != AppLifecycleState.resumed) {
       return;
     }
+
+    final coinSyncService = await ref.watch(coinsSyncServiceProvider.future);
 
     if (authState.isAuthenticated.falseOrValue) {
       await coinSyncService.syncAllCoins();
       coinSyncService.startPeriodicSync();
+      ref.onDispose(coinSyncService.stopPeriodicSync);
       await coinSyncService.startActiveCoinsSyncQueue();
     } else {
       coinSyncService.removeActiveCoinsSyncQueue();
     }
-
-    ref.onDispose(coinSyncService.stopPeriodicSync);
   }
 }

--- a/lib/app/utils/functions.dart
+++ b/lib/app/utils/functions.dart
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: ice License 1.0
+
+void noop(_, __) {}


### PR DESCRIPTION
## Description
The issue was pretty complex:
- `CoinsSync` provider got disposed because it was read, not watched (changed to `ref.listen`)
- There was exception because `CoinsSync` provider was initialized at the same time as `authProvider` (moved to a later stage at `initProvider`)
- Backend changed a few things on their side too

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
