### PR TITLE
bugfix: add yuv420p pixel format support for video compression

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -436,11 +436,11 @@ SPEC CHECKSUMS:
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  external_app_launcher: 3411245965270a74040a3de17e27bd02b8abb905
-  ffmpeg-kit-ios-full-gpl: d8fd8d021e82787cf8fb502bcba6e258d8a35abb
-  ffmpeg_kit_flutter_full_gpl: 70e43c864657d5dc8a6568481786f635a1e375b2
-  file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
-  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
+  external_app_launcher: ad55ac844aa21f2d2197d7cec58ff0d0dc40bbc0
+  ffmpeg-kit-ios-full-gpl: 78f81da9b8c14f62f5013dd90f0c9c80bd720140
+  ffmpeg_kit_flutter_full_gpl: 8d15c14c0c3aba616fac04fe44b3d27d02e3c330
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
@@ -467,17 +467,17 @@ SPEC CHECKSUMS:
   quill_native_bridge_ios: 2b01d585fcc73d0f5eed78c0bd244ee564b06f5a
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SecureBiometricSwift: f8a373c07fb46c9ca1b2b53be51a485d2828a3d8
-  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  sqflite: c35dad70033b8862124f8337cc994a809fcd9fa3
-  sqlite3: 7559e33dae4c78538df563795af3a86fc887ee71
-  sqlite3_flutter_libs: f0b59f6bb2a18597d0796558725007e5a7428397
+  sensors_plus: 7229095999f30740798f0eeef5cd120357a8f4f2
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  sqlite3: fc1400008a9b3525f5914ed715a5d1af0b8f4983
+  sqlite3_flutter_libs: 487032b9008b28de37c72a3aa66849ef3745f3e6
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  ua_client_hints: ef4ddde0e2b2be5f0731a31721c4cbbb889b1aa4
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
+  ua_client_hints: aeabd123262c087f0ce151ef96fa3ab77bfc8b38
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
 
 PODFILE CHECKSUM: 25c66a7d639279b0967a8613f67ad18d1c1c196e
 

--- a/lib/app/services/compressor/compress_service.c.dart
+++ b/lib/app/services/compressor/compress_service.c.dart
@@ -13,6 +13,7 @@ import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_audio_bitrate_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_audio_codec_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_bitrate_arg.dart';
+import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_pixel_format_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_preset_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_scale_arg.dart';
 import 'package:ion/app/services/media_service/ffmpeg_args/ffmpeg_video_codec_arg.dart';
@@ -50,6 +51,7 @@ class CompressionService {
     int fps = 24,
     FfmpegAudioCodecArg audioCodec = FfmpegAudioCodecArg.aac,
     FfmpegAudioBitrateArg audioBitrate = FfmpegAudioBitrateArg.low,
+    FfmpegPixelFormatArg pixelFormat = FfmpegPixelFormatArg.yuv420p,
   }) async {
     try {
       final output = await _generateOutputPath(extension: 'mp4');
@@ -70,6 +72,8 @@ class CompressionService {
         audioCodec.codec,
         '-b:a',
         audioBitrate.bitrate,
+        '-pix_fmt',
+        pixelFormat.name,
         '-vf',
         'scale=-2:${scale.resolution},fps=$fps',
         output,

--- a/lib/app/services/media_service/ffmpeg_args/ffmpeg_pixel_format_arg.dart
+++ b/lib/app/services/media_service/ffmpeg_args/ffmpeg_pixel_format_arg.dart
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
+enum FfmpegPixelFormatArg {
+  yuv420p,
+}


### PR DESCRIPTION
## Description
Add YUV420P pixel format support to ensure better video compatibility across platforms and devices. This flag forces it to export in standard 8-bit format so it works on all devices.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/1f9113ce-569f-4bbe-9b22-35b98a43263b


