### PR TITLE
bugfix(chat): handle document media preview

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/document_message/document_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/document_message/document_message.dart
@@ -66,7 +66,7 @@ class DocumentMessage extends HookConsumerWidget {
         });
         return null;
       },
-      [messageMedia?.cacheKey, mediaAttachment],
+      [messageMedia?.cacheKey, mediaAttachment?.url],
     );
 
     final hasReactions = useHasReaction(eventMessage, ref);

--- a/lib/app/services/media_service/media_encryption_service.c.dart
+++ b/lib/app/services/media_service/media_encryption_service.c.dart
@@ -81,17 +81,22 @@ class MediaEncryptionService {
         await file.delete();
         await fileCacheService.removeFile(url);
 
-        final decryptedFile = await fileCacheService.putFile(
-          url: url,
-          bytes: decryptedFileBytes,
-          fileExtension: fileExtension,
-        );
-
         if (attachment.mediaType == MediaType.unknown) {
           final decompressedFile = await brotliCompressor.decompress(decryptedFileBytes);
 
-          return decompressedFile;
+          final decryptedFile = await fileCacheService.putFile(
+            url: url,
+            bytes: decompressedFile.readAsBytesSync(),
+            fileExtension: fileExtension,
+          );
+
+          return decryptedFile;
         } else {
+          final decryptedFile = await fileCacheService.putFile(
+            url: url,
+            bytes: decryptedFileBytes,
+            fileExtension: 'pdf',
+          );
           return decryptedFile;
         }
       } else {


### PR DESCRIPTION
## Description
Chat receiver should be able to preview the document message.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/ec425b28-2212-48bf-b2e4-6ddef5e1321f

