### PR TITLE
feat:  edit chat message migration, phase 2

### DIFF
--- a/lib/app/exceptions/exceptions.dart
+++ b/lib/app/exceptions/exceptions.dart
@@ -477,3 +477,13 @@ class WalletsLoadingException extends IONException {
 class FailedToGenerateMediaUrlFallback extends IONException {
   FailedToGenerateMediaUrlFallback() : super(10094, 'Failed to generate media fallback url');
 }
+
+class ImmutablePrivateDirectMessageDecodeException extends IONException {
+  ImmutablePrivateDirectMessageDecodeException(String id)
+      : super(10095, 'Failed to convert event message with id $id');
+}
+
+class ReplaceablePrivateDirectMessageDecodeException extends IONException {
+  ReplaceablePrivateDirectMessageDecodeException(String id)
+      : super(10096, 'Failed to convert event message with id $id');
+}

--- a/lib/app/features/chat/community/providers/community_messages_subscriber_provider.c.dart
+++ b/lib/app/features/chat/community/providers/community_messages_subscriber_provider.c.dart
@@ -57,10 +57,10 @@ class CommunityMessagesSubscriber extends _$CommunityMessagesSubscriber {
       },
       maxCreatedAtBuilder: () => ref
           .watch(conversationEventMessageDaoProvider)
-          .getLatestEventMessageDate(ModifiablePostEntity.kind),
+          .getLatestEventMessageDate([ModifiablePostEntity.kind]),
       minCreatedAtBuilder: (since) => ref
           .watch(conversationEventMessageDaoProvider)
-          .getEarliestEventMessageDate(ModifiablePostEntity.kind, after: since),
+          .getEarliestEventMessageDate([ModifiablePostEntity.kind], after: since),
       overlap: const Duration(days: 2),
       actionSource: ActionSourceUser(ownerPubkey),
     );

--- a/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart
+++ b/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart
@@ -300,7 +300,6 @@ class ReplaceablePrivateDirectMessageData
       if (media.isNotEmpty) ...media.values.map((mediaAttachment) => mediaAttachment.toTag()),
       ReplaceableEventIdentifier(value: messageId).toTag(),
       ConversationIdentifier(value: conversationId).toTag(),
-     
     ];
 
     final createdAt = DateTime.now();

--- a/lib/app/features/chat/e2ee/model/entities/private_message_reaction_data.c.dart
+++ b/lib/app/features/chat/e2ee/model/entities/private_message_reaction_data.c.dart
@@ -64,7 +64,10 @@ class PrivateMessageReactionEntityData with _$PrivateMessageReactionEntityData {
 
     if (eventId == null ||
         pubkey == null ||
-        kind != ImmutablePrivateDirectMessageEntity.kind.toString()) {
+        ![
+          ImmutablePrivateDirectMessageEntity.kind.toString(),
+          ReplaceablePrivateDirectMessageEntity.kind.toString(),
+        ].contains(kind)) {
       throw IncorrectEventTagsException(eventId: eventMessage.id);
     }
 

--- a/lib/app/features/chat/e2ee/providers/send_chat_message_service.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message_service.c.dart
@@ -50,9 +50,9 @@ class SendChatMessageService {
         );
 
     await sendChatMessageService.sendMessage(
-      conversationId: conversationId,
       content: content,
       mediaFiles: mediaFiles,
+      conversationId: conversationId,
       participantsMasterPubkeys: [receiverPubkey, currentPubkey],
     );
   }

