### PR TITLE
fix: add @ReferenceName annotations to resolve drift duplicate references warning

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,10 @@
 PODS:
+  - AppAuth (1.7.6):
+    - AppAuth/Core (= 1.7.6)
+    - AppAuth/ExternalUserAgent (= 1.7.6)
+  - AppAuth/Core (1.7.6)
+  - AppAuth/ExternalUserAgent (1.7.6):
+    - AppAuth/Core
   - audio_waveforms (0.0.1):
     - Flutter
   - BanubaARCloudSDK (1.40.0):
@@ -142,6 +148,24 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - google_sign_in_ios (0.0.1):
+    - AppAuth (>= 1.7.4)
+    - Flutter
+    - FlutterMacOS
+    - GoogleSignIn (~> 7.1)
+    - GTMSessionFetcher (>= 3.4.0)
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher (3.5.0):
+    - GTMSessionFetcher/Full (= 3.5.0)
+  - GTMSessionFetcher/Core (3.5.0)
+  - GTMSessionFetcher/Full (3.5.0):
+    - GTMSessionFetcher/Core
   - icloud_storage (0.0.1):
     - Flutter
   - image_cropper (0.0.4):
@@ -239,6 +263,7 @@ DEPENDENCIES:
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_keyboard_visibility_temp_fork (from `.symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - icloud_storage (from `.symlinks/plugins/icloud_storage/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
@@ -274,9 +299,13 @@ SPEC REPOS:
     - BanubaVideoEditorSDK
     - BNBLicenseUtils
   https://github.com/CocoaPods/Specs.git:
+    - AppAuth
     - DKImagePickerController
     - DKPhotoGallery
     - ffmpeg-kit-ios-full-gpl
+    - GoogleSignIn
+    - GTMAppAuth
+    - GTMSessionFetcher
     - MTBBarcodeScanner
     - OrderedSet
     - SDWebImage
@@ -324,6 +353,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  google_sign_in_ios:
+    :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   icloud_storage:
     :path: ".symlinks/plugins/icloud_storage/ios"
   image_cropper:
@@ -368,7 +399,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
-  audio_waveforms: cd736909ebc6b6a164eb74701d8c705ce3241e1c
+  AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  audio_waveforms: a6dde7fe7c0ea05f06ffbdb0f7c1b2b2ba6cedcf
   BanubaARCloudSDK: 34549c4ae8634d9e31fc80ff3f706b45b533668d
   BanubaAudioBrowserSDK: 383031135fe8be4e6cce45a77d2be89eef2bfb1c
   BanubaLicenseServicingSDK: 64a57a86b74b327cddc0412b1e348233d19e3475
@@ -378,7 +410,7 @@ SPEC CHECKSUMS:
   BanubaUtilities: 6291027414c4c1b0b9e6e304771e483514d498fd
   BanubaVideoEditorCore: b1a4e7356d5c8bcb86ac8ea4c5379aed0f7f2d64
   BanubaVideoEditorSDK: 2fb5846e999059340910f0f3148888fab388c54d
-  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
+  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
   BNBAcneEyebagsRemoval: 552d5da9993f5bc5840b3414ffb26726265bd660
   BNBBackground: cdbc07dc698d2d094cc676e0e77845e219d9e2ba
   BNBEffectPlayer: d5813b05afce282f0959e31fda877a06dbed1bce
@@ -391,47 +423,52 @@ SPEC CHECKSUMS:
   BNBSdkApi: a05a2201214e3e7f8920f645fbb98d5b8df4fe19
   BNBSdkCore: 90da0c0c1fe1f10377d4ab1e00aa701926faea17
   BNBSkin: 1f6ff9507b1e35af1469e4fc91270154149ab673
-  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  camera_avfoundation: 04b44aeb14070126c6529e5ab82cc7c9fca107cf
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  external_app_launcher: ad55ac844aa21f2d2197d7cec58ff0d0dc40bbc0
+  external_app_launcher: 3411245965270a74040a3de17e27bd02b8abb905
   ffmpeg-kit-ios-full-gpl: 80adc341962e55ef709e36baa8ed9a70cf4ea62b
-  ffmpeg_kit_flutter_full_gpl: 8d15c14c0c3aba616fac04fe44b3d27d02e3c330
-  file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
-  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
+  ffmpeg_kit_flutter_full_gpl: ce18b888487c05c46ed252cd2e7956812f2e3bd1
+  file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
+  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
-  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
-  flutter_keyboard_visibility_temp_fork: 8a8809c4129e31d25fca77446e0f3fd548122ced
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  icloud_storage: d9ac7a33ced81df08ba7ea1bf3099cc0ee58f60a
-  image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  ion_screenshot_detector: bd85296e1347b5bf5acf71407a6d9b7933bfe604
-  local_auth_crypto: 3ee858ca5d40c9da56dcd1fe8d814e92438a9371
-  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
+  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
+  flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  google_sign_in_ios: 19297361f2c51d7d8ac0201b866ef1fa5d1f94a8
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  icloud_storage: e55639f0c0d7cb2b0ba9c0b3d5968ccca9cd9aa2
+  image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  ion_screenshot_detector: 6981b7ec0add023ce57337882e28dc4b80caad4b
+  local_auth_crypto: 0f489ce05f51504fc091a53ce357e98313696085
+  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
-  passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
-  qr_code_scanner_plus: 3bfe4deb7f28996a63a2a580819d49dae80d5ed3
-  quill_native_bridge_ios: 2b01d585fcc73d0f5eed78c0bd244ee564b06f5a
+  package_info_plus: 566e1b7a2f3900e4b0020914ad3fc051dcc95596
+  passkeys_ios: 939d7d44f825048c8dffd4644f52444164c80ecd
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  photo_manager: d2fbcc0f2d82458700ee6256a15018210a81d413
+  qr_code_scanner_plus: 7e087021bc69873140e0754750eb87d867bed755
+  quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SecureBiometricSwift: f8a373c07fb46c9ca1b2b53be51a485d2828a3d8
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
+  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite: c35dad70033b8862124f8337cc994a809fcd9fa3
   sqlite3: 7559e33dae4c78538df563795af3a86fc887ee71
-  sqlite3_flutter_libs: 1b4e98da20ebd4e9b1240269b78cdcf492dbe9f3
+  sqlite3_flutter_libs: f0b59f6bb2a18597d0796558725007e5a7428397
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  ua_client_hints: 3b617011e47bea4b1ea65647efa12860b7280ad5
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
+  ua_client_hints: ef4ddde0e2b2be5f0731a31721c4cbbb889b1aa4
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
 
 PODFILE CHECKSUM: 25c66a7d639279b0967a8613f67ad18d1c1c196e
 

--- a/lib/app/features/chat/model/database/tables/reaction_table.dart
+++ b/lib/app/features/chat/model/database/tables/reaction_table.dart
@@ -3,8 +3,12 @@
 part of '../chat_database.c.dart';
 
 class ReactionTable extends Table {
+  @ReferenceName('reactionEventRef')
   late final id = text().references(EventMessageTable, #id)();
+
+  @ReferenceName('reactionSourceMessageRef')
   late final kind14Id = text().references(EventMessageTable, #id)();
+
   late final content = text()();
   late final masterPubkey = text()();
   late final isDeleted = boolean().withDefault(const Constant(false))();

--- a/packages/ion_identity_client/pubspec.yaml
+++ b/packages/ion_identity_client/pubspec.yaml
@@ -46,7 +46,6 @@ dev_dependencies:
   json_serializable: ^6.8.0
   very_good_analysis: ^6.0.0
 
-flutter:
 
 dependency_overrides:
   js: ^0.7.1


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

Added `@ReferenceName` annotations to resolve Drift duplicate references warning in `ReactionTable`. This fixes the issue where Drift couldn't generate proper filtering and sorting methods due to multiple references to the same table ([doc](https://drift.simonbinder.eu/dart_api/manager/#name-clashes)):

```
[WARNING] drift_dev on lib/app/features/chat/model/database/chat_database.c.dart:
Duplicate orderings/filters detected for field "reactionTableRefs" on table "$EventMessageTableTable". Filter and orderings for this field wont be generated. Use the @ReferenceName() annotation to resolve this issue. See https://drift.simonbinder.eu/docs/manager/#name-clashes for more information
[WARNING] drift_dev on lib/app/features/chat/model/database/chat_database.c.dart:
Duplicate orderings/filters detected for field "reactionTableRefs" on table "$EventMessageTableTable". Filter and orderings for this field wont be generated. Use the @ReferenceName() annotation to resolve this issue. See https://drift.simonbinder.eu/docs/manager/#name-clashes for more information
```

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
