### PR TITLE
bugfix(chat): improve archive section animation in recent chats to prevent overflow issue

### DIFF
--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/inputs/search_input/search_input.dart';
@@ -75,9 +76,9 @@ class RecentChatsTimelinePage extends HookConsumerWidget {
         ),
         if (scrollController.hasClients && !isArchivedConversationsEmpty)
           SliverToBoxAdapter(
-            child: AnimatedContainer(
-              height: archiveVisible.value ? 60.0.s : 0,
-              duration: const Duration(milliseconds: 100),
+            child: AnimatedOpacity(
+              opacity: archiveVisible.value ? 1.0 : 0.0,
+              duration: 500.milliseconds,
               child: archiveVisible.value ? const ArchiveChatTile() : const SizedBox.shrink(),
             ),
           ),


### PR DESCRIPTION
## Description
Enhances the animation of the archive section in the recent chats timeline by switching from height-based to opacity-based animation.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/6a83ae54-45d6-4afa-95c0-09f1316e0b9c

