### PR TITLE
fix(wallet): hide create wallet button

### DIFF
--- a/lib/app/features/wallets/views/components/wallets_list.dart
+++ b/lib/app/features/wallets/views/components/wallets_list.dart
@@ -9,10 +9,12 @@ import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.d
 class WalletsList extends ConsumerWidget {
   const WalletsList({
     required this.itemBuilder,
+    this.padding,
     super.key,
   });
 
   final Widget Function(WalletViewData) itemBuilder;
+  final EdgeInsets? padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -24,7 +26,7 @@ class WalletsList extends ConsumerWidget {
     }
 
     return Padding(
-      padding: EdgeInsets.only(top: 6.0.s),
+      padding: padding ?? EdgeInsets.only(top: 6.0.s),
       child: Column(
         children: [
           for (final walletView in walletViews) itemBuilder(walletView),

--- a/lib/app/features/wallets/views/pages/manage_wallets_modal.dart
+++ b/lib/app/features/wallets/views/pages/manage_wallets_modal.dart
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
+import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
-import 'package:ion/app/extensions/asset_gen_image.dart';
-import 'package:ion/app/extensions/build_context.dart';
-import 'package:ion/app/extensions/num.dart';
-import 'package:ion/app/extensions/theme_data.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
 import 'package:ion/app/features/wallets/views/components/manage_wallet_tile.dart';
 import 'package:ion/app/features/wallets/views/components/wallets_list.dart';
 import 'package:ion/app/router/app_routes.c.dart';
@@ -15,11 +15,16 @@ import 'package:ion/app/router/components/navigation_app_bar/navigation_close_bu
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-class ManageWalletsModal extends StatelessWidget {
+class ManageWalletsModal extends ConsumerWidget {
   const ManageWalletsModal({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final walletViews = ref.watch(walletViewsDataNotifierProvider).valueOrNull;
+
+    final walletViewsCount = walletViews?.length ?? 0;
+    final shouldShowCreateWalletButton = walletViewsCount < 2;
+
     return SheetContent(
       body: SingleChildScrollView(
         child: Column(
@@ -31,26 +36,26 @@ class ManageWalletsModal extends StatelessWidget {
                 NavigationCloseButton(),
               ],
             ),
-            SizedBox(
-              height: 9.0.s,
-            ),
-            ScreenSideOffset.small(
-              child: Button(
-                leadingIcon: Assets.svg.iconButtonAddstroke
-                    .icon(color: context.theme.appColors.onPrimaryAccent),
-                onPressed: () {
-                  CreateWalletRoute().push<void>(context);
-                },
-                label: Text(context.i18n.wallet_create_new),
-                mainAxisSize: MainAxisSize.max,
+            SizedBox(height: shouldShowCreateWalletButton ? 17.0.s : 4.0.s),
+            if (shouldShowCreateWalletButton)
+              ScreenSideOffset.small(
+                child: Button(
+                  leadingIcon: Assets.svg.iconButtonAddstroke
+                      .icon(color: context.theme.appColors.onPrimaryAccent),
+                  onPressed: () {
+                    CreateWalletRoute().push<void>(context);
+                  },
+                  label: Text(context.i18n.wallet_create_new),
+                  mainAxisSize: MainAxisSize.max,
+                ),
               ),
-            ),
             ScreenSideOffset.small(
               child: WalletsList(
+                padding: shouldShowCreateWalletButton ? null : EdgeInsets.zero,
                 itemBuilder: (walletData) => ManageWalletTile(walletViewId: walletData.id),
               ),
             ),
-            SizedBox(height: MediaQuery.paddingOf(context).bottom + 16.0.s),
+            ScreenBottomOffset(),
           ],
         ),
       ),


### PR DESCRIPTION
## Description
Hide "Create wallet" button if a user already has 2 wallest.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots 
![photo_2025-02-27_12-59-27](https://github.com/user-attachments/assets/cf0e2afc-5fd6-4327-b288-97c291d1b5b3)
![photo_2025-02-27_12-59-28](https://github.com/user-attachments/assets/59fadbf9-3b96-43be-8404-6641bb8e38f7)
