### PR TITLE
feat: initiate conversation from profile page

### DIFF
--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -46,7 +46,9 @@ class ProfileActions extends ConsumerWidget {
         ),
         SizedBox(width: 8.0.s),
         ProfileAction(
-          onPressed: () {},
+          onPressed: () {
+            ConversationRoute(receiverPubKey: pubkey).push<void>(context);
+          },
           assetName: Assets.svg.iconChatOff,
         ),
         SizedBox(width: 8.0.s),


### PR DESCRIPTION
## Description
This enables users to start a conversation by clicking the chat button in the profile actions section.

## Additional Notes
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/9437daaf-ca03-4ac8-99be-3cbf58b7cc6a

