### PR TITLE
feat(chat): Add character limit for text messages

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -408,7 +408,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  audio_waveforms: a6dde7fe7c0ea05f06ffbdb0f7c1b2b2ba6cedcf
+  audio_waveforms: cd736909ebc6b6a164eb74701d8c705ce3241e1c
   BanubaARCloudSDK: 34549c4ae8634d9e31fc80ff3f706b45b533668d
   BanubaAudioBrowserSDK: 383031135fe8be4e6cce45a77d2be89eef2bfb1c
   BanubaLicenseServicingSDK: 64a57a86b74b327cddc0412b1e348233d19e3475
@@ -418,8 +418,8 @@ SPEC CHECKSUMS:
   BanubaUtilities: 6291027414c4c1b0b9e6e304771e483514d498fd
   BanubaVideoEditorCore: b1a4e7356d5c8bcb86ac8ea4c5379aed0f7f2d64
   BanubaVideoEditorSDK: 2fb5846e999059340910f0f3148888fab388c54d
-  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
-  blurhash_ffi: 87aab623d744d4d6cd6057d285bd2258df904786
+  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
+  blurhash_ffi: 4831b96320d4273876c9a2fd3f7d50b8a3a53509
   BNBAcneEyebagsRemoval: 552d5da9993f5bc5840b3414ffb26726265bd660
   BNBBackground: cdbc07dc698d2d094cc676e0e77845e219d9e2ba
   BNBEffectPlayer: d5813b05afce282f0959e31fda877a06dbed1bce
@@ -432,52 +432,52 @@ SPEC CHECKSUMS:
   BNBSdkApi: a05a2201214e3e7f8920f645fbb98d5b8df4fe19
   BNBSdkCore: 90da0c0c1fe1f10377d4ab1e00aa701926faea17
   BNBSkin: 1f6ff9507b1e35af1469e4fc91270154149ab673
-  camera_avfoundation: 04b44aeb14070126c6529e5ab82cc7c9fca107cf
-  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
+  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
+  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  external_app_launcher: 3411245965270a74040a3de17e27bd02b8abb905
+  external_app_launcher: ad55ac844aa21f2d2197d7cec58ff0d0dc40bbc0
   ffmpeg-kit-ios-full-gpl: 78f81da9b8c14f62f5013dd90f0c9c80bd720140
-  ffmpeg_kit_flutter_full_gpl: ce18b888487c05c46ed252cd2e7956812f2e3bd1
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
-  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
+  ffmpeg_kit_flutter_full_gpl: 8d15c14c0c3aba616fac04fe44b3d27d02e3c330
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
-  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
-  flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  google_sign_in_ios: 19297361f2c51d7d8ac0201b866ef1fa5d1f94a8
+  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
+  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
+  flutter_keyboard_visibility_temp_fork: 8a8809c4129e31d25fca77446e0f3fd548122ced
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  google_sign_in_ios: 4111e87aa5e24a4404f00ea13479f35e571969cc
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  icloud_storage: e55639f0c0d7cb2b0ba9c0b3d5968ccca9cd9aa2
-  image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
-  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
-  ion_screenshot_detector: 6981b7ec0add023ce57337882e28dc4b80caad4b
-  local_auth_crypto: 0f489ce05f51504fc091a53ce357e98313696085
-  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
+  icloud_storage: d9ac7a33ced81df08ba7ea1bf3099cc0ee58f60a
+  image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  ion_screenshot_detector: bd85296e1347b5bf5acf71407a6d9b7933bfe604
+  local_auth_crypto: 3ee858ca5d40c9da56dcd1fe8d814e92438a9371
+  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: 566e1b7a2f3900e4b0020914ad3fc051dcc95596
-  passkeys_ios: 939d7d44f825048c8dffd4644f52444164c80ecd
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  photo_manager: d2fbcc0f2d82458700ee6256a15018210a81d413
-  qr_code_scanner_plus: 7e087021bc69873140e0754750eb87d867bed755
-  quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
+  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
+  passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
+  qr_code_scanner_plus: 3bfe4deb7f28996a63a2a580819d49dae80d5ed3
+  quill_native_bridge_ios: 2b01d585fcc73d0f5eed78c0bd244ee564b06f5a
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SecureBiometricSwift: f8a373c07fb46c9ca1b2b53be51a485d2828a3d8
-  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  sensors_plus: 7229095999f30740798f0eeef5cd120357a8f4f2
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   sqlite3: fc1400008a9b3525f5914ed715a5d1af0b8f4983
-  sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2
+  sqlite3_flutter_libs: 487032b9008b28de37c72a3aa66849ef3745f3e6
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  ua_client_hints: 92fe0d139619b73ec9fcb46cc7e079a26178f586
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
+  ua_client_hints: aeabd123262c087f0ce151ef96fa3ab77bfc8b38
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
 
 PODFILE CHECKSUM: 25c66a7d639279b0967a8613f67ad18d1c1c196e
 

