### PR TITLE
fix(chat):  improve reliability of multiple media uploads

### DIFF
--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_chat_media_provider.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_chat_media_provider.c.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/features/ion_connect/providers/ion_connect_notifier.c.da
 import 'package:ion/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart';
 import 'package:ion/app/services/compressor/compress_service.c.dart';
 import 'package:ion/app/services/ion_connect/ed25519_key_store.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/blurhash_service.c.dart';
 import 'package:ion/app/services/media_service/media_encryption_service.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
@@ -41,9 +42,11 @@ class SendChatMedia extends _$SendChatMedia {
 
     _cancellableOperation = CancelableOperation.fromFuture(
       AsyncValue.guard(() async {
+        Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - COMPRESS MEDIA FILE START');
         final compressedMediaFile = await ref.read(
           compressChatMediaProvider(mediaFile),
         );
+        Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - COMPRESS MEDIA FILE END');
 
         for (final participantKey in participantsMasterPubkeys) {
           if (_cancellableOperation?.isCanceled ?? false) {
@@ -59,6 +62,10 @@ class SendChatMedia extends _$SendChatMedia {
           result.add((participantKey, processedAttachments));
         }
 
+        if (_cancellableOperation?.isCanceled ?? false) {
+          return [];
+        }
+
         return mediaAttachments;
       }),
     );
@@ -68,6 +75,10 @@ class SendChatMedia extends _$SendChatMedia {
     );
 
     state = operation!;
+
+    if (_cancellableOperation?.isCanceled ?? false) {
+      return [];
+    }
 
     return result;
   }
@@ -81,6 +92,7 @@ class SendChatMedia extends _$SendChatMedia {
     MediaFile mediaFile,
     String masterPubkey,
   ) async {
+    Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA START');
     final mediaAttachments = <MediaAttachment>[];
     final oneTimeEventSigner = await Ed25519KeyStore.generate();
     final env = ref.read(envProvider.notifier);
@@ -92,27 +104,39 @@ class SendChatMedia extends _$SendChatMedia {
     String? thumbUrl;
 
     if (isVideo) {
+      Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - THUMB START');
       final thumbMediaFile = await ref.read(compressServiceProvider).getThumbnail(mediaFile);
       blurHash = await ref.read(generateBlurhashProvider(thumbMediaFile));
       final thumbMediaAttachment = (await _processMedia(thumbMediaFile, masterPubkey)).first;
       mediaAttachments.add(thumbMediaAttachment);
       thumbUrl = thumbMediaAttachment.url;
+      Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - THUMB END');
     }
+
+    Logger.info(
+      'CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - ENCRYPT MEDIA FILE START',
+    );
 
     final encryptedMediaFile = await ref.read(mediaEncryptionServiceProvider).encryptMediaFile(
           mediaFile,
         );
+    Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - ENCRYPT MEDIA FILE END');
 
+    Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - UPLOAD MEDIA FILE START');
     final uploadResult = await ref.read(ionConnectUploadNotifierProvider.notifier).upload(
           encryptedMediaFile.mediaFile,
           alt: FileAlt.message,
           customEventSigner: oneTimeEventSigner,
         );
+    Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - UPLOAD MEDIA FILE END');
 
     if (isImage) {
       thumbUrl = uploadResult.mediaAttachment.url;
     }
 
+    Logger.info(
+      'CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - CREATE MEDIA METADATA EVENT START',
+    );
     final mediaMetadataEvent = await uploadResult.fileMetadata
         .copyWith(
       blurhash: blurHash,
@@ -137,6 +161,9 @@ class SendChatMedia extends _$SendChatMedia {
           ),
     );
 
+    Logger.info(
+      'CHAT - SEND MESSAGE - SEND MEDIA FILES - PROCESS MEDIA - CREATE MEDIA ATTACHMENT START',
+    );
     final mediaAttachment = uploadResult.mediaAttachment.copyWith(
       blurhash: blurHash,
       encryptionKey: encryptedMediaFile.secretKey,

--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
@@ -28,7 +28,6 @@ import 'package:ion/app/features/ion_connect/providers/ion_connect_notifier.c.da
 import 'package:ion/app/services/compressor/compress_service.c.dart';
 import 'package:ion/app/services/ion_connect/ion_connect_gift_wrap_service.c.dart';
 import 'package:ion/app/services/ion_connect/ion_connect_seal_service.c.dart';
-import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:ion/app/services/uuid/uuid.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -56,7 +55,6 @@ class SendE2eeChatMessageService {
     EventMessage? repliedMessage,
     List<String>? failedParticipantsMasterPubkeys,
   }) async {
-    Logger.info('CHAT - SEND MESSAGE - START');
     String? currentUserEventMessageId;
 
     try {
@@ -110,14 +108,12 @@ class SendE2eeChatMessageService {
             );
       });
 
-      Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES START');
       final mediaAttachmentsUsersBased = await _sendMediaFiles(
         mediaFiles,
         failedParticipantsMasterPubkeys ?? participantsMasterPubkeys,
         eventMessage.id,
         messageMediaIds,
       );
-      Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES END');
 
       final participantsKeysMap = await ref
           .read(conversationPubkeysProvider.notifier)
@@ -128,7 +124,6 @@ class SendE2eeChatMessageService {
         if (b == currentUserMasterPubkey) return -1;
         return a.compareTo(b);
       });
-      Logger.info('CHAT - SEND MESSAGE - SEND EVENT MESSAGE START');
 
       await Future.wait(
         participantsMasterPubkeys.map((masterPubkey) async {
@@ -181,7 +176,6 @@ class SendE2eeChatMessageService {
           }
         }),
       );
-      Logger.info('CHAT - SEND MESSAGE - SEND EVENT MESSAGE END');
     } catch (e) {
       if (currentUserEventMessageId != null) {
         for (final pubkey in participantsMasterPubkeys) {
@@ -227,8 +221,6 @@ class SendE2eeChatMessageService {
     String eventMessageId,
     List<int> messageMediaIds,
   ) async {
-    Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES -  CACHE END');
-
     final currentUserMasterPubkey = ref.read(currentPubkeySelectorProvider);
     final mediaAttachmentsUsersBased = <String, List<MediaAttachment>>{};
 
@@ -236,8 +228,6 @@ class SendE2eeChatMessageService {
       (mediaFile) async {
         final indexOfMediaFile = mediaFiles.indexOf(mediaFile);
         final id = messageMediaIds[indexOfMediaFile];
-
-        Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - SEND MEDIA FILE START $id');
 
         final sendResult = await ref
             .read(sendChatMediaProvider(id).notifier)
@@ -256,7 +246,6 @@ class SendE2eeChatMessageService {
               MessageMediaStatus.completed,
             );
 
-        Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES - SEND MEDIA FILE END $id');
         return sendResult;
       },
     ).toList();
@@ -273,7 +262,6 @@ class SendE2eeChatMessageService {
       }
     }
 
-    Logger.info('CHAT - SEND MESSAGE - SEND MEDIA FILES -END');
     return mediaAttachmentsUsersBased;
   }
 

--- a/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/features/ion_connect/model/file_alt.dart';
 import 'package:ion/app/features/ion_connect/model/file_metadata.c.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/features/ion_connect/utils/file_storage_utils.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -38,9 +39,15 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
 
     final dimension = '${file.width}x${file.height}';
 
+    Logger.info('ION CONNECT - UPLOAD - START');
+
     final url = await getFileStorageApiUrl(ref);
 
+    Logger.info('ION CONNECT - UPLOAD - GET FILE STORAGE API URL END');
+
     final fileBytes = await File(file.path).readAsBytes();
+
+    Logger.info('ION CONNECT - UPLOAD - GET FILE BYTES END');
 
     final authorizationToken = await generateAuthorizationToken(
       ref: ref,
@@ -50,6 +57,8 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
       method: 'POST',
     );
 
+    Logger.info('ION CONNECT - UPLOAD - GENERATE AUTHORIZATION TOKEN END');
+
     final response = await _makeUploadRequest(
       url: url,
       alt: alt,
@@ -58,10 +67,14 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
       authorizationToken: authorizationToken,
     );
 
+    Logger.info('ION CONNECT - UPLOAD - MAKE UPLOAD REQUEST END');
+
     final fileMetadata = FileMetadata.fromUploadResponseTags(
       response.nip94Event.tags,
       mimeType: file.mimeType,
     );
+
+    Logger.info('ION CONNECT - UPLOAD - CREATE FILE METADATA END');
 
     final mediaAttachment = MediaAttachment(
       url: fileMetadata.url,

--- a/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
@@ -14,7 +14,6 @@ import 'package:ion/app/features/ion_connect/model/file_alt.dart';
 import 'package:ion/app/features/ion_connect/model/file_metadata.c.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/features/ion_connect/utils/file_storage_utils.dart';
-import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -39,15 +38,9 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
 
     final dimension = '${file.width}x${file.height}';
 
-    Logger.info('ION CONNECT - UPLOAD - START');
-
     final url = await getFileStorageApiUrl(ref);
 
-    Logger.info('ION CONNECT - UPLOAD - GET FILE STORAGE API URL END');
-
     final fileBytes = await File(file.path).readAsBytes();
-
-    Logger.info('ION CONNECT - UPLOAD - GET FILE BYTES END');
 
     final authorizationToken = await generateAuthorizationToken(
       ref: ref,
@@ -57,8 +50,6 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
       method: 'POST',
     );
 
-    Logger.info('ION CONNECT - UPLOAD - GENERATE AUTHORIZATION TOKEN END');
-
     final response = await _makeUploadRequest(
       url: url,
       alt: alt,
@@ -67,14 +58,10 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
       authorizationToken: authorizationToken,
     );
 
-    Logger.info('ION CONNECT - UPLOAD - MAKE UPLOAD REQUEST END');
-
     final fileMetadata = FileMetadata.fromUploadResponseTags(
       response.nip94Event.tags,
       mimeType: file.mimeType,
     );
-
-    Logger.info('ION CONNECT - UPLOAD - CREATE FILE METADATA END');
 
     final mediaAttachment = MediaAttachment(
       url: fileMetadata.url,

--- a/lib/app/services/compressor/compress_service.c.dart
+++ b/lib/app/services/compressor/compress_service.c.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 
 import 'package:es_compression/brotli.dart';
 import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_session.dart';
 import 'package:ffmpeg_kit_flutter/ffprobe_kit.dart';
 import 'package:ffmpeg_kit_flutter/return_code.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2418,7 +2418,7 @@ packages:
     source: hosted
     version: "1.1.0"
   synchronized:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: synchronized
       sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,6 +111,7 @@ dependencies:
   shimmer: ^3.0.0
   smooth_sheets: ^1.0.0-f324.0.10.2
   stream_transform: ^2.1.1
+  synchronized: ^3.3.0+3
   talker_dio_logger: 4.7.1
   talker_flutter: 4.7.1
   talker_riverpod_logger: 4.7.1


### PR DESCRIPTION
## Description
- Added database transactions and synchronized FFmpeg operations for better reliability [issue](https://github.com/arthenica/ffmpeg-kit/issues/1037)
- Improved media operation cancellation handling


## Additional Notes
- Added [synchronized](https://pub.dev/packages/synchronized) package to prevent concurrent FFmpeg operations during multiple media uploads

## Type of Change
- [x] Bug fix