### PR TITLE
fix: double camera page push upon initial permission grant when creating a video post

### DIFF
--- a/lib/app/features/core/permissions/views/components/permission_aware_widget.dart
+++ b/lib/app/features/core/permissions/views/components/permission_aware_widget.dart
@@ -37,8 +37,8 @@ class PermissionAwareWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final compositeKey = '${permissionType.name}_$requestId';
-    final activeRequestId = ref.watch(activePermissionRequestIdProvider(compositeKey));
+    final permissionKey = permissionType.name;
+    final activeRequestId = ref.watch(activePermissionRequestIdProvider(permissionKey));
     final hasPermission = ref.watch(hasPermissionProvider(permissionType));
 
     ref.listen<bool>(
@@ -53,12 +53,10 @@ class PermissionAwareWidget extends ConsumerWidget {
     return builder(
       context,
       () {
-        if (hasPermission) {
-          if (_shouldExecuteOnGranted(context, activeRequestId)) {
-            onGranted();
-          }
+        if (hasPermission && onGrantedPredicate()) {
+          onGranted();
         } else {
-          _handlePermissionRequest(context, ref, compositeKey);
+          _handlePermissionRequest(context, ref, permissionKey);
         }
       },
     );
@@ -79,9 +77,9 @@ class PermissionAwareWidget extends ConsumerWidget {
   Future<void> _handlePermissionRequest(
     BuildContext context,
     WidgetRef ref,
-    String compositeKey,
+    String permissionKey,
   ) async {
-    ref.read(activePermissionRequestIdProvider(compositeKey).notifier).requestId = requestId;
+    ref.read(activePermissionRequestIdProvider(permissionKey).notifier).requestId = requestId;
 
     final isPermanentlyDenied = ref.read(isPermanentlyDeniedProvider(permissionType));
     final permissionsNotifier = ref.read(permissionsProvider.notifier);

--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -48,6 +48,7 @@ class FeedMainModalPage extends ConsumerWidget {
               if (type == FeedType.story) {
                 return PermissionAwareWidget(
                   permissionType: Permission.camera,
+                  requestId: 'story_record',
                   builder: (_, onPressed) => MainModalItem(
                     item: type,
                     onTap: onPressed,

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_avatar_with_permission.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/current_user_avatar_with_permission.dart
@@ -29,6 +29,7 @@ class CurrentUserAvatarWithPermission extends StatelessWidget {
   Widget build(BuildContext context) {
     return PermissionAwareWidget(
       permissionType: Permission.camera,
+      requestId: 'story_record',
       onGrantedPredicate: () =>
           GoRouter.of(context).state.fullPath?.startsWith(FeedRoute().location) ?? false,
       onGranted: () => hasStories

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/plus_button_with_permission.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/plus_button_with_permission.dart
@@ -21,6 +21,7 @@ class PlusButtonWithPermission extends StatelessWidget {
       bottom: iconPosition,
       child: PermissionAwareWidget(
         permissionType: Permission.camera,
+        requestId: 'story_record',
         onGrantedPredicate: () =>
             GoRouter.of(context).state.fullPath?.startsWith(FeedRoute().location) ?? false,
         onGranted: () => StoryRecordRoute().push<void>(context),


### PR DESCRIPTION
## Description
This PR fixes an issue where double record video page was pushed because of multiple widgets reacting to granted permission.

## Additional Notes
- Refactored how a `resourceId` is used inside the `PermissionAwareWidget`
- Removed checks for correct `resourceId` during tap callback as user initiated actions should always pass.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