--- a/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart
+++ b/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart
@@ -148,4 +148,6 @@ class PrivateDirectMessageData with _$PrivateDirectMessageData, EntityDataWithMe
 
     return MessageType.text;
   }
+
+  static const textMessageLimit = 4096;
 }

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/action_button.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/action_button.dart
@@ -29,7 +29,6 @@ class ActionButton extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bottomBarState = ref.watch(messagingBottomBarActiveStateProvider);
     final paddingBottom = useState<double>(0);
-
     final onSend = useCallback(() async {
       ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
       await onSubmitted?.call();
@@ -41,6 +40,7 @@ class ActionButton extends HookConsumerWidget {
         case MessagingBottomBarState.voicePaused:
           return SendButton(
             onSend: onSend,
+            disabled: onSubmitted == null,
           );
         case MessagingBottomBarState.voice:
         case MessagingBottomBarState.voiceLocked:

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
@@ -62,7 +62,9 @@ class MoreContentView extends ConsumerWidget {
               PermissionAwareWidget(
                 permissionType: Permission.photos,
                 onGranted: () async {
-                  final mediaFiles = await MediaPickerRoute().push<List<MediaFile>>(context);
+                  final mediaFiles = await MediaPickerRoute(
+                    maxSelection: 10,
+                  ).push<List<MediaFile>>(context);
                   if (mediaFiles != null && mediaFiles.isNotEmpty && context.mounted) {
                     final convertedMediaFiles = await ref
                         .read(mediaServiceProvider)

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/text_message_limit_label.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/text_message_limit_label.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/text_message_limit_label.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/text_message_limit_label.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart';
+
+class TextMessageLimitLabel extends HookWidget {
+  const TextMessageLimitLabel({
+    required this.textEditingController,
+    super.key,
+  });
+
+  final TextEditingController textEditingController;
+
+  @override
+  Widget build(BuildContext context) {
+    final exceededLimit = useState<int>(0);
+
+    useEffect(
+      () {
+        void onTextChanged() {
+          exceededLimit.value =
+              textEditingController.text.length - PrivateDirectMessageData.textMessageLimit;
+        }
+
+        textEditingController.addListener(onTextChanged);
+        return () => textEditingController.removeListener(onTextChanged);
+      },
+      [textEditingController],
+    );
+
+    if (exceededLimit.value > 0) {
+      return Positioned(
+        top: 8.0.s,
+        right: 15.0.s,
+        child: Text(
+          style: context.theme.appTextThemes.caption2.copyWith(
+            color: context.theme.appColors.attentionRed,
+          ),
+          '-$exceededLimit',
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/text_message_limit_label.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/text_message_limit_label.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart';
+import 'package:ion/app/features/chat/providers/messaging_bottom_bar_state_provider.c.dart';
 
-class TextMessageLimitLabel extends HookWidget {
+class TextMessageLimitLabel extends HookConsumerWidget {
   const TextMessageLimitLabel({
     required this.textEditingController,
     super.key,
@@ -12,7 +14,8 @@ class TextMessageLimitLabel extends HookWidget {
   final TextEditingController textEditingController;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bottomBarState = ref.watch(messagingBottomBarActiveStateProvider);
     final exceededLimit = useState<int>(0);
 
     useEffect(
@@ -28,7 +31,7 @@ class TextMessageLimitLabel extends HookWidget {
       [textEditingController],
     );
 
-    if (exceededLimit.value > 0) {
+    if (exceededLimit.value > 0 && bottomBarState.isHasText) {
       return Positioned(
         top: 8.0.s,
         right: 15.0.s,
@@ -36,7 +39,7 @@ class TextMessageLimitLabel extends HookWidget {
           style: context.theme.appTextThemes.caption2.copyWith(
             color: context.theme.appColors.attentionRed,
           ),
-          '-$exceededLimit',
+          '-${exceededLimit.value}',
         ),
       );
     }

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
@@ -135,7 +135,9 @@ class BottomBarInitialView extends HookConsumerWidget {
                 PermissionAwareWidget(
                   permissionType: Permission.photos,
                   onGranted: () async {
-                    final mediaFiles = await MediaPickerRoute().push<List<MediaFile>>(context);
+                    final mediaFiles = await MediaPickerRoute(
+                      maxSelection: 10,
+                    ).push<List<MediaFile>>(context);
                     if (mediaFiles != null && mediaFiles.isNotEmpty && context.mounted) {
                       final convertedMediaFiles = await ref
                           .read(mediaServiceProvider)


### PR DESCRIPTION
## Description
Implements a 4096 character limit for text messages with visual feedback. When users exceed the limit, a red counter shows the number of excess characters and the send button is disabled.

## Additional Notes
- Set max selection count to 10 from media picker modal

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<img width="180" alt="image" src="https://github.com/user-attachments/assets/44dd144a-b103-4479-a1ba-d62341747809">


