### PR TITLE
fix: e2ee message subscriber should not be disposed

### DIFF
--- a/lib/app/features/chat/e2ee/providers/e2ee_messages_subscriber.c.dart
+++ b/lib/app/features/chat/e2ee/providers/e2ee_messages_subscriber.c.dart
@@ -23,7 +23,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'e2ee_messages_subscriber.c.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class E2eeMessagesSubscriber extends _$E2eeMessagesSubscriber {
   @override
   Stream<void> build() async* {


### PR DESCRIPTION
## Description
Add `keepAlive` to `E2eeMessagesSubscriber` to ensure continuous message updates.  Without `keepAlive`, the subscription would be disposed when no widgets are listening


## Additional Notes
In a previous release, I listened to the `ref.dispose`, which is triggered when the user enters the conversation page.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
