### PR TITLE
fix(wallet): make `TransactionDetails.networkFeeOption` nullable

### DIFF
--- a/lib/app/features/wallets/model/transaction_details.c.dart
+++ b/lib/app/features/wallets/model/transaction_details.c.dart
@@ -22,7 +22,7 @@ class TransactionDetails with _$TransactionDetails {
     required String receiverAddress,
     required String? receiverPubkey,
     // TODO: Most likely will be replaced with more flexible model to cover case with receive transactions.
-    required NetworkFeeOption networkFeeOption,
+    required NetworkFeeOption? networkFeeOption,
     // TODO: Recheck these fields. We don't have them for the receive transactions.
     required TransferStatus status,
     required DateTime dateRequested,

--- a/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
@@ -68,7 +68,7 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
         receiverAddress: form.receiverAddress,
         receiverPubkey: form.contactPubkey,
         type: TransactionType.send,
-        networkFeeOption: form.selectedNetworkFeeOption!,
+        networkFeeOption: form.selectedNetworkFeeOption,
       );
     });
   }

--- a/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
+++ b/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
@@ -138,18 +138,19 @@ class TransactionDetailsPage extends ConsumerWidget {
                       ),
                     ),
                     SizedBox(height: 12.0.s),
-                    ListItemArrivalTime(
-                      formattedTime: transactionData.networkFeeOption.getDisplayArrivalTime(
-                        context,
+                    if (transactionData.networkFeeOption != null) ...[
+                      ListItemArrivalTime(
+                        formattedTime:
+                            transactionData.networkFeeOption!.getDisplayArrivalTime(context),
                       ),
-                    ),
-                    SizedBox(height: 12.0.s),
-                    ListItemNetworkFee(
-                      value: formatCrypto(
-                        transactionData.networkFeeOption.amount,
-                        transactionData.networkFeeOption.symbol,
+                      SizedBox(height: 12.0.s),
+                      ListItemNetworkFee(
+                        value: formatCrypto(
+                          transactionData.networkFeeOption!.amount,
+                          transactionData.networkFeeOption!.symbol,
+                        ),
                       ),
-                    ),
+                    ],
                     SizedBox(height: 15.0.s),
                     TransactionDetailsActions(
                       onViewOnExplorer: () {


### PR DESCRIPTION
## Description
There was a parsing error for `TransactionDetails.networkFeeOption`. I changed the field to be nullable.

### Changes:
- change type of `TransactionDetails.networkFeeOption`
- hide some views if `networkFeeOption` is `null`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
