### PR TITLE
fix(wallet): create wallet with correct network value

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/receive_coins/providers/wallet_address_notifier_provider.c.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/receive_coins/providers/wallet_address_notifier_provider.c.dart
@@ -28,7 +28,7 @@ class WalletAddressNotifier extends _$WalletAddressNotifier {
       final walletView = await ref.read(currentWalletViewDataProvider.future);
 
       final result = await ionIdentity.wallets.createWallet(
-        network: network.displayName,
+        network: network.id,
         walletViewId: walletView.id,
         onVerifyIdentity: onVerifyIdentity,
       );


### PR DESCRIPTION
## Description
Fix the value to pass to `createWallet`. e.g. it has to be `BscTestnet` but we sent `BSC`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

