### PR TITLE
fix: multiple feed requests after pull to refresh

### DIFF
--- a/lib/app/features/feed/views/pages/feed_page/feed_page.dart
+++ b/lib/app/features/feed/views/pages/feed_page/feed_page.dart
@@ -84,10 +84,10 @@ class FeedPage extends HookConsumerWidget {
 
   Future<void> _onRefresh(WidgetRef ref) async {
     ref
+      // invalidate feedFilterRelaysProvider to trigger provider rebuild with new relays
+      ..invalidate(feedFilterRelaysProvider)
       ..invalidate(entitiesPagedDataProvider(ref.read(feedStoriesDataSourceProvider)))
       ..invalidate(entitiesPagedDataProvider(ref.read(feedPostsDataSourceProvider)))
-      ..invalidate(entitiesPagedDataProvider(ref.read(feedTrendingVideosDataSourceProvider)))
-      // invalidate feedFilterRelaysProvider to trigger provider rebuild with new relays
-      ..invalidate(feedFilterRelaysProvider);
+      ..invalidate(entitiesPagedDataProvider(ref.read(feedTrendingVideosDataSourceProvider)));
   }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where the same requests for feed related data was fired multiple times upon pull to refresh.

## Additional Notes
It appears that the order of invalidations mattered here, as moving the feedRelays provider invalidation to the top of the chain resolved the issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
