### PR TITLE
fix: improve chat conversation id generation to prevent duplicate conversation issue

### DIFF
--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
@@ -415,4 +415,17 @@ class SendE2eeChatMessageService {
       failedParticipantsMasterPubkeys: failedParticipantsMasterPubkeys,
     );
   }
+
+  String generateConversationId({
+    required String receiverPubkey,
+  }) {
+    final currentPubkey = ref.read(currentPubkeySelectorProvider);
+
+    if (currentPubkey == null) {
+      throw UserMasterPubkeyNotFoundException();
+    }
+
+    final sorted = [receiverPubkey, currentPubkey]..sort();
+    return sorted.join();
+  }
 }

--- a/lib/app/features/chat/e2ee/providers/send_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message_service.c.dart
@@ -6,7 +6,6 @@ import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart';
 import 'package:ion/app/features/chat/providers/exist_chat_conversation_id_provider.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
-import 'package:ion/app/services/uuid/uuid.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'send_chat_message_service.c.g.dart';
@@ -45,7 +44,10 @@ class SendChatMessageService {
 
     final existingConversationId = await getExistingConversationId(receiverPubkey);
 
-    final conversationId = existingConversationId ?? generateUuid();
+    final conversationId = existingConversationId ??
+        sendChatMessageService.generateConversationId(
+          receiverPubkey: receiverPubkey,
+        );
 
     await sendChatMessageService.sendMessage(
       conversationId: conversationId,

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -34,15 +34,15 @@ class OneToOneMessagesPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     ref.displayErrors(sendE2eeMessageServiceProvider);
 
-    final conversationId = useState<String?>(null);
-    final currentPubkey = ref.watch(currentPubkeySelectorProvider);
-
-    if (currentPubkey == null) {
-      throw UserMasterPubkeyNotFoundException();
-    }
-
     useEffect(
       () {
+        final conversationId = useState<String?>(null);
+        final currentPubkey = ref.watch(currentPubkeySelectorProvider);
+
+        if (currentPubkey == null) {
+          throw UserMasterPubkeyNotFoundException();
+        }
+
         ref.read(existChatConversationIdProvider(receiverPubKey).future).then(
           (value) {
             conversationId.value = value ??

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -51,7 +51,7 @@ class OneToOneMessagesPage extends HookConsumerWidget {
 
     final onSubmitted = useCallback(
       ({String? content, List<MediaFile>? mediaFiles}) async {
-        final currentPubkey = ref.watch(currentPubkeySelectorProvider);
+        final currentPubkey = ref.read(currentPubkeySelectorProvider);
         if (currentPubkey == null) {
           throw UserMasterPubkeyNotFoundException();
         }

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -33,16 +33,10 @@ class OneToOneMessagesPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.displayErrors(sendE2eeMessageServiceProvider);
+    final conversationId = useState<String?>(null);
 
     useEffect(
       () {
-        final conversationId = useState<String?>(null);
-        final currentPubkey = ref.watch(currentPubkeySelectorProvider);
-
-        if (currentPubkey == null) {
-          throw UserMasterPubkeyNotFoundException();
-        }
-
         ref.read(existChatConversationIdProvider(receiverPubKey).future).then(
           (value) {
             conversationId.value = value ??
@@ -57,6 +51,11 @@ class OneToOneMessagesPage extends HookConsumerWidget {
 
     final onSubmitted = useCallback(
       ({String? content, List<MediaFile>? mediaFiles}) async {
+        final currentPubkey = ref.watch(currentPubkeySelectorProvider);
+        if (currentPubkey == null) {
+          throw UserMasterPubkeyNotFoundException();
+        }
+
         final repliedMessage = ref.read(selectedMessageProvider);
 
         ref.read(selectedMessageProvider.notifier).clear();


### PR DESCRIPTION
## Description
Generate conversation IDs by combining the sorted participant master pubkeys. This ensures:
	•	Messages sent simultaneously by User A and User B are grouped in the same conversation.
	•	User B can continue receiving messages in the existing conversation even if User A reinstalls the app.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
