### PR TITLE
feat: remove muted conversations from archive unread count

### DIFF
--- a/lib/app/features/chat/model/database/dao/conversation_message_dao.c.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_message_dao.c.dart
@@ -41,7 +41,6 @@ class ConversationMessageDao extends DatabaseAccessor<ChatDatabase>
 
   Stream<int> getAllUnreadMessagesCountInArchive(
     String currentUserMasterPubkey,
-    List<String> mutedConversationIds,
   ) {
     final query = select(messageStatusTable).join([
       innerJoin(
@@ -55,8 +54,7 @@ class ConversationMessageDao extends DatabaseAccessor<ChatDatabase>
     ])
       ..where(messageStatusTable.status.equals(MessageDeliveryStatus.received.index))
       ..where(messageStatusTable.masterPubkey.equals(currentUserMasterPubkey))
-      ..where(conversationTable.isArchived.equals(true))
-      ..where(conversationTable.id.isNotIn(mutedConversationIds));
+      ..where(conversationTable.isArchived.equals(true));
 
     return query.watch().map((rows) => rows.length);
   }

--- a/lib/app/features/chat/providers/unread_message_count_provider.c.dart
+++ b/lib/app/features/chat/providers/unread_message_count_provider.c.dart
@@ -31,11 +31,9 @@ Stream<int> getAllUnreadMessagesCountInArchive(Ref ref) async* {
     throw UserMasterPubkeyNotFoundException();
   }
 
-  final mutedConversationIds = await ref.watch(mutedConversationIdsProvider.future);
-
   yield* ref
       .watch(conversationMessageDaoProvider)
-      .getAllUnreadMessagesCountInArchive(currentUserMasterPubkey, mutedConversationIds);
+      .getAllUnreadMessagesCountInArchive(currentUserMasterPubkey);
 }
 
 @riverpod

--- a/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/archive_chat_tile.dart
+++ b/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/archive_chat_tile.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/hooks/use_combined_conversation_names.dart';
 import 'package:ion/app/features/chat/model/message_type.dart';
 import 'package:ion/app/features/chat/providers/conversations_provider.c.dart';
+import 'package:ion/app/features/chat/providers/muted_conversations_provider.c.dart';
 import 'package:ion/app/features/chat/providers/unread_message_count_provider.c.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/archive_state_provider.c.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/conversations_edit_mode_provider.c.dart';
@@ -35,6 +36,15 @@ class ArchiveChatTile extends HookConsumerWidget {
               .map((c) => c.latestMessage?.createdAt ?? c.joinedAt)
               .reduce((a, b) => a.isAfter(b) ? a : b),
       [conversations],
+    );
+
+    final mutedConversationIds = ref.watch(mutedConversationIdsProvider).valueOrNull;
+    final hasMutedConversation = useMemoized(
+      () {
+        final archiveConversationIds = conversations.map((e) => e.conversationId).toList();
+        return mutedConversationIds?.any(archiveConversationIds.contains) ?? false;
+      },
+      [conversations, mutedConversationIds],
     );
 
     if (conversations.isEmpty) {
@@ -93,7 +103,10 @@ class ArchiveChatTile extends HookConsumerWidget {
                                 messageType: MessageType.text,
                               ),
                             ),
-                            UnreadCountBadge(unreadCount: unreadMessagesCount, isMuted: false),
+                            UnreadCountBadge(
+                              unreadCount: unreadMessagesCount,
+                              isMuted: hasMutedConversation,
+                            ),
                           ],
                         ),
                       ],


### PR DESCRIPTION
## Description
This PR removes the filtering of muted conversations from the archive unread message count and show badge in gray if it has any muted conversation.

## Additional Notes
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/5aa163b9-cbbb-4c54-a5b4-3aa58d0b72ac" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/7366ec25-cc91-4d14-821d-31bc6c6c98f3" />