### PR TITLE
fix: catch exception during history loading and log them

### DIFF
--- a/lib/app/features/wallets/domain/transactions/sync_transactions_service.c.dart
+++ b/lib/app/features/wallets/domain/transactions/sync_transactions_service.c.dart
@@ -64,11 +64,11 @@ class SyncTransactionsService {
           if (!wereAnyUpdates) nextPageToken = null;
         }
       }
-    } on Exception catch (ex, stacktrace) {
+    } catch (ex, stacktrace) {
       Logger.error(
-        'Failed to sync wallet(${wallet.id}) history by pages.\n'
-        'Error: $ex,\n'
-        'StackTrace: $stacktrace',
+        ex,
+        stackTrace: stacktrace,
+        message: 'Failed to sync wallet(${wallet.id}) history by pages',
       );
     }
   }
@@ -97,11 +97,11 @@ class SyncTransactionsService {
       }
 
       await _cryptoWalletsRepository.save(wallet: wallet, isHistoryLoaded: true);
-    } on Exception catch (ex, stacktrace) {
+    } catch (ex, stacktrace) {
       Logger.error(
-        'Failed to load all transactions of the wallet(${wallet.id}).\n'
-        'Error: $ex,\n'
-        'StackTrace: $stacktrace',
+        ex,
+        stackTrace: stacktrace,
+        message: 'Failed to load all transactions of the wallet(${wallet.id})',
       );
     }
   }

--- a/lib/app/features/wallets/providers/wallets_initializer_provider.c.dart
+++ b/lib/app/features/wallets/providers/wallets_initializer_provider.c.dart
@@ -17,7 +17,10 @@ class WalletsInitializerNotifier extends _$WalletsInitializerNotifier {
 
   @override
   Future<void> build() async {
-    _completer ??= Completer<void>();
+    // Since this method may be retriggered if some dependency changes,
+    // we also need to check if the completer was completed earlier.
+    // If so, we need to create a new one.
+    _completer = _completer == null || _completer!.isCompleted ? Completer<void>() : _completer;
 
     // Just wait here, until user becomes authenticated
     final authState = await ref.watch(authProvider.future);


### PR DESCRIPTION
## Description
1. Catch exception during history loading and log them. As for now, just skip wallet, if we cannot get history for it. This flow will be improved in the future.
2. Improve `WalletsInitializer` to avoid wallets page freezing.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore


