### PR TITLE
fix: enable isPostChildBlockedOrBlocking provider

### DIFF
--- a/lib/app/features/user/providers/block_list_notifier.c.dart
+++ b/lib/app/features/user/providers/block_list_notifier.c.dart
@@ -119,9 +119,7 @@ bool isPostChildBlockedOrBlocking(
     ionConnectSyncEntityProvider(eventReference: quotedEvent.eventReference),
   );
   if (quotedPost == null) return false;
-  //TODO: fix auto-dispose issue
-  // return ref.watch(isEntityBlockedOrBlockingProvider(quotedPost, cacheOnly: cacheOnly).future);
-  return false;
+  return ref.watch(isEntityBlockedOrBlockingProvider(quotedPost));
 }
 
 @riverpod


### PR DESCRIPTION
## Description
After latest changes related to making most of the providers sync, the issue previously related to blocking provider is no longer reproducable, hence the provider can be brought back to life.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
