### PR TITLE
fix(wallet): clear address field before send coin flow

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/network_list/network_list_view.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/network_list/network_list_view.dart
@@ -62,7 +62,9 @@ class NetworkListView extends ConsumerWidget {
 
       switch (type) {
         case NetworkListViewType.send:
-          ref.read(sendAssetFormControllerProvider().notifier).setNetwork(network);
+          ref.read(sendAssetFormControllerProvider().notifier)
+            ..setNetwork(network)
+            ..setReceiverAddress('');
           CoinsSendFormRoute().push<void>(context);
         case NetworkListViewType.receive:
           ref.read(receiveCoinsFormControllerProvider.notifier).setNetwork(network);


### PR DESCRIPTION
## Description
Clear the address field before the Send form is opened. Currently this the only place we open the form. Also, I tried to `ref.invalidate` it (to reset to its initial state), but by some reason we get a `npe`.

This provider should be `keepAlive`d. And in future we gonna set the address from QR scanner before opening the form.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
