### PR TITLE
fix: prevent double banuba editor opening on Android camera capture

### DIFF
--- a/lib/app/features/feed/stories/views/pages/story_record_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_record_page.dart
@@ -6,6 +6,7 @@ import 'package:image_cropper/image_cropper.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_sheets.dart';
@@ -39,16 +40,18 @@ class StoryRecordPage extends HookConsumerWidget {
 
     final isCameraReady = cameraState is CameraReady;
     final cameraActionsState = ref.watch(cameraActionsControllerProvider);
-    final selectedFile = cameraActionsState.whenOrNull(saved: (file) => file);
+    final videoFile = cameraActionsState.whenOrNull(
+      saved: (file) => MediaType.fromMimeType(file.mimeType ?? '') == MediaType.video ? file : null,
+    );
 
-    if (selectedFile != null) {
+    if (videoFile != null) {
       ref
-        ..displayErrors(editMediaProvider(selectedFile))
-        ..listenSuccess(editMediaProvider(selectedFile), (filePath) async {
+        ..displayErrors(editMediaProvider(videoFile))
+        ..listenSuccess(editMediaProvider(videoFile), (filePath) async {
           if (context.mounted && filePath != null) {
             await StoryPreviewRoute(
               path: filePath,
-              mimeType: selectedFile.mimeType,
+              mimeType: videoFile.mimeType,
             ).push<void>(context);
           }
         });

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -92,7 +92,7 @@ class BanubaService {
   }
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 BanubaService banubaService(Ref ref) {
   return BanubaService(ref.watch(envProvider.notifier));
 }


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
