### PR TITLE
feat(chat): implement file upload size limit and update UI

### DIFF
--- a/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart
+++ b/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart
@@ -152,4 +152,5 @@ class PrivateDirectMessageData with _$PrivateDirectMessageData, EntityDataWithMe
   static const textMessageLimit = 4096;
   static const videoDurationLimitInSeconds = 300;
   static const audioMessageDurationLimitInSeconds = 300;
+  static const fileMessageSizeLimit = 25 * 1024 * 1024; // 25MB
 }

--- a/lib/app/features/chat/model/upload_limit_modal_type.dart
+++ b/lib/app/features/chat/model/upload_limit_modal_type.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:ion/app/extensions/extensions.dart';
 

--- a/lib/app/features/chat/model/upload_limit_modal_type.dart
+++ b/lib/app/features/chat/model/upload_limit_modal_type.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:ion/app/extensions/extensions.dart';
+
+enum UploadLimitModalType {
+  file,
+  video;
+
+  String getDescription(BuildContext context) {
+    return switch (this) {
+      UploadLimitModalType.file => context.i18n.file_upload_limit_modal_description,
+      UploadLimitModalType.video => context.i18n.video_upload_limit_modal_description,
+    };
+  }
+}

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
@@ -7,7 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart';
+import 'package:ion/app/features/chat/model/upload_limit_modal_type.dart';
 import 'package:ion/app/features/chat/providers/messaging_bottom_bar_state_provider.c.dart';
+import 'package:ion/app/features/chat/views/pages/upload_limit_reached_modal/upload_limit_reached_modal.dart';
 import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_request_sheet.dart';
@@ -121,6 +123,18 @@ class MoreContentView extends ConsumerWidget {
                   final firstFile = result?.files.first;
                   if (firstFile != null && context.mounted && firstFile.path != null) {
                     final mimeType = lookupMimeType(firstFile.path!);
+                    if (firstFile.size > PrivateDirectMessageData.fileMessageSizeLimit) {
+                      unawaited(
+                        showModalBottomSheet(
+                          context: context,
+                          builder: (context) => const UploadLimitReachedModal(
+                            type: UploadLimitModalType.file,
+                          ),
+                        ),
+                      );
+                      return;
+                    }
+
                     unawaited(
                       onSubmitted(
                         content: firstFile.name,

--- a/lib/app/features/chat/views/pages/upload_limit_reached_modal/upload_limit_reached_modal.dart
+++ b/lib/app/features/chat/views/pages/upload_limit_reached_modal/upload_limit_reached_modal.dart
@@ -6,12 +6,16 @@ import 'package:ion/app/components/card/info_card.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/model/upload_limit_modal_type.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class UploadLimitReachedModal extends StatelessWidget {
   const UploadLimitReachedModal({
+    required this.type,
     super.key,
   });
+
+  final UploadLimitModalType type;
 
   @override
   Widget build(BuildContext context) {
@@ -23,8 +27,8 @@ class UploadLimitReachedModal extends StatelessWidget {
               EdgeInsetsDirectional.only(start: 28.0.s, end: 28.0.s, top: 38.0.s, bottom: 31.0.s),
           child: InfoCard(
             iconAsset: Assets.svg.actionWalletKeyserror,
-            title: context.i18n.video_upload_limit_error_title,
-            description: context.i18n.video_upload_limit_error_description,
+            title: context.i18n.upload_limit_error_title,
+            description: type.getDescription(context),
           ),
         ),
         ScreenSideOffset.small(

--- a/lib/app/features/gallery/views/components/gallery_grid_cell.dart
+++ b/lib/app/features/gallery/views/components/gallery_grid_cell.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/model/upload_limit_modal_type.dart';
 import 'package:ion/app/features/chat/views/pages/upload_limit_reached_modal/upload_limit_reached_modal.dart';
 import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
 import 'package:ion/app/features/gallery/providers/media_selection_provider.c.dart';
@@ -132,7 +133,9 @@ class GalleryGridCell extends ConsumerWidget {
         unawaited(
           showSimpleBottomSheet<void>(
             context: context,
-            child: const UploadLimitReachedModal(),
+            child: const UploadLimitReachedModal(
+              type: UploadLimitModalType.video,
+            ),
           ),
         );
       }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -796,6 +796,7 @@
   "users_search": "ابحث أعلاه عن المستخدمين",
   "contact_wallet_not_found_title": "لم يتم العثور على المحفظة",
   "contact_wallet_not_found_description": "لا يملك محفظة في شبكة {network}",
-  "video_upload_limit_error_title": "تم الوصول إلى حد الرفع",
-  "video_upload_limit_error_description": "يمكنك رفع فيديو بمدة تصل إلى 5 دقائق"
+  "upload_limit_error_title": "تم الوصول إلى الحد الأقصى للتحميل",
+  "video_upload_limit_modal_description": "يمكنك رفع فيديو مدته تصل إلى 5 دقائق",
+  "file_upload_limit_modal_description": "يمكنك رفع ملف حجمه يصل إلى 25 ميغابايت"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -796,6 +796,7 @@
   "users_search": "Search above for users",
   "contact_wallet_not_found_title": "Wallet not found",
   "contact_wallet_not_found_description": "doesn't have a wallet in the {network} network",
-  "video_upload_limit_error_title": "Upload limit reached",
-  "video_upload_limit_error_description": "You can upload a video of up to 5 minutes"
+  "upload_limit_error_title": "Upload limit reached",
+  "video_upload_limit_modal_description": "You can upload a video of up to 5 minutes",
+  "file_upload_limit_modal_description": "You can upload a file of up to 25 megabytes"
 }


### PR DESCRIPTION
## Description
This PR implements a file upload size limit of 25MB for chat messages, similar to the existing video duration limit. It introduces a new `UploadLimitModalType` enum to handle different types of upload limits and updates the UI to show appropriate error messages when limits are reached.

## Additional Notes
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/60c54812-4e5a-4ed1-894c-f77b8cd6275e


