### PR TITLE
feat: seamless feed filter update

### DIFF
--- a/lib/app/features/feed/providers/feed_filter_relays_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_filter_relays_provider.c.dart
@@ -17,6 +17,8 @@ part 'feed_filter_relays_provider.c.g.dart';
 Future<Map<String, List<String>>> feedFilterRelays(Ref ref) async {
   final filter = ref.watch(feedCurrentFilterProvider.select((state) => state.filter));
 
+  // Use ref.read instead of ref.watch to avoid triggering data source provider which depends on this filter,
+  // preventing unnecessary feed rerenders
   switch (filter) {
     case FeedFilter.forYou:
       return ref.read(feedForYouFilterRelaysProvider.future);
@@ -30,7 +32,7 @@ Future<Map<String, List<String>>> feedForYouFilterRelays(Ref ref) async {
   final followList = await ref.watch(currentUserFollowListProvider.future);
 
   final followListRelays = followList != null
-      ? await ref.read(userRelaysManagerProvider.notifier).fetch(
+      ? await ref.watch(userRelaysManagerProvider.notifier).fetch(
             followList.pubkeys,
             actionSource: const ActionSourceCurrentUser(),
           )
@@ -52,7 +54,7 @@ Future<Map<String, List<String>>> feedFollowingFilterRelays(Ref ref) async {
   final followList = await ref.watch(currentUserFollowListProvider.future);
 
   final followListRelays = followList != null
-      ? await ref.read(userRelaysManagerProvider.notifier).fetch(
+      ? await ref.watch(userRelaysManagerProvider.notifier).fetch(
             followList.pubkeys,
             actionSource: const ActionSourceCurrentUser(),
           )

--- a/lib/app/features/feed/providers/feed_filter_relays_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_filter_relays_provider.c.dart
@@ -3,6 +3,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/feed/data/models/feed_filter.dart';
+import 'package:ion/app/features/feed/providers/feed_current_filter_provider.c.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.dart';
 import 'package:ion/app/features/user/model/user_relays.c.dart';
 import 'package:ion/app/features/user/providers/follow_list_provider.c.dart';
@@ -13,7 +14,19 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'feed_filter_relays_provider.c.g.dart';
 
 @riverpod
-Future<Map<String, List<String>>> feedFilterRelays(Ref ref, FeedFilter filter) async {
+Future<Map<String, List<String>>> feedFilterRelays(Ref ref) async {
+  final filter = ref.watch(feedCurrentFilterProvider.select((state) => state.filter));
+
+  switch (filter) {
+    case FeedFilter.forYou:
+      return ref.read(feedForYouFilterRelaysProvider.future);
+    case FeedFilter.following:
+      return ref.read(feedFollowingFilterRelaysProvider.future);
+  }
+}
+
+@riverpod
+Future<Map<String, List<String>>> feedForYouFilterRelays(Ref ref) async {
   final followList = await ref.watch(currentUserFollowListProvider.future);
 
   final followListRelays = followList != null
@@ -23,21 +36,30 @@ Future<Map<String, List<String>>> feedFilterRelays(Ref ref, FeedFilter filter) a
           )
       : <UserRelaysEntity>[];
 
-  switch (filter) {
-    case FeedFilter.forYou:
-      final userRelays = await ref.watch(currentUserRelayProvider.future);
-      if (userRelays == null) {
-        throw UserRelaysNotFoundException();
-      }
-
-      final options = {
-        for (final relays in [...followListRelays, userRelays]) relays.masterPubkey: relays.urls,
-      };
-      return findBestOptions(options);
-    case FeedFilter.following:
-      final options = {
-        for (final relays in followListRelays) relays.masterPubkey: relays.urls,
-      };
-      return findBestOptions(options);
+  final userRelays = await ref.watch(currentUserRelayProvider.future);
+  if (userRelays == null) {
+    throw UserRelaysNotFoundException();
   }
+
+  final options = {
+    for (final relays in [...followListRelays, userRelays]) relays.masterPubkey: relays.urls,
+  };
+  return findBestOptions(options);
+}
+
+@riverpod
+Future<Map<String, List<String>>> feedFollowingFilterRelays(Ref ref) async {
+  final followList = await ref.watch(currentUserFollowListProvider.future);
+
+  final followListRelays = followList != null
+      ? await ref.read(userRelaysManagerProvider.notifier).fetch(
+            followList.pubkeys,
+            actionSource: const ActionSourceCurrentUser(),
+          )
+      : <UserRelaysEntity>[];
+
+  final options = {
+    for (final relays in followListRelays) relays.masterPubkey: relays.urls,
+  };
+  return findBestOptions(options);
 }

--- a/lib/app/features/feed/providers/feed_posts_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_posts_data_source_provider.c.dart
@@ -32,7 +32,7 @@ List<EntitiesDataSource>? feedPostsDataSource(Ref ref) {
   final languageInterestSet =
       ref.watch(currentUserInterestsSetProvider(InterestSetType.languages)).valueOrNull;
   final filters = ref.watch(feedCurrentFilterProvider);
-  final filterRelays = ref.watch(feedFilterRelaysProvider(filters.filter)).valueOrNull;
+  final filterRelays = ref.watch(feedFilterRelaysProvider).valueOrNull;
   final currentPubkey = ref.watch(currentPubkeySelectorProvider);
 
   if (filterRelays != null && currentPubkey != null && languageInterestSet != null) {

--- a/lib/app/features/feed/providers/feed_stories_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_stories_data_source_provider.c.dart
@@ -3,7 +3,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
-import 'package:ion/app/features/feed/data/models/feed_filter.dart';
 import 'package:ion/app/features/feed/providers/feed_filter_relays_provider.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.dart';
@@ -17,7 +16,7 @@ part 'feed_stories_data_source_provider.c.g.dart';
 
 @riverpod
 List<EntitiesDataSource>? feedStoriesDataSource(Ref ref) {
-  final filterRelays = ref.watch(feedFilterRelaysProvider(FeedFilter.forYou)).valueOrNull;
+  final filterRelays = ref.watch(feedForYouFilterRelaysProvider).valueOrNull;
   final currentPubkey = ref.watch(currentPubkeySelectorProvider);
 
   if (filterRelays == null || currentPubkey == null) {

--- a/lib/app/features/feed/providers/feed_trending_videos_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_trending_videos_data_source_provider.c.dart
@@ -20,7 +20,7 @@ part 'feed_trending_videos_data_source_provider.c.g.dart';
 @riverpod
 List<EntitiesDataSource>? feedTrendingVideosDataSource(Ref ref) {
   final filters = ref.watch(feedCurrentFilterProvider.select((state) => state.filter));
-  final filterRelays = ref.watch(feedFilterRelaysProvider(filters)).valueOrNull;
+  final filterRelays = ref.watch(feedFilterRelaysProvider).valueOrNull;
   final currentPubkey = ref.watch(currentPubkeySelectorProvider);
 
   if (filterRelays == null || currentPubkey == null) return null;

--- a/lib/app/features/feed/providers/feed_videos_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_videos_data_source_provider.c.dart
@@ -23,7 +23,7 @@ List<EntitiesDataSource>? feedVideosDataSource(
   required EventReference eventReference,
 }) {
   final filters = ref.watch(feedCurrentFilterProvider.select((state) => state.filter));
-  final filterRelays = ref.watch(feedFilterRelaysProvider(filters)).valueOrNull;
+  final filterRelays = ref.watch(feedFilterRelaysProvider).valueOrNull;
   final until =
       ref.watch(ionConnectEntityProvider(eventReference: eventReference)).valueOrNull?.createdAt;
   final currentPubkey = ref.watch(currentPubkeySelectorProvider);

--- a/lib/app/features/feed/providers/topic_articles_data_source_provider.c.dart
+++ b/lib/app/features/feed/providers/topic_articles_data_source_provider.c.dart
@@ -21,7 +21,7 @@ part 'topic_articles_data_source_provider.c.g.dart';
 @riverpod
 List<EntitiesDataSource>? topicArticlesDataSource(Ref ref, ArticleTopic topic) {
   final filter = ref.watch(feedCurrentFilterProvider.select((state) => state.filter));
-  final filterRelays = ref.watch(feedFilterRelaysProvider(filter)).valueOrNull;
+  final filterRelays = ref.watch(feedFilterRelaysProvider).valueOrNull;
   final currentPubkey = ref.watch(currentPubkeySelectorProvider);
 
   if (filterRelays != null && currentPubkey != null) {

--- a/lib/app/features/feed/views/pages/feed_page/feed_page.dart
+++ b/lib/app/features/feed/views/pages/feed_page/feed_page.dart
@@ -81,6 +81,7 @@ class FeedPage extends HookConsumerWidget {
       ..invalidate(entitiesPagedDataProvider(ref.read(feedStoriesDataSourceProvider)))
       ..invalidate(entitiesPagedDataProvider(ref.read(feedPostsDataSourceProvider)))
       ..invalidate(entitiesPagedDataProvider(ref.read(feedTrendingVideosDataSourceProvider)))
+      // invalidate feedFilterRelaysProvider to trigger provider rebuild with new relays
       ..invalidate(feedFilterRelaysProvider);
   }
 }

--- a/lib/app/features/feed/views/pages/feed_page/feed_page.dart
+++ b/lib/app/features/feed/views/pages/feed_page/feed_page.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/features/core/model/feature_flags.dart';
 import 'package:ion/app/features/core/providers/feature_flags_provider.c.dart';
 import 'package:ion/app/features/feed/data/models/feed_category.dart';
 import 'package:ion/app/features/feed/providers/feed_current_filter_provider.c.dart';
+import 'package:ion/app/features/feed/providers/feed_filter_relays_provider.c.dart';
 import 'package:ion/app/features/feed/providers/feed_posts_data_source_provider.c.dart';
 import 'package:ion/app/features/feed/providers/feed_posts_provider.c.dart';
 import 'package:ion/app/features/feed/providers/feed_stories_data_source_provider.c.dart';
@@ -31,8 +32,7 @@ class FeedPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final feedCategory = ref.watch(feedCurrentFilterProvider.select((state) => state.category));
     final hasMorePosts =
-        ref.watch(feedPostsProvider.select((state) => (state?.hasMore).falseOrValue));
-
+        ref.watch(feedPostsProvider.select((state) => state?.hasMore)).falseOrValue;
     final showTrendingVideos = useRef(
       ref.watch(featureFlagsProvider.notifier).get(FeedFeatureFlag.showTrendingVideo),
     );
@@ -80,6 +80,7 @@ class FeedPage extends HookConsumerWidget {
     ref
       ..invalidate(entitiesPagedDataProvider(ref.read(feedStoriesDataSourceProvider)))
       ..invalidate(entitiesPagedDataProvider(ref.read(feedPostsDataSourceProvider)))
-      ..invalidate(entitiesPagedDataProvider(ref.read(feedTrendingVideosDataSourceProvider)));
+      ..invalidate(entitiesPagedDataProvider(ref.read(feedTrendingVideosDataSourceProvider)))
+      ..invalidate(feedFilterRelaysProvider);
   }
 }


### PR DESCRIPTION
## Description
Seamless feed filter update to prevent feed from re-render after follow/unfollow 
Now `feedFilterRelays` updates only after pull-to-refresh

## Additional Notes
Splitting the existing `feedFilterRelaysProvider` into three specialized providers:
- Main provider that determines which specialized provider to use
- feedForYouFilterRelaysProvider for the "For You" feed
- feedFollowingFilterRelaysProvider for the "Following" feed

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
