### PR TITLE
bugfix(chat): use original filename and extension when sharing files

### DIFF
--- a/lib/app/features/chat/e2ee/providers/chat_message_load_media_provider.c.dart
+++ b/lib/app/features/chat/e2ee/providers/chat_message_load_media_provider.c.dart
@@ -17,6 +17,7 @@ Raw<Future<File?>> chatMessageLoadMedia(
   required PrivateDirectMessageData entity,
   String? cacheKey,
   MediaAttachment? mediaAttachment,
+  bool loadThumbnail = true,
 }) async {
   if (cacheKey != null) {
     final cachedFile = await ref.watch(mediaServiceProvider).getFileFromAppDirectory(cacheKey);
@@ -31,14 +32,19 @@ Raw<Future<File?>> chatMessageLoadMedia(
     return null;
   }
 
-  // Get thumbnail from media attachments
-  final thumb = entity.media.values.firstWhere(
-    (e) => e.url == mediaAttachment.thumb,
-  );
+  final MediaAttachment mediaAttachmentToLoad;
+  if (loadThumbnail) {
+    // Get thumbnail from media attachments
+    mediaAttachmentToLoad = entity.media.values.firstWhere(
+      (e) => e.url == mediaAttachment.thumb,
+    );
+  } else {
+    mediaAttachmentToLoad = mediaAttachment;
+  }
 
   // Load encrypted thumbnail
   final encryptedMedia =
-      await ref.watch(mediaEncryptionServiceProvider).retrieveEncryptedMedia(thumb);
+      await ref.watch(mediaEncryptionServiceProvider).retrieveEncryptedMedia(mediaAttachmentToLoad);
 
   return encryptedMedia;
 }

--- a/lib/app/features/chat/views/components/message_items/message_reaction_dialog/message_reaction_dialog.dart
+++ b/lib/app/features/chat/views/components/message_items/message_reaction_dialog/message_reaction_dialog.dart
@@ -39,7 +39,7 @@ class MessageReactionDialog extends HookConsumerWidget {
           ref.read(featureFlagsProvider.notifier).get(ChatFeatureFlag.hideChatBookmark);
 
       final heightOfFailedMessageOverlayMenu = 103.0.s;
-      final heightOfSuccessMessageOverlayMenu = 184.0.s;
+      final heightOfSuccessMessageOverlayMenu = 185.0.s;
       final heightOfSuccessMessageOverlayMenuWithBookmark = 203.0.s;
 
       if (messageStatus == MessageDeliveryStatus.failed) {

--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -6,7 +6,6 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_metadata/message_metadata.dart';
-import 'package:ion/app/features/chat/views/components/message_items/message_reactions/message_reactions.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 
 class TextMessage extends ConsumerWidget {
@@ -46,6 +45,69 @@ class TextMessage extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  Widget _buildText(String message, TextStyle style) {
+    final oneLineTextPainter = TextPainter(
+      text: TextSpan(text: message, style: style),
+      textDirection: TextDirection.ltr,
+      textWidthBasis: TextWidthBasis.longestLine,
+    )..layout(maxWidth: 194.0.s);
+
+    final oneLineMetrics = oneLineTextPainter.computeLineMetrics();
+
+    if (oneLineMetrics.isEmpty) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            message,
+            style: style,
+          ),
+          MessageMetaData(eventMessage: eventMessage),
+        ],
+      );
+    }
+
+    if (oneLineMetrics.length == 1) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            message,
+            style: style,
+          ),
+          MessageMetaData(eventMessage: eventMessage),
+        ],
+      );
+    } else {
+      final multiLineTextPainter = TextPainter(
+        text: TextSpan(text: message, style: style),
+        textDirection: TextDirection.ltr,
+        textWidthBasis: TextWidthBasis.longestLine,
+      )..layout(maxWidth: 240.0.s);
+
+      final lineMetrics = multiLineTextPainter.computeLineMetrics();
+
+      final lastLineWidth = lineMetrics.last.width;
+
+      final bool wouldOverlap;
+
+      wouldOverlap = lastLineWidth > 170.0.s;
+
+      return Stack(
+        alignment: Alignment.bottomRight,
+        children: [
+          Text(
+            '$message${wouldOverlap ? '\n' : ''}',
+            style: style,
+          ),
+          MessageMetaData(eventMessage: eventMessage),
+        ],
+      );
+    }
   }
 }
 

--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -6,6 +6,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart';
 import 'package:ion/app/features/chat/views/components/message_items/message_metadata/message_metadata.dart';
+import 'package:ion/app/features/chat/views/components/message_items/message_reactions/message_reactions.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 
 class TextMessage extends ConsumerWidget {
@@ -45,69 +46,6 @@ class TextMessage extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  Widget _buildText(String message, TextStyle style) {
-    final oneLineTextPainter = TextPainter(
-      text: TextSpan(text: message, style: style),
-      textDirection: TextDirection.ltr,
-      textWidthBasis: TextWidthBasis.longestLine,
-    )..layout(maxWidth: 194.0.s);
-
-    final oneLineMetrics = oneLineTextPainter.computeLineMetrics();
-
-    if (oneLineMetrics.isEmpty) {
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Text(
-            message,
-            style: style,
-          ),
-          MessageMetaData(eventMessage: eventMessage),
-        ],
-      );
-    }
-
-    if (oneLineMetrics.length == 1) {
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Text(
-            message,
-            style: style,
-          ),
-          MessageMetaData(eventMessage: eventMessage),
-        ],
-      );
-    } else {
-      final multiLineTextPainter = TextPainter(
-        text: TextSpan(text: message, style: style),
-        textDirection: TextDirection.ltr,
-        textWidthBasis: TextWidthBasis.longestLine,
-      )..layout(maxWidth: 240.0.s);
-
-      final lineMetrics = multiLineTextPainter.computeLineMetrics();
-
-      final lastLineWidth = lineMetrics.last.width;
-
-      final bool wouldOverlap;
-
-      wouldOverlap = lastLineWidth > 170.0.s;
-
-      return Stack(
-        alignment: Alignment.bottomRight,
-        children: [
-          Text(
-            '$message${wouldOverlap ? '\n' : ''}',
-            style: style,
-          ),
-          MessageMetaData(eventMessage: eventMessage),
-        ],
-      );
-    }
   }
 }
 

--- a/lib/app/services/share/share.dart
+++ b/lib/app/services/share/share.dart
@@ -9,15 +9,18 @@ void shareContent(String text, {String? subject}) {
   Share.share(text, subject: subject);
 }
 
-void shareFile(String path, {String subject = ''}) {
+void shareFile(String path, {String name = ''}) {
   Share.shareXFiles(
     [
       XFile.fromData(
         File(path).readAsBytesSync(),
-        mimeType: lookupMimeType(path),
-        name: path,
+        mimeType: lookupMimeType(name),
+        name: name,
       ),
     ],
-    subject: subject,
+    subject: name,
+    fileNameOverrides: [
+      name,
+    ],
   );
 }


### PR DESCRIPTION
## Description
Fixes an issue where shared files did not retain their original filename and extension in chat.

## Additional Notes
 - Fix overflow issue on message reaction dialog

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
N/A
<img width="180" alt="image" src="https://github.com/user-attachments/assets/a1fd3839-2a8d-4796-b0c7-73c64458e166"> <img width="180" alt="image" src="https://github.com/user-attachments/assets/7b14b788-b4b8-416d-8857-2518b37cc7c1"> <img width="180" alt="image" src="https://github.com/user-attachments/assets/98cf28e9-52af-4e4a-ba8b-383ae9c190b7">

