### PR TITLE
fix(wallet): handle 400 network fees response

### DIFF
--- a/lib/app/features/wallets/providers/network_fee_provider.c.dart
+++ b/lib/app/features/wallets/providers/network_fee_provider.c.dart
@@ -31,7 +31,12 @@ Future<NetworkFeeInformation?> networkFee(
 
   final client = await ref.read(ionIdentityClientProvider.future);
 
-  final estimateFees = await client.networks.getEstimateFees(network: network.id);
+  final estimateFees =
+      await client.networks.getEstimateFees(network: network.id).onError((error, stack) {
+    Logger.error('Cannot load fees info. $error', stackTrace: stack);
+    return ion.EstimateFee(network: network.id);
+  });
+
   final walletAssets =
       await client.wallets.getWalletAssets(walletId).then((result) => result.assets);
 

--- a/packages/ion_identity_client/lib/ion_identity.dart
+++ b/packages/ion_identity_client/lib/ion_identity.dart
@@ -16,6 +16,7 @@ export 'src/core/types/user_token.c.dart';
 export 'src/ion_identity.dart';
 export 'src/ion_identity_client.dart';
 export 'src/ion_identity_config.dart';
+export 'src/networks/services/get_estimate_fees/models/estimate_fee.c.dart';
 export 'src/networks/services/get_estimate_fees/models/network_fee.c.dart';
 export 'src/signer/dtos/assertion_request_data.c.dart';
 export 'src/signer/dtos/user_registration_challenge.c.dart';

--- a/packages/ion_identity_client/lib/src/networks/services/get_estimate_fees/data_sources/get_estimate_fees_data_source.dart
+++ b/packages/ion_identity_client/lib/src/networks/services/get_estimate_fees/data_sources/get_estimate_fees_data_source.dart
@@ -7,7 +7,6 @@ import 'package:ion_identity_client/src/core/network/network_exception.dart';
 import 'package:ion_identity_client/src/core/network/utils.dart';
 import 'package:ion_identity_client/src/core/storage/token_storage.dart';
 import 'package:ion_identity_client/src/core/types/request_headers.dart';
-import 'package:ion_identity_client/src/networks/services/get_estimate_fees/models/estimate_fee.c.dart';
 
 class GetEstimateFeesDataSource {
   const GetEstimateFeesDataSource(this._networkClient, this._tokenStorage);

--- a/packages/ion_identity_client/lib/src/networks/services/get_estimate_fees/models/estimate_fee.c.dart
+++ b/packages/ion_identity_client/lib/src/networks/services/get_estimate_fees/models/estimate_fee.c.dart
@@ -3,18 +3,18 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ion_identity_client/src/networks/services/get_estimate_fees/models/network_fee.c.dart';
 
-part 'estimate_fee.c.g.dart';
 part 'estimate_fee.c.freezed.dart';
+part 'estimate_fee.c.g.dart';
 
 @freezed
 class EstimateFee with _$EstimateFee {
   factory EstimateFee({
     required String network,
-    required int? estimatedBaseFee,
-    required String? kind,
-    required NetworkFee? fast,
-    required NetworkFee? standard,
-    required NetworkFee? slow,
+    int? estimatedBaseFee,
+    String? kind,
+    NetworkFee? fast,
+    NetworkFee? standard,
+    NetworkFee? slow,
   }) = _EstimateFee;
 
   factory EstimateFee.fromJson(Map<String, dynamic> json) => _$EstimateFeeFromJson(json);

--- a/packages/ion_identity_client/lib/src/networks/services/get_estimate_fees/models/estimate_fee.c.freezed.dart
+++ b/packages/ion_identity_client/lib/src/networks/services/get_estimate_fees/models/estimate_fee.c.freezed.dart
@@ -227,11 +227,11 @@ class __$$EstimateFeeImplCopyWithImpl<$Res>
 class _$EstimateFeeImpl implements _EstimateFee {
   _$EstimateFeeImpl(
       {required this.network,
-      required this.estimatedBaseFee,
-      required this.kind,
-      required this.fast,
-      required this.standard,
-      required this.slow});
+      this.estimatedBaseFee,
+      this.kind,
+      this.fast,
+      this.standard,
+      this.slow});
 
   factory _$EstimateFeeImpl.fromJson(Map<String, dynamic> json) =>
       _$$EstimateFeeImplFromJson(json);
@@ -293,11 +293,11 @@ class _$EstimateFeeImpl implements _EstimateFee {
 abstract class _EstimateFee implements EstimateFee {
   factory _EstimateFee(
       {required final String network,
-      required final int? estimatedBaseFee,
-      required final String? kind,
-      required final NetworkFee? fast,
-      required final NetworkFee? standard,
-      required final NetworkFee? slow}) = _$EstimateFeeImpl;
+      final int? estimatedBaseFee,
+      final String? kind,
+      final NetworkFee? fast,
+      final NetworkFee? standard,
+      final NetworkFee? slow}) = _$EstimateFeeImpl;
 
   factory _EstimateFee.fromJson(Map<String, dynamic> json) =
       _$EstimateFeeImpl.fromJson;

--- a/packages/ion_identity_client/lib/src/wallets/services/make_transfer/models/transfer.c.g.dart
+++ b/packages/ion_identity_client/lib/src/wallets/services/make_transfer/models/transfer.c.g.dart
@@ -18,23 +18,14 @@ _$NativeTokenTransferImpl _$$NativeTokenTransferImplFromJson(
     );
 
 Map<String, dynamic> _$$NativeTokenTransferImplToJson(
-    _$NativeTokenTransferImpl instance) {
-  final val = <String, dynamic>{
-    'to': instance.to,
-    'amount': instance.amount,
-    'kind': instance.kind,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('priority', instance.priority?.toJson());
-  writeNotNull('memo', instance.memo);
-  return val;
-}
+        _$NativeTokenTransferImpl instance) =>
+    <String, dynamic>{
+      'to': instance.to,
+      'amount': instance.amount,
+      'kind': instance.kind,
+      if (instance.priority?.toJson() case final value?) 'priority': value,
+      if (instance.memo case final value?) 'memo': value,
+    };
 
 const _$TransferPriorityEnumMap = {
   TransferPriority.slow: 'slow',
@@ -68,23 +59,14 @@ _$Erc20TransferImpl _$$Erc20TransferImplFromJson(Map<String, dynamic> json) =>
           $enumDecodeNullable(_$TransferPriorityEnumMap, json['priority']),
     );
 
-Map<String, dynamic> _$$Erc20TransferImplToJson(_$Erc20TransferImpl instance) {
-  final val = <String, dynamic>{
-    'contract': instance.contract,
-    'to': instance.to,
-    'amount': instance.amount,
-    'kind': instance.kind,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('priority', instance.priority?.toJson());
-  return val;
-}
+Map<String, dynamic> _$$Erc20TransferImplToJson(_$Erc20TransferImpl instance) =>
+    <String, dynamic>{
+      'contract': instance.contract,
+      'to': instance.to,
+      'amount': instance.amount,
+      'kind': instance.kind,
+      if (instance.priority?.toJson() case final value?) 'priority': value,
+    };
 
 _$Erc721TransferImpl _$$Erc721TransferImplFromJson(Map<String, dynamic> json) =>
     _$Erc721TransferImpl(
@@ -97,23 +79,14 @@ _$Erc721TransferImpl _$$Erc721TransferImplFromJson(Map<String, dynamic> json) =>
     );
 
 Map<String, dynamic> _$$Erc721TransferImplToJson(
-    _$Erc721TransferImpl instance) {
-  final val = <String, dynamic>{
-    'contract': instance.contract,
-    'to': instance.to,
-    'tokenId': instance.tokenId,
-    'kind': instance.kind,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('priority', instance.priority?.toJson());
-  return val;
-}
+        _$Erc721TransferImpl instance) =>
+    <String, dynamic>{
+      'contract': instance.contract,
+      'to': instance.to,
+      'tokenId': instance.tokenId,
+      'kind': instance.kind,
+      if (instance.priority?.toJson() case final value?) 'priority': value,
+    };
 
 _$SplTransferImpl _$$SplTransferImplFromJson(Map<String, dynamic> json) =>
     _$SplTransferImpl(
@@ -124,23 +97,15 @@ _$SplTransferImpl _$$SplTransferImplFromJson(Map<String, dynamic> json) =>
       createDestinationAccount: json['createDestinationAccount'] as bool?,
     );
 
-Map<String, dynamic> _$$SplTransferImplToJson(_$SplTransferImpl instance) {
-  final val = <String, dynamic>{
-    'mint': instance.mint,
-    'to': instance.to,
-    'amount': instance.amount,
-    'kind': instance.kind,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('createDestinationAccount', instance.createDestinationAccount);
-  return val;
-}
+Map<String, dynamic> _$$SplTransferImplToJson(_$SplTransferImpl instance) =>
+    <String, dynamic>{
+      'mint': instance.mint,
+      'to': instance.to,
+      'amount': instance.amount,
+      'kind': instance.kind,
+      if (instance.createDestinationAccount case final value?)
+        'createDestinationAccount': value,
+    };
 
 _$Spl2022TransferImpl _$$Spl2022TransferImplFromJson(
         Map<String, dynamic> json) =>
@@ -153,23 +118,15 @@ _$Spl2022TransferImpl _$$Spl2022TransferImplFromJson(
     );
 
 Map<String, dynamic> _$$Spl2022TransferImplToJson(
-    _$Spl2022TransferImpl instance) {
-  final val = <String, dynamic>{
-    'mint': instance.mint,
-    'to': instance.to,
-    'amount': instance.amount,
-    'kind': instance.kind,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('createDestinationAccount', instance.createDestinationAccount);
-  return val;
-}
+        _$Spl2022TransferImpl instance) =>
+    <String, dynamic>{
+      'mint': instance.mint,
+      'to': instance.to,
+      'amount': instance.amount,
+      'kind': instance.kind,
+      if (instance.createDestinationAccount case final value?)
+        'createDestinationAccount': value,
+    };
 
 _$Sep41TransferImpl _$$Sep41TransferImplFromJson(Map<String, dynamic> json) =>
     _$Sep41TransferImpl(
@@ -181,24 +138,15 @@ _$Sep41TransferImpl _$$Sep41TransferImplFromJson(Map<String, dynamic> json) =>
       memo: json['memo'] as String?,
     );
 
-Map<String, dynamic> _$$Sep41TransferImplToJson(_$Sep41TransferImpl instance) {
-  final val = <String, dynamic>{
-    'issuer': instance.issuer,
-    'assetCode': instance.assetCode,
-    'to': instance.to,
-    'amount': instance.amount,
-    'kind': instance.kind,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('memo', instance.memo);
-  return val;
-}
+Map<String, dynamic> _$$Sep41TransferImplToJson(_$Sep41TransferImpl instance) =>
+    <String, dynamic>{
+      'issuer': instance.issuer,
+      'assetCode': instance.assetCode,
+      'to': instance.to,
+      'amount': instance.amount,
+      'kind': instance.kind,
+      if (instance.memo case final value?) 'memo': value,
+    };
 
 _$Tep74TransferImpl _$$Tep74TransferImplFromJson(Map<String, dynamic> json) =>
     _$Tep74TransferImpl(


### PR DESCRIPTION
## Description
Currently our BE supports fees for EVM chains only, and returns 400 error for other networks. I set a default empty NetworkFee value in case of error to let the app continue the flow without fee information.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
