### PR TITLE
fix(chat): upload multiple media fixes

### DIFF
--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_chat_media_provider.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_chat_media_provider.c.dart
@@ -14,14 +14,14 @@ import 'package:ion/app/features/ion_connect/providers/ion_connect_notifier.c.da
 import 'package:ion/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart';
 import 'package:ion/app/services/compressor/compress_service.c.dart';
 import 'package:ion/app/services/ion_connect/ed25519_key_store.dart';
+import 'package:ion/app/services/media_service/blurhash_service.c.dart';
 import 'package:ion/app/services/media_service/media_encryption_service.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
-import 'package:ion/app/utils/blurhash.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'send_chat_media_provider.c.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class SendChatMedia extends _$SendChatMedia {
   CancelableOperation<AsyncValue<List<MediaAttachment>>>? _cancellableOperation;
 
@@ -88,12 +88,12 @@ class SendChatMedia extends _$SendChatMedia {
     final isVideo = mediaFile.mimeType?.startsWith('video/') ?? false;
     final isImage = mediaFile.mimeType?.startsWith('image/') ?? false;
 
-    var blurHash = await generateBlurhash(mediaFile);
+    var blurHash = await ref.read(generateBlurhashProvider(mediaFile));
     String? thumbUrl;
 
     if (isVideo) {
       final thumbMediaFile = await ref.read(compressServiceProvider).getThumbnail(mediaFile);
-      blurHash = await generateBlurhash(thumbMediaFile);
+      blurHash = await ref.read(generateBlurhashProvider(thumbMediaFile));
       final thumbMediaAttachment = (await _processMedia(thumbMediaFile, masterPubkey)).first;
       mediaAttachments.add(thumbMediaAttachment);
       thumbUrl = thumbMediaAttachment.url;

--- a/lib/app/services/compressor/compress_service.c.dart
+++ b/lib/app/services/compressor/compress_service.c.dart
@@ -17,6 +17,7 @@ import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_preset_arg.dar
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_scale_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_video_codec_arg.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
+import 'package:ion/app/services/uuid/uuid.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -125,6 +126,9 @@ class CompressionService {
 
       final returnCode = await session.getReturnCode();
       if (!ReturnCode.isSuccess(returnCode)) {
+        final logs = await session.getAllLogsAsString();
+        final stackTrace = await session.getFailStackTrace();
+        Logger.log('Failed to compress image. Logs: $logs, StackTrace: $stackTrace');
         throw CompressImageException(returnCode);
       }
 
@@ -317,8 +321,8 @@ class CompressionService {
     final tempDir = await getApplicationCacheDirectory();
 
     // Generate a new output filename
-    final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final outputFileName = 'compressed_$timestamp.$extension';
+    final uuid = generateUuid();
+    final outputFileName = 'compressed_$uuid.$extension';
 
     // Join temp directory with the generated filename
     final outputPath = path.join(tempDir.path, outputFileName);

--- a/lib/app/services/media_service/blurhash_service.c.dart
+++ b/lib/app/services/media_service/blurhash_service.c.dart
@@ -4,11 +4,16 @@ import 'dart:io';
 
 import 'package:blurhash_ffi/blurhash.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-Future<String?> generateBlurhash(MediaFile mediaFile) async {
+part 'blurhash_service.c.g.dart';
+
+@Riverpod(keepAlive: true)
+Raw<Future<String?>> generateBlurhash(Ref ref, MediaFile mediaFile) async {
   try {
     if (mediaFile.mimeType == null) {
       return null;


### PR DESCRIPTION
## Description
- Replaced timestamp with UUID for compressed file names to prevent conflicts while work in parallel
- Moved blurhash generation to provider-based service to use already generated hash for same media
- Added detailed error logging for media compression failures
- Made SendChatMedia provider keep-alive to cancelable work as expected

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots (if applicable)
N/A
