### PR TITLE
feat: add unknown embed builder

### DIFF
--- a/lib/app/components/text_editor/components/custom_blocks/unknown/text_editor_unknown_embed_builder.dart
+++ b/lib/app/components/text_editor/components/custom_blocks/unknown/text_editor_unknown_embed_builder.dart
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+
+///
+/// Embed builder for unknown embeds
+///
+class TextEditorUnknownEmbedBuilder extends EmbedBuilder {
+  TextEditorUnknownEmbedBuilder();
+
+  @override
+  String get key => 'unknown-embed';
+
+  @override
+  Widget build(
+    BuildContext context,
+    EmbedContext embedContext,
+  ) {
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/app/components/text_editor/text_editor.dart
+++ b/lib/app/components/text_editor/text_editor.dart
@@ -7,6 +7,7 @@ import 'package:ion/app/components/text_editor/components/custom_blocks/text_edi
 import 'package:ion/app/components/text_editor/components/custom_blocks/text_editor_poll_block/text_editor_poll_block.dart';
 import 'package:ion/app/components/text_editor/components/custom_blocks/text_editor_separator_block/text_editor_separator_block.dart';
 import 'package:ion/app/components/text_editor/components/custom_blocks/text_editor_single_image_block/text_editor_single_image_block.dart';
+import 'package:ion/app/components/text_editor/components/custom_blocks/unknown/text_editor_unknown_embed_builder.dart';
 import 'package:ion/app/components/text_editor/custom_recognizer_builder.dart';
 import 'package:ion/app/components/text_editor/utils/links_handler.dart';
 import 'package:ion/app/components/text_editor/utils/mentions_hashtags_handler.dart';
@@ -98,6 +99,7 @@ class TextEditorState extends ConsumerState<TextEditor> {
           TextEditorSeparatorBuilder(),
           TextEditorCodeBuilder(),
         ],
+        unknownEmbedBuilder: TextEditorUnknownEmbedBuilder(),
         autoFocus: widget.autoFocus,
         placeholder: widget.placeholder,
         customStyles: textEditorStyles(context),

--- a/lib/app/components/text_editor/text_editor_preview.dart
+++ b/lib/app/components/text_editor/text_editor_preview.dart
@@ -7,6 +7,7 @@ import 'package:flutter_quill/quill_delta.dart';
 import 'package:ion/app/components/text_editor/components/custom_blocks/text_editor_code_block/text_editor_code_block.dart';
 import 'package:ion/app/components/text_editor/components/custom_blocks/text_editor_separator_block/text_editor_separator_block.dart';
 import 'package:ion/app/components/text_editor/components/custom_blocks/text_editor_single_image_block/text_editor_single_image_block.dart';
+import 'package:ion/app/components/text_editor/components/custom_blocks/unknown/text_editor_unknown_embed_builder.dart';
 import 'package:ion/app/components/text_editor/custom_recognizer_builder.dart';
 import 'package:ion/app/components/text_editor/utils/text_editor_styles.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
@@ -59,6 +60,7 @@ class TextEditorPreview extends HookWidget {
           TextEditorSeparatorBuilder(readOnly: true),
           TextEditorCodeBuilder(readOnly: true),
         ],
+        unknownEmbedBuilder: TextEditorUnknownEmbedBuilder(),
         disableClipboard: !enableInteractiveSelection,
         customStyleBuilder: (attribute) => customTextStyleBuilder(attribute, context),
         customRecognizerBuilder: (attribute, leaf) => customRecognizerBuilder(context, attribute),


### PR DESCRIPTION
## Description
By adding an `unknownEmbedBuilder` we enable backwards compatibility for when new embed builders are introduces and not supported on older version of the app.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
