### PR TITLE
fix: stories likes

### DIFF
--- a/lib/app/features/feed/stories/providers/story_viewing_provider.c.dart
+++ b/lib/app/features/feed/stories/providers/story_viewing_provider.c.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:collection/collection.dart';
+import 'package:ion/app/features/feed/providers/counters/likes_notifier.c.dart';
 import 'package:ion/app/features/feed/stories/data/models/models.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -79,19 +81,14 @@ class StoryViewingController extends _$StoryViewingController {
   }
 
   void toggleLike(String postId) {
-    final updatedUsers = state.userStories.map((user) {
-      final updatedPosts = user.stories.map((post) {
-        if (post.id == postId) {
-          // wait for an event from post to cheсk the like's state when it's ready on the backend
-        }
-        return post;
-      }).toList();
-
-      return user.copyWith(stories: updatedPosts);
-    }).toList();
-
-    state = state.copyWith(
-      userStories: updatedUsers,
+    final userStory = state.userStories.firstWhereOrNull(
+      (user) => user.getStoryById(postId) != null,
     );
+
+    if (userStory != null) {
+      final post = userStory.getStoryById(postId)!;
+      final eventReference = post.toEventReference();
+      ref.read(likesNotifierProvider(eventReference).notifier).toggle();
+    }
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_viewer_action_buttons.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_viewer_action_buttons.dart
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/core/providers/mute_provider.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
+import 'package:ion/app/features/feed/providers/counters/like_reaction_provider.c.dart';
+import 'package:ion/app/features/feed/providers/counters/likes_notifier.c.dart';
 import 'package:ion/app/features/feed/stories/providers/story_pause_provider.c.dart';
-import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.c.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_capture/components.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -85,24 +86,29 @@ class _SoundButton extends ConsumerWidget {
               color: context.theme.appColors.onPrimaryAccent,
               size: 20.0.s,
             ),
-      onPressed: () => ref.read(globalMuteProvider.notifier).toggle(),
+      onPressed: () {
+        HapticFeedback.lightImpact();
+        ref.read(globalMuteProvider.notifier).toggle();
+      },
     );
   }
 }
 
-class _LikeButton extends HookConsumerWidget {
+class _LikeButton extends ConsumerWidget {
   const _LikeButton({required this.post});
 
   final ModifiablePostEntity post;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isLiked = useState(false);
+    final eventReference = post.toEventReference();
+    final isLiked = ref.watch(isLikedProvider(eventReference));
 
-    final icon = isLiked.value ? Assets.svg.iconVideoLikeOn : Assets.svg.iconVideoLikeOff;
-    final color = isLiked.value
-        ? context.theme.appColors.attentionRed
-        : context.theme.appColors.onPrimaryAccent;
+    final icon = isLiked ? Assets.svg.iconVideoLikeOn : Assets.svg.iconVideoLikeOff;
+    final color =
+        isLiked ? context.theme.appColors.attentionRed : context.theme.appColors.onPrimaryAccent;
+
+    ref.displayErrors(likesNotifierProvider(eventReference));
 
     return StoryControlButton(
       icon: icon.icon(
@@ -112,8 +118,8 @@ class _LikeButton extends HookConsumerWidget {
       borderRadius: 16.0.s,
       iconPadding: 8.0.s,
       onPressed: () {
-        isLiked.value = !isLiked.value;
-        ref.read(storyViewingControllerProvider.notifier).toggleLike(post.id);
+        HapticFeedback.lightImpact();
+        ref.read(likesNotifierProvider(eventReference).notifier).toggle();
       },
     );
   }

--- a/lib/app/services/file_cache/ion_cache_manager.dart
+++ b/lib/app/services/file_cache/ion_cache_manager.dart
@@ -28,7 +28,7 @@ class IONFileSystem implements FileSystem {
   final String _cacheKey;
 
   static Future<Directory> createDirectory(String key) async {
-    final baseDir = await getLibraryDirectory();
+    final baseDir = await getApplicationSupportDirectory();
     final path = p.join(baseDir.path, key);
 
     const fs = LocalFileSystem();


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
- fix handling the likes for the stories
- replace `getLibraryDirectory` method with `getApplicationSupportDirectory`, since it isn't supported on Android

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
