### PR TITLE
fix: remove repost padding

### DIFF
--- a/lib/app/features/components/entities_list/components/repost_list_item.dart
+++ b/lib/app/features/components/entities_list/components/repost_list_item.dart
@@ -50,29 +50,19 @@ class RepostListItem extends ConsumerWidget {
             child: RepostAuthorHeader(pubkey: repostEntity.masterPubkey),
           ),
           SizedBox(height: 6.0.s),
-          Padding(
-            padding: EdgeInsetsDirectional.only(end: 16.0.s),
-            child: switch (repostEntity) {
-              RepostEntity() => Padding(
-                  padding: EdgeInsetsDirectional.only(start: 16.0.s),
-                  child: Post(
-                    eventReference: repostEntity.data.eventReference,
-                  ),
-                ),
-              GenericRepostEntity() when repostEntity.data.kind == ModifiablePostEntity.kind =>
-                Padding(
-                  padding: EdgeInsetsDirectional.only(start: 16.0.s),
-                  child: Post(
-                    eventReference: repostEntity.data.eventReference,
-                  ),
-                ),
-              GenericRepostEntity() when repostEntity.data.kind == ArticleEntity.kind => Padding(
-                  padding: EdgeInsetsDirectional.only(top: 12.0.s),
-                  child: Article(eventReference: repostEntity.data.eventReference),
-                ),
-              _ => const SizedBox.shrink(),
-            },
-          ),
+          switch (repostEntity) {
+            RepostEntity() => Post(
+                eventReference: repostEntity.data.eventReference,
+              ),
+            GenericRepostEntity() when repostEntity.data.kind == ModifiablePostEntity.kind => Post(
+                eventReference: repostEntity.data.eventReference,
+              ),
+            GenericRepostEntity() when repostEntity.data.kind == ArticleEntity.kind => Padding(
+                padding: EdgeInsetsDirectional.only(top: 12.0.s),
+                child: Article(eventReference: repostEntity.data.eventReference),
+              ),
+            _ => const SizedBox.shrink(),
+          },
         ],
       ),
     );


### PR DESCRIPTION
## Description
Align repost padding with plain post

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="240" alt="image" src="https://github.com/user-attachments/assets/dbb5539c-4b5e-4632-96cc-7d6e027dabdd">
<img width="240" alt="image" src="https://github.com/user-attachments/assets/66589090-10b4-47f3-94b8-a373b6553c96">