### PR TITLE
fix: modify url matcher regex to match old images urls

### DIFF
--- a/lib/app/services/text_parser/model/text_matcher.dart
+++ b/lib/app/services/text_parser/model/text_matcher.dart
@@ -25,7 +25,7 @@ class UrlMatcher extends TextMatcher {
 
   @override
   String get pattern =>
-      r'((https?:\/\/)?(www\.)?[a-zA-Z0-9-]+(?<!\d)\.[a-zA-Z]{2,6}(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)\b)';
+      r'(\b((?:https?:\/\/)?(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,6}(?::\d+)?(?:[-A-Za-z0-9()@:%_+.~#?&\/=]*)?)\b)';
 }
 
 class CashtagMatcher extends TextMatcher {


### PR DESCRIPTION
## Description
This PR updates the regex for URLMatcher to cover old media urls

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
