### PR TITLE
fix(chat): Add chat relay validation before message processing

### DIFF
--- a/lib/app/features/chat/e2ee/providers/e2ee_messages_subscriber.c.dart
+++ b/lib/app/features/chat/e2ee/providers/e2ee_messages_subscriber.c.dart
@@ -10,6 +10,7 @@ import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message
 import 'package:ion/app/features/chat/e2ee/model/entities/private_message_reaction_data.c.dart';
 import 'package:ion/app/features/chat/e2ee/providers/send_e2ee_message_provider.c.dart';
 import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
+import 'package:ion/app/features/chat/providers/user_chat_relays_provider.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.c.dart';
 import 'package:ion/app/features/ion_connect/model/deletion_request.c.dart';
@@ -40,6 +41,14 @@ class E2eeMessagesSubscriber extends _$E2eeMessagesSubscriber {
     final latestEventMessageDate = await ref
         .watch(conversationEventMessageDaoProvider)
         .getLatestEventMessageDate(PrivateDirectMessageEntity.kind);
+
+    final userChatRelays = await ref.watch(userChatRelaysProvider(masterPubkey).future);
+
+    if (userChatRelays == null) {
+      await ref.read(userChatRelaysManagerProvider.notifier).sync();
+      ref.invalidateSelf();
+      return;
+    }
 
     final sinceDate = latestEventMessageDate?.add(const Duration(days: -2));
 
@@ -127,7 +136,10 @@ class E2eeMessagesSubscriber extends _$E2eeMessagesSubscriber {
 
             if (currentStatus == null ||
                 currentStatus.index < MessageDeliveryStatus.received.index) {
-              await sendE2eeMessageService.sendMessageStatus(rumor, MessageDeliveryStatus.received);
+              await sendE2eeMessageService.sendMessageStatus(
+                rumor,
+                MessageDeliveryStatus.received,
+              );
             }
 
             // Only for kind 7

--- a/lib/app/features/chat/e2ee/providers/e2ee_messages_subscriber.c.dart
+++ b/lib/app/features/chat/e2ee/providers/e2ee_messages_subscriber.c.dart
@@ -136,10 +136,7 @@ class E2eeMessagesSubscriber extends _$E2eeMessagesSubscriber {
 
             if (currentStatus == null ||
                 currentStatus.index < MessageDeliveryStatus.received.index) {
-              await sendE2eeMessageService.sendMessageStatus(
-                rumor,
-                MessageDeliveryStatus.received,
-              );
+              await sendE2eeMessageService.sendMessageStatus(rumor, MessageDeliveryStatus.received);
             }
 
             // Only for kind 7

--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
@@ -138,7 +138,7 @@ class SendE2eeChatMessageService {
               content: content,
               signer: eventSigner,
               tags: conversationTagsWithMediaTags,
-              previousId: eventMessage.id,
+              previousId: isCurrentUser ? eventMessage.id : null,
             );
 
             await _sendKind14Message(

--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart
@@ -138,7 +138,7 @@ class SendE2eeChatMessageService {
               content: content,
               signer: eventSigner,
               tags: conversationTagsWithMediaTags,
-              previousId: isCurrentUser ? eventMessage.id : null,
+              previousId: eventMessage.id,
             );
 
             await _sendKind14Message(


### PR DESCRIPTION
## Description
Ensure messages are only processed when chat relays are properly synced, preventing potential message delivery issues.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
