### PR TITLE
fix: filter story from post feed

### DIFF
--- a/lib/app/features/feed/providers/feed_posts_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_posts_provider.c.dart
@@ -27,7 +27,9 @@ class FeedPosts extends _$FeedPosts {
   }
 
   bool _filterEntities(IonConnectEntity entity) {
-    return entity is ModifiablePostEntity && entity.data.parentEvent?.eventReference == null;
+    return entity is ModifiablePostEntity &&
+        entity.data.parentEvent?.eventReference == null &&
+        entity.data.expiration == null;
   }
 
   Future<void> loadMore() async {


### PR DESCRIPTION
## Description
Add filter to avoid showing story in feed as a post, after publish

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