--- a/lib/app/features/chat/e2ee/providers/send_e2ee_message_provider.c.dart
+++ b/lib/app/features/chat/e2ee/providers/send_e2ee_message_provider.c.dart
@@ -77,7 +77,7 @@ class SendE2eeMessageService {
       signer: eventSigner!,
       kind: PrivateMessageReactionEntity.kind,
       tags: [
-        ['k', ImmutablePrivateDirectMessageEntity.kind.toString()],
+        ['k', ReplaceablePrivateDirectMessageEntity.kind.toString()],
         [PubkeyTag.tagName, kind14Rumor.pubkey],
         [RelatedImmutableEvent.tagName, kind14Rumor.id],
         ['b', currentUserMasterPubkey],
@@ -132,7 +132,7 @@ class SendE2eeMessageService {
       signer: eventSigner!,
       kind: PrivateMessageReactionEntity.kind,
       tags: [
-        ['k', ImmutablePrivateDirectMessageEntity.kind.toString()],
+        ['k', ReplaceablePrivateDirectMessageEntity.kind.toString()],
         [PubkeyTag.tagName, kind14Rumor.pubkey],
         [RelatedImmutableEvent.tagName, kind14Rumor.id],
         ['b', currentUserMasterPubkey],
@@ -182,7 +182,7 @@ class SendE2eeMessageService {
     required EventSigner signer,
     required List<List<String>> tags,
     String? previousId,
-    int kind = ImmutablePrivateDirectMessageEntity.kind,
+    int kind = ReplaceablePrivateDirectMessageEntity.kind,
   }) async {
     final createdAt = DateTime.now().toUtc();
 
@@ -215,7 +215,7 @@ class SendE2eeMessageService {
     required EventMessage eventMessage,
     List<String>? kinds,
   }) async {
-    final contentKinds = kinds ?? [ImmutablePrivateDirectMessageEntity.kind.toString()];
+    final contentKinds = kinds ?? [ReplaceablePrivateDirectMessageEntity.kind.toString()];
 
     final expirationTag = EntityExpiration(
       value: DateTime.now().add(

--- a/lib/app/features/chat/model/database/dao/conversation_dao.c.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_dao.c.dart
@@ -159,7 +159,7 @@ class ConversationDao extends DatabaseAccessor<ChatDatabase> with _$Conversation
   /// Get the id of the conversation with the given receiver master pubkey
   /// Only searches for non-deleted conversations of type [ConversationType.oneToOne]
   ///
-  Future<String?> getExistOnetOneConversationId(String receiverMasterPubkey) async {
+  Future<String?> getExistOneToOneConversationId(String receiverMasterPubkey) async {
     final query = select(conversationTable).join([
       innerJoin(
         conversationMessageTable,
@@ -173,7 +173,12 @@ class ConversationDao extends DatabaseAccessor<ChatDatabase> with _$Conversation
       ..where(conversationTable.type.equals(ConversationType.oneToOne.index))
       ..where(conversationTable.isDeleted.equals(false))
       ..where(eventMessageTable.tags.contains(receiverMasterPubkey))
-      ..where(eventMessageTable.kind.equals(ImmutablePrivateDirectMessageEntity.kind))
+      ..where(
+        eventMessageTable.kind.isIn([
+          ImmutablePrivateDirectMessageEntity.kind,
+          ReplaceablePrivateDirectMessageEntity.kind,
+        ]),
+      )
       ..orderBy([OrderingTerm.desc(eventMessageTable.createdAt)])
       ..limit(1);
 

--- a/lib/app/features/chat/model/database/dao/conversation_event_message_dao.c.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_event_message_dao.c.dart
@@ -44,14 +44,13 @@ class ConversationEventMessageDao extends DatabaseAccessor<ChatDatabase>
     );
   }
 
-  ///
-  /// Get the creation date of the most recent event message of a specific kind
-  /// Returns null if no messages of that kind exist
-  ///
-  Future<DateTime?> getLatestEventMessageDate(int kind) async {
+  
+  /// Get the creation date of the most recent event messages of specific kinds
+  /// Returns null if no messages of those kinds exist
+  Future<DateTime?> getLatestEventMessageDate(List<int> kinds) async {
     final query = select(eventMessageTable)
       ..orderBy([(t) => OrderingTerm.desc(t.createdAt)])
-      ..where((t) => t.kind.equals(kind))
+      ..where((t) => t.kind.isIn(kinds))
       ..limit(1);
 
     final row = await query.getSingleOrNull();
@@ -59,12 +58,11 @@ class ConversationEventMessageDao extends DatabaseAccessor<ChatDatabase>
     return row?.createdAt;
   }
 
-  ///
-  /// Get the creation date of the oldest event message of a specific kind
-  /// Returns null if no messages of that kind exist
-  ///
-  Future<DateTime?> getEarliestEventMessageDate(int kind, {DateTime? after}) async {
-    final query = select(eventMessageTable)..where((t) => t.kind.equals(kind));
+  /// Get the creation date of the oldest event messages of specific kinds
+  /// Returns null if no messages of those kinds exist
+  Future<DateTime?> getEarliestEventMessageDate(List<int> kinds, {DateTime? after}) async {
+    final query = select(eventMessageTable)
+      ..where((t) => t.kind.isIn(kinds));
 
     if (after != null) {
       query.where((t) => t.createdAt.isBiggerThanValue(after));

--- a/lib/app/features/chat/model/database/dao/conversation_event_message_dao.c.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_event_message_dao.c.dart
@@ -44,7 +44,6 @@ class ConversationEventMessageDao extends DatabaseAccessor<ChatDatabase>
     );
   }
 
-  
   /// Get the creation date of the most recent event messages of specific kinds
   /// Returns null if no messages of those kinds exist
   Future<DateTime?> getLatestEventMessageDate(List<int> kinds) async {
@@ -61,8 +60,7 @@ class ConversationEventMessageDao extends DatabaseAccessor<ChatDatabase>
   /// Get the creation date of the oldest event messages of specific kinds
   /// Returns null if no messages of those kinds exist
   Future<DateTime?> getEarliestEventMessageDate(List<int> kinds, {DateTime? after}) async {
-    final query = select(eventMessageTable)
-      ..where((t) => t.kind.isIn(kinds));
+    final query = select(eventMessageTable)..where((t) => t.kind.isIn(kinds));
 
     if (after != null) {
       query.where((t) => t.createdAt.isBiggerThanValue(after));

--- a/lib/app/features/chat/providers/exist_chat_conversation_id_provider.c.dart
+++ b/lib/app/features/chat/providers/exist_chat_conversation_id_provider.c.dart
@@ -8,5 +8,5 @@ part 'exist_chat_conversation_id_provider.c.g.dart';
 
 @riverpod
 Future<String?> existChatConversationId(Ref ref, String receiverMasterPubKey) async {
-  return ref.watch(conversationDaoProvider).getExistOnetOneConversationId(receiverMasterPubKey);
+  return ref.watch(conversationDaoProvider).getExistOneToOneConversationId(receiverMasterPubKey);
 }

--- a/lib/app/features/feed/stories/providers/story_reply_provider.c.dart
+++ b/lib/app/features/feed/stories/providers/story_reply_provider.c.dart
@@ -102,7 +102,7 @@ class StoryReply extends _$StoryReply {
           eventSigner: eventSigner,
           masterPubkey: masterPubkey,
           eventMessage: kind16Rumor,
-          kinds: [
+          wrappedKinds: [
             GenericRepostEntity.kind.toString(),
             ModifiablePostEntity.kind.toString(),
           ],

--- a/lib/app/features/wallets/domain/transactions/send_transaction_to_relay_service.c.dart
+++ b/lib/app/features/wallets/domain/transactions/send_transaction_to_relay_service.c.dart
@@ -107,6 +107,7 @@ class SendTransactionToRelayService {
     required String receiverMasterPubkey,
     required EventSigner signer,
     required EventMessage eventMessage,
+    // TODO: Use ReplaceablePrivateDirectMessageEntity.kind when migration is done
     int kind = ImmutablePrivateDirectMessageEntity.kind,
   }) async {
     final expirationTag = EntityExpiration(

--- a/test/app/services/ion_connect/ion_connect_gift_wrap_service_test.dart
+++ b/test/app/services/ion_connect/ion_connect_gift_wrap_service_test.dart
@@ -37,7 +37,7 @@ void main() {
         event: event,
         receiverMasterPubkey: masterPubkey,
         receiverPubkey: receiverSigner.publicKey,
-        contentKinds: [ReplaceablePrivateDirectMessageEntity.kind.toString()],
+        contentKinds: [ImmutablePrivateDirectMessageEntity.kind.toString()],
       );
 
       expect(wrap.kind, equals(1059));
@@ -59,7 +59,7 @@ void main() {
         event: event,
         receiverMasterPubkey: "Doesn't matter",
         receiverPubkey: senderSigner.publicKey,
-        contentKinds: [ReplaceablePrivateDirectMessageEntity.kind.toString()],
+        contentKinds: [ImmutablePrivateDirectMessageEntity.kind.toString()],
       );
 
       final decodedWrap = await giftWrapService.decodeWrap(
@@ -81,7 +81,7 @@ void main() {
         event: event,
         receiverMasterPubkey: "Doesn't matter",
         receiverPubkey: receiverSigner.publicKey,
-        contentKinds: [ReplaceablePrivateDirectMessageEntity.kind.toString()],
+        contentKinds: [ImmutablePrivateDirectMessageEntity.kind.toString()],
       );
 
       final decodedWrap = await giftWrapService.decodeWrap(

--- a/test/app/services/ion_connect/ion_connect_gift_wrap_service_test.dart
+++ b/test/app/services/ion_connect/ion_connect_gift_wrap_service_test.dart
@@ -37,7 +37,7 @@ void main() {
         event: event,
         receiverMasterPubkey: masterPubkey,
         receiverPubkey: receiverSigner.publicKey,
-        contentKinds: [ImmutablePrivateDirectMessageEntity.kind.toString()],
+        contentKinds: [ReplaceablePrivateDirectMessageEntity.kind.toString()],
       );
 
       expect(wrap.kind, equals(1059));
@@ -59,7 +59,7 @@ void main() {
         event: event,
         receiverMasterPubkey: "Doesn't matter",
         receiverPubkey: senderSigner.publicKey,
-        contentKinds: [ImmutablePrivateDirectMessageEntity.kind.toString()],
+        contentKinds: [ReplaceablePrivateDirectMessageEntity.kind.toString()],
       );
 
       final decodedWrap = await giftWrapService.decodeWrap(
@@ -81,7 +81,7 @@ void main() {
         event: event,
         receiverMasterPubkey: "Doesn't matter",
         receiverPubkey: receiverSigner.publicKey,
-        contentKinds: [ImmutablePrivateDirectMessageEntity.kind.toString()],
+        contentKinds: [ReplaceablePrivateDirectMessageEntity.kind.toString()],
       );
 
       final decodedWrap = await giftWrapService.decodeWrap(


### PR DESCRIPTION
## Description
- Allows to subscribe to new Replaceable events 
- All new messages send only new Replaceable events kind
- Backward compatible with Immutable events
- Allows to send both types of events

## Type of Change
- [x] New feature
- [x] Refactoring
