### PR TITLE
fix: add protection from empty attempts to sync

### DIFF
--- a/lib/app/features/wallets/domain/wallet_views/sync_wallet_views_coins_service.c.dart
+++ b/lib/app/features/wallets/domain/wallet_views/sync_wallet_views_coins_service.c.dart
@@ -14,10 +14,14 @@ part 'sync_wallet_views_coins_service.c.g.dart';
 
 @riverpod
 Future<SyncWalletViewCoinsService> syncWalletViewCoinsService(Ref ref) async {
-  return SyncWalletViewCoinsService(
+  final service = SyncWalletViewCoinsService(
     coinsRepository: ref.watch(coinsRepositoryProvider),
     ionIdentityClient: await ref.watch(ionIdentityClientProvider.future),
   );
+
+  ref.onDispose(service._stopQueue);
+
+  return service;
 }
 
 class SyncWalletViewCoinsService {
@@ -27,11 +31,14 @@ class SyncWalletViewCoinsService {
   })  : _coinsRepository = coinsRepository,
         _ionIdentityClient = ionIdentityClient;
 
+  static const _syncThreshold = Duration(seconds: 3);
+
   final CoinsRepository _coinsRepository;
   final IONIdentityClient _ionIdentityClient;
 
   Timer? _syncTimer;
-  StreamSubscription<List<CoinData>>? _subscription;
+  bool _syncInProgress = false;
+  bool _isSyncQueueIsRunning = false;
 
   Future<void> start(List<CoinData> coins) async {
     final coinIds = coins.map((coin) => coin.id).toSet();
@@ -45,39 +52,32 @@ class SyncWalletViewCoinsService {
       // that are in WalletViews. So if the isQueueIsNotReady returns false in the stream,
       // we tell the sync method to remove the coins that are not in WalletViews from the queue
       // and add new ones.
-      final completer = Completer<void>();
+      final coins =
+          await _coinsRepository.watchCoins(coinIds).firstWhere((result) => result.isNotEmpty);
+      if (await isQueueNotReady()) {
+        Logger.log(
+          'The queue needs to be created/updated as it does not match the selected coins.',
+        );
 
-      await _subscription?.cancel();
-      _subscription = _coinsRepository.watchCoins(coinIds).listen((coins) async {
-        if (coins.isNotEmpty) {
-          if (await isQueueNotReady()) {
-            Logger.log(
-              'The queue needs to be created/updated as it does not match the selected coins.',
-            );
-
-            await _updateCoinsSyncQueue(
-              coins.map(
-                (coin) => (coinId: coin.id, syncFrequency: coin.syncFrequency),
-              ),
-              updateOnlyDifferences: true,
-            );
-          }
-          completer.complete();
-        }
-      });
-
-      await completer.future;
-      await _subscription?.cancel();
+        await _updateCoinsSyncQueue(
+          coins.map(
+            (coin) => (coinId: coin.id, syncFrequency: coin.syncFrequency),
+          ),
+          updateOnlyDifferences: true,
+        );
+      }
     }
 
-    await _scheduleNextSync();
+    if (!_isSyncQueueIsRunning) {
+      _isSyncQueueIsRunning = true;
+      await _scheduleNextSync();
+    }
   }
 
   void removeQueue() {
     Logger.log('Remove coins sync queue.');
 
     _stopQueue();
-    _subscription?.cancel();
     _coinsRepository.removeSyncQueue();
   }
 
@@ -86,50 +86,82 @@ class SyncWalletViewCoinsService {
 
     _syncTimer?.cancel();
     _syncTimer = null;
+    _isSyncQueueIsRunning = false;
   }
 
   Future<void> _scheduleNextSync() async {
+    if (!_isSyncQueueIsRunning) return;
+
     final nextUpdate = await _coinsRepository.getNextSyncTime();
     if (nextUpdate == null) {
-      Logger.log('Cannot schedule the next coins sync, because the next update date is null');
+      Logger.log('Cannot schedule the next coins sync, because the next update date is null.');
       _stopQueue();
       return;
     }
 
-    final delay = nextUpdate.difference(DateTime.now());
+    var delay = nextUpdate.difference(DateTime.now());
+    // If delay is less or the same as threshold, increase delay manually
+    if (delay <= _syncThreshold) {
+      Logger.log(
+        'Next coins sync time is in the past or now. Forcing delay to ${_syncThreshold.inSeconds} second.',
+      );
+      delay = _syncThreshold;
+      nextUpdate.add(_syncThreshold);
+    }
 
-    Logger.log('Next coins sync scheduled at $nextUpdate.');
+    Logger.log('Next coins sync scheduled at $nextUpdate, after $delay.');
 
     _syncTimer?.cancel();
-    _syncTimer = Timer(delay > Duration.zero ? delay : Duration.zero, () async {
+    _syncTimer = Timer(delay, () async {
       await _syncCoins();
-      await _scheduleNextSync();
+
+      if (_isSyncQueueIsRunning && (_syncTimer == null || !_syncTimer!.isActive)) {
+        await _scheduleNextSync();
+      } else {
+        final reason =
+            !_isSyncQueueIsRunning ? 'Sync queue was stopped.' : 'Sync timer is already active.';
+        Logger.log('Skipping reschedule. $reason');
+      }
     });
   }
 
   Future<void> _syncCoins() async {
-    final coins = await _coinsRepository.getCoinsToSync(DateTime.now());
+    if (_syncInProgress) {
+      Logger.log('Coins sync is already in progress. Skipping sync request.');
+      return;
+    }
+    _syncInProgress = true;
 
-    Logger.log('Sync coins to get actual prices. Need to update ${coins.length} coins.');
-    if (coins.isEmpty) return;
+    try {
+      final coins = await _coinsRepository.getCoinsToSync(DateTime.now().add(_syncThreshold));
 
-    final syncedCoinsData = await _ionIdentityClient.coins.syncCoins(
-      coins.map((e) => e.symbolGroup).toSet(),
-    );
+      Logger.log('Sync coins to get actual prices. Need to update ${coins.length} coins.');
+      if (coins.isEmpty) return;
 
-    final syncedCoins = coins.map((coinDB) {
-      final syncedData = syncedCoinsData.firstWhere((e) => e.symbolGroup == coinDB.symbolGroup);
-      return coinDB.copyWith(
-        priceUSD: syncedData.priceUSD,
-        syncFrequency: syncedData.syncFrequency,
-        decimals: syncedData.decimals,
+      final syncedCoinsData = await _ionIdentityClient.coins.syncCoins(
+        coins.map((e) => e.symbolGroup).toSet(),
       );
-    }).toList();
 
-    await _coinsRepository.updateCoins(syncedCoins);
-    await _updateCoinsSyncQueue(
-      syncedCoins.map((coin) => (coinId: coin.id, syncFrequency: coin.syncFrequency)),
-    );
+      final syncedCoins = coins.map((coinDB) {
+        final syncedData = syncedCoinsData.firstWhere((e) => e.symbolGroup == coinDB.symbolGroup);
+        return coinDB.copyWith(
+          priceUSD: syncedData.priceUSD,
+          syncFrequency: syncedData.syncFrequency,
+          decimals: syncedData.decimals,
+        );
+      }).toList();
+
+      await _coinsRepository.updateCoins(syncedCoins);
+      await _updateCoinsSyncQueue(
+        syncedCoins.map((coin) => (coinId: coin.id, syncFrequency: coin.syncFrequency)),
+      );
+    } catch (ex, stackTrace) {
+      Logger.error(ex, stackTrace: stackTrace, message: 'Error during syncing coins.');
+      _stopQueue();
+    } finally {
+      _syncInProgress = false;
+      Logger.log('Coins sync finished.');
+    }
   }
 
   Future<void> _updateCoinsSyncQueue(

--- a/lib/app/features/wallets/domain/wallet_views/sync_wallet_views_coins_service.c.dart
+++ b/lib/app/features/wallets/domain/wallet_views/sync_wallet_views_coins_service.c.dart
@@ -49,7 +49,7 @@ class SyncWalletViewCoinsService {
       // We need to be sure, that coins from the WalletView already in the DB,
       // so we wait to get them from there. This is the entry point to the queue,
       // so before we start the periodic sync, we need to make sure that it only contains the coins
-      // that are in WalletViews. So if the isQueueIsNotReady returns false in the stream,
+      // that are in WalletViews. So if the isQueueNotReady returns false in the stream,
       // we tell the sync method to remove the coins that are not in WalletViews from the queue
       // and add new ones.
       final coins =

--- a/lib/app/features/wallets/domain/wallet_views/sync_wallet_views_coins_service.c.dart
+++ b/lib/app/features/wallets/domain/wallet_views/sync_wallet_views_coins_service.c.dart
@@ -38,7 +38,7 @@ class SyncWalletViewCoinsService {
 
   Timer? _syncTimer;
   bool _syncInProgress = false;
-  bool _isSyncQueueIsRunning = false;
+  bool _isSyncQueueRunning = false;
 
   Future<void> start(List<CoinData> coins) async {
     final coinIds = coins.map((coin) => coin.id).toSet();
@@ -68,8 +68,8 @@ class SyncWalletViewCoinsService {
       }
     }
 
-    if (!_isSyncQueueIsRunning) {
-      _isSyncQueueIsRunning = true;
+    if (!_isSyncQueueRunning) {
+      _isSyncQueueRunning = true;
       await _scheduleNextSync();
     }
   }
@@ -86,11 +86,11 @@ class SyncWalletViewCoinsService {
 
     _syncTimer?.cancel();
     _syncTimer = null;
-    _isSyncQueueIsRunning = false;
+    _isSyncQueueRunning = false;
   }
 
   Future<void> _scheduleNextSync() async {
-    if (!_isSyncQueueIsRunning) return;
+    if (!_isSyncQueueRunning) return;
 
     final nextUpdate = await _coinsRepository.getNextSyncTime();
     if (nextUpdate == null) {
@@ -115,11 +115,11 @@ class SyncWalletViewCoinsService {
     _syncTimer = Timer(delay, () async {
       await _syncCoins();
 
-      if (_isSyncQueueIsRunning && (_syncTimer == null || !_syncTimer!.isActive)) {
+      if (_isSyncQueueRunning && (_syncTimer == null || !_syncTimer!.isActive)) {
         await _scheduleNextSync();
       } else {
         final reason =
-            !_isSyncQueueIsRunning ? 'Sync queue was stopped.' : 'Sync timer is already active.';
+            !_isSyncQueueRunning ? 'Sync queue was stopped.' : 'Sync timer is already active.';
         Logger.log('Skipping reschedule. $reason');
       }
     });


### PR DESCRIPTION
## Description
1. Added several checks to protect against multiple queue runs.
2.  Added a time threshold for better grouping of coins for sync.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
