### PR TITLE
fix: show video duration label from file metadata for a chat video message

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/visual_media_message/visual_media_content.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/visual_media_message/visual_media_content.dart
@@ -159,9 +159,9 @@ class _VideoDurationLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Positioned(
+    return PositionedDirectional(
       bottom: 5.0.s,
-      left: 5.0.s,
+      start: 5.0.s,
       child: Container(
         padding: EdgeInsetsDirectional.symmetric(horizontal: 4.0.s),
         decoration: BoxDecoration(

--- a/lib/app/features/chat/views/components/message_items/message_types/visual_media_message/visual_media_content.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/visual_media_message/visual_media_content.dart
@@ -13,6 +13,7 @@ import 'package:ion/app/features/chat/e2ee/providers/send_chat_message/send_chat
 import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/utils/date.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class VisualMediaContent extends HookConsumerWidget {
@@ -95,6 +96,8 @@ class VisualMediaContent extends HookConsumerWidget {
               ),
             ),
           ),
+        if (isVideo && mediaAttachment?.duration != null)
+          _VideoDurationLabel(duration: mediaAttachment!.duration!),
         if (messageMediaTableData.status == MessageMediaStatus.processing)
           CancelButton(
             messageMediaId: messageMediaTableData.id,
@@ -141,6 +144,35 @@ class CancelButton extends ConsumerWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VideoDurationLabel extends StatelessWidget {
+  const _VideoDurationLabel({
+    required this.duration,
+  });
+
+  final int duration;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      bottom: 5.0.s,
+      left: 5.0.s,
+      child: Container(
+        padding: EdgeInsetsDirectional.symmetric(horizontal: 4.0.s),
+        decoration: BoxDecoration(
+          color: context.theme.appColors.backgroundSheet.withValues(alpha: 0.7),
+          borderRadius: BorderRadius.circular(6.0.s),
+        ),
+        child: Text(
+          formatDuration(Duration(seconds: duration)),
+          style: context.theme.appTextThemes.caption.copyWith(
+            color: context.theme.appColors.secondaryBackground,
+          ),
         ),
       ),
     );

--- a/lib/app/features/ion_connect/model/media_attachment.dart
+++ b/lib/app/features/ion_connect/model/media_attachment.dart
@@ -26,6 +26,7 @@ class MediaAttachment {
     this.thumb,
     this.image,
     this.blurhash,
+    this.duration,
   });
 
   factory MediaAttachment.fromMediaFile(MediaFile mediaFile) {
@@ -40,6 +41,7 @@ class MediaAttachment {
       image: mediaFile.path,
       blurhash: mediaFile.blurhash,
       thumb: mediaFile.path,
+      duration: mediaFile.duration,
     );
   }
 
@@ -62,6 +64,7 @@ class MediaAttachment {
     String? encryptionNonce;
     String? encryptionMac;
     String? blurhash;
+    int? duration;
     for (final params in tag.skip(1)) {
       final pair = params.split(' ');
       final value = pair[1];
@@ -97,6 +100,8 @@ class MediaAttachment {
             encryptionNonce = nonce;
             encryptionMac = mac;
           }
+        case 'duration':
+          duration = int.tryParse(value);
       }
     }
 
@@ -114,6 +119,7 @@ class MediaAttachment {
       encryptionNonce: encryptionNonce,
       encryptionMac: encryptionMac,
       blurhash: blurhash,
+      duration: duration,
     );
   }
 
@@ -132,6 +138,7 @@ class MediaAttachment {
         thumb: json['thumb'] as String?,
         image: json['image'] as String?,
         blurhash: json['blurhash'] as String?,
+        duration: json['duration'] as int?,
       );
 
   Map<String, dynamic> toJson() => {
@@ -147,6 +154,7 @@ class MediaAttachment {
         'encryptionMac': encryptionMac,
         'thumb': thumb,
         'blurhash': blurhash,
+        'duration': duration,
       };
 
   final String url;
@@ -178,6 +186,8 @@ class MediaAttachment {
   late MediaType mediaType = _parseMediaType(url: url, mimeType: mimeType);
 
   final String? blurhash;
+
+  final int? duration;
 
   /// Calculates the aspect ratio from a given dimension string.
   ///
@@ -226,6 +236,7 @@ class MediaAttachment {
       if (thumb != null) 'thumb $thumb',
       if (image != null) 'image $image',
       if (blurhash != null) 'blurhash $blurhash',
+      if (duration != null) 'duration $duration',
     ];
   }
 
@@ -233,7 +244,7 @@ class MediaAttachment {
 
   @override
   String toString() {
-    return 'MediaAttachment(url: $url, mimeType: $mimeType, dimension: $dimension, alt: $alt, fileHash: $fileHash, originalFileHash: $originalFileHash, torrentInfoHash: $torrentInfoHash, thumb: $thumb, image: $image, blurhash: $blurhash)';
+    return 'MediaAttachment(url: $url, mimeType: $mimeType, dimension: $dimension, alt: $alt, fileHash: $fileHash, originalFileHash: $originalFileHash, torrentInfoHash: $torrentInfoHash, thumb: $thumb, image: $image, blurhash: $blurhash, duration: $duration)';
   }
 
   MediaAttachment copyWith({
@@ -250,6 +261,7 @@ class MediaAttachment {
     String? encryptionNonce,
     String? encryptionMac,
     String? blurhash,
+    int? duration,
   }) {
     return MediaAttachment(
       url: url ?? this.url,
@@ -265,6 +277,7 @@ class MediaAttachment {
       encryptionNonce: encryptionNonce ?? this.encryptionNonce,
       encryptionMac: encryptionMac ?? this.encryptionMac,
       blurhash: blurhash ?? this.blurhash,
+      duration: duration ?? this.duration,
     );
   }
 }

--- a/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
@@ -72,6 +72,7 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
       originalFileHash: fileMetadata.originalFileHash,
       alt: alt,
       thumb: fileMetadata.thumb,
+      duration: file.duration,
     );
 
     return (fileMetadata: fileMetadata, mediaAttachment: mediaAttachment);

--- a/lib/app/services/compressor/compress_service.c.dart
+++ b/lib/app/services/compressor/compress_service.c.dart
@@ -100,6 +100,7 @@ class CompressionService {
         mimeType: 'video/mp4',
         width: outWidth,
         height: outHeight,
+        duration: inputFile.duration,
       );
     } catch (error, stackTrace) {
       Logger.log('Error during video compression!', error: error, stackTrace: stackTrace);

--- a/lib/app/services/media_service/media_encryption_service.c.dart
+++ b/lib/app/services/media_service/media_encryption_service.c.dart
@@ -144,6 +144,7 @@ class MediaEncryptionService {
           width: mediaFile.width,
           height: mediaFile.height,
           mimeType: mediaFile.mimeType,
+          duration: mediaFile.duration,
         );
 
         return EncryptedMediaFile(

--- a/lib/app/services/media_service/media_service.c.dart
+++ b/lib/app/services/media_service/media_service.c.dart
@@ -35,6 +35,7 @@ class MediaFile with _$MediaFile {
     String? mimeType,
     String? thumb,
     String? blurhash,
+    int? duration,
   }) = _MediaFile;
 
   const MediaFile._();
@@ -242,6 +243,7 @@ class MediaService {
           width: assetEntity.width,
           mimeType: mimeType,
           thumb: mediaFile.thumb,
+          duration: assetEntity.duration,
         );
       }),
     );


### PR DESCRIPTION
## Description
This PR adds video duration display functionality to the chat interface. 

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
 <img width="180" alt="image" src="https://github.com/user-attachments/assets/ad601e9d-d25e-4698-9774-9937544ac2b9">


