### PR TITLE
fix: import token page issues

### DIFF
--- a/lib/app/components/inputs/text_input/components/paste_suffix_button.dart
+++ b/lib/app/components/inputs/text_input/components/paste_suffix_button.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:ion/app/extensions/extensions.dart';
 

--- a/lib/app/components/inputs/text_input/components/paste_suffix_button.dart
+++ b/lib/app/components/inputs/text_input/components/paste_suffix_button.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:ion/app/extensions/extensions.dart';
+
+class PasteSuffixButton extends StatelessWidget {
+  const PasteSuffixButton({
+    required this.onTap,
+    super.key,
+  });
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyles = context.theme.appTextThemes;
+    final colors = context.theme.appColors;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16.0.s),
+        child: Text(
+          context.i18n.common_paste,
+          style: textStyles.caption.copyWith(color: colors.primaryAccent),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/features/wallets/views/pages/import_token_page/components/import_token_form.dart
+++ b/lib/app/features/wallets/views/pages/import_token_page/components/import_token_form.dart
@@ -25,7 +25,12 @@ import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion/app/services/clipboard/clipboard.dart';
 
 class ImportTokenForm extends HookConsumerWidget {
-  const ImportTokenForm({super.key});
+  const ImportTokenForm({
+    required this.onValidationStateChanged,
+    super.key,
+  });
+
+  final ValueChanged<bool> onValidationStateChanged;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -57,6 +62,14 @@ class ImportTokenForm extends HookConsumerWidget {
       );
 
     _useListenAddressChanges(ref, tokenAddressController);
+
+    useOnInit(
+      () {
+        final isValid = selectedNetwork != null && tokenAddressController.text.isNotEmpty;
+        onValidationStateChanged(isValid);
+      },
+      [selectedNetwork, tokenAddressController.text],
+    );
 
     return Column(
       children: [

--- a/lib/app/features/wallets/views/pages/import_token_page/components/import_token_form.dart
+++ b/lib/app/features/wallets/views/pages/import_token_page/components/import_token_form.dart
@@ -84,7 +84,7 @@ class ImportTokenForm extends HookConsumerWidget {
           onTapOutside: (_) => FocusScope.of(context).unfocus(),
           suffixIcon: PasteSuffixButton(
             onTap: () async {
-              tokenAddressController.text = await pasteFromClipboard();
+              tokenAddressController.text = await getClipboardText();
               unawaited(ref.read(tokenDataNotifierProvider.notifier).fetchTokenData());
             },
           ),

--- a/lib/app/features/wallets/views/pages/import_token_page/components/token_already_exists_dialog.dart
+++ b/lib/app/features/wallets/views/pages/import_token_page/components/token_already_exists_dialog.dart
@@ -45,7 +45,7 @@ class TokenAlreadyExistsDialog extends ConsumerWidget {
               ),
               SizedBox(height: 28.0.s),
               Button(
-                label: Text(locales.button_try_again),
+                label: Text(locales.button_close),
                 onPressed: () => Navigator.pop(context),
               ),
               ScreenBottomOffset(),

--- a/lib/app/features/wallets/views/pages/import_token_page/import_token_page.dart
+++ b/lib/app/features/wallets/views/pages/import_token_page/import_token_page.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
@@ -15,14 +16,18 @@ import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-class ImportTokenPage extends ConsumerWidget {
+class ImportTokenPage extends HookConsumerWidget {
   const ImportTokenPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isFormValid = useState(false);
+
     ref
       ..displayErrors(importTokenNotifierProvider)
       ..listenSuccess(importTokenNotifierProvider, (_) => _onTokenImported(context));
+
+    final isButtonDisabled = !isFormValid.value || ref.watch(importTokenNotifierProvider).isLoading;
 
     return KeyboardVisibilityProvider(
       child: SheetContent(
@@ -36,13 +41,15 @@ class ImportTokenPage extends ConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    const Expanded(
+                    Expanded(
                       child: SingleChildScrollView(
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
-                            ImportTokenForm(),
-                            SecurityRisks(),
+                            ImportTokenForm(
+                              onValidationStateChanged: (isValid) => isFormValid.value = isValid,
+                            ),
+                            const SecurityRisks(),
                           ],
                         ),
                       ),
@@ -50,7 +57,8 @@ class ImportTokenPage extends ConsumerWidget {
                     Button(
                       onPressed: () => ref.read(importTokenNotifierProvider.notifier).importToken(),
                       label: Text(context.i18n.wallet_import_token_import_button),
-                      disabled: ref.watch(importTokenNotifierProvider).isLoading,
+                      type: isButtonDisabled ? ButtonType.disabled : ButtonType.primary,
+                      disabled: isButtonDisabled,
                       leadingIcon: Assets.svg.iconImportcoin.icon(),
                       trailingIcon: ref.watch(importTokenNotifierProvider).isLoading
                           ? const IONLoadingIndicator()

--- a/lib/app/services/clipboard/clipboard.dart
+++ b/lib/app/services/clipboard/clipboard.dart
@@ -3,3 +3,8 @@
 import 'package:flutter/services.dart';
 
 void copyToClipboard(String text) => Clipboard.setData(ClipboardData(text: text));
+
+Future<String> pasteFromClipboard() async {
+  final data = await Clipboard.getData(Clipboard.kTextPlain);
+  return data?.text ?? '';
+}

--- a/lib/app/services/clipboard/clipboard.dart
+++ b/lib/app/services/clipboard/clipboard.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 
 void copyToClipboard(String text) => Clipboard.setData(ClipboardData(text: text));
 
-Future<String> pasteFromClipboard() async {
+Future<String> getClipboardText() async {
   final data = await Clipboard.getData(Clipboard.kTextPlain);
   return data?.text ?? '';
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -383,7 +383,7 @@
   "wallet_import_token_security_risks_description": "Do not forget about security. Anyone can create a token.",
   "wallet_import_token_security_risks_learn_more": "Learn more about",
   "wallet_import_token_token_already_exists_title": "Token already exists in your wallet",
-  "wallet_import_token_token_already_exists_description": "Find and enable the display of this coin in the manage coins",
+  "wallet_import_token_token_already_exists_description": "This token is already in your wallet. Go to Manage Coins to view and manage it.",
   "wallet_import_token_token_not_found_title": "Token not found",
   "wallet_import_token_token_not_found_description": "Please verify the address",
   "sorting_price_asc": "Price: low to high",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -382,7 +382,7 @@
   "wallet_import_token_security_risks_title": "Security risks",
   "wallet_import_token_security_risks_description": "Do not forget about security. Anyone can create a token.",
   "wallet_import_token_security_risks_learn_more": "Learn more about",
-  "wallet_import_token_token_already_exists_title": "Token already exists in your wallet",
+  "wallet_import_token_token_already_exists_title": "Token already added",
   "wallet_import_token_token_already_exists_description": "This token is already in your wallet. Go to Manage Coins to view and manage it.",
   "wallet_import_token_token_not_found_title": "Token not found",
   "wallet_import_token_token_not_found_description": "Please verify the address",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -98,6 +98,7 @@
   "common_copied": "Copied",
   "common_comments": "Comments",
   "common_select_network_button_unselected": "Select network",
+  "common_paste": "Paste",
   "auth_secured_by": "Secured by",
   "auth_link_new_device_title": "Log in with new device",
   "auth_link_new_device_description": "You have logged in with a new device, to log in to the app, link your account to the new device.",


### PR DESCRIPTION
## Description
Consider reviewing this PR by commits (each commits fixes an issue)
This PR contains the following changes:
- "token already exists" dialog: changed button text, title and description
- added "paste" button for address text field
- "import" button is now disabled if the form is invalid (selectedNetwork == null || address.isEmpty)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
