### PR TITLE
fix: update previousId assignment in SendE2eeChatMessageService

### DIFF
--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
@@ -138,7 +138,7 @@ class SendE2eeChatMessageService {
               content: content,
               signer: eventSigner,
               tags: conversationTagsWithMediaTags,
-              previousId: isCurrentUser ? eventMessage.id : null,
+              previousId: eventMessage.id,
             );
 
             await _sendKind14Message(


### PR DESCRIPTION
## Description
Always set previousId for encrypted messages to ensure consistent message threading

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
