### PR TITLE
fix: remove network prefix for qr code scanner

### DIFF
--- a/lib/app/features/wallets/utils/prefix_trimmer.dart
+++ b/lib/app/features/wallets/utils/prefix_trimmer.dart
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: ice License 1.0
+
+String trimPrefix(
+  String value, {
+  String separator = ':',
+}) {
+  final parts = value.split(separator);
+  if (parts.length == 1) {
+    return parts.first;
+  }
+  return parts.skip(1).join(separator);
+}

--- a/lib/app/features/wallets/views/components/qr_scanner_bottom_sheet.dart
+++ b/lib/app/features/wallets/views/components/qr_scanner_bottom_sheet.dart
@@ -8,12 +8,19 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/build_context.dart';
 import 'package:ion/app/extensions/num.dart';
+import 'package:ion/app/extensions/object.dart';
 import 'package:ion/app/extensions/theme_data.dart';
+import 'package:ion/app/features/wallets/utils/prefix_trimmer.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
 
 class QRScannerBottomSheet extends HookConsumerWidget {
-  const QRScannerBottomSheet({super.key});
+  const QRScannerBottomSheet({
+    super.key,
+    this.shouldTrimPrefix = true,
+  });
+
+  final bool shouldTrimPrefix;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -25,8 +32,10 @@ class QRScannerBottomSheet extends HookConsumerWidget {
       (QRViewController controller) {
         controllerRef.value = controller;
         subscriptionRef.value = controller.scannedDataStream.listen((scanData) {
-          if (scanData.code != null && context.mounted) {
-            context.pop(scanData.code);
+          if (context.mounted) {
+            scanData.code
+                ?.map((code) => shouldTrimPrefix ? trimPrefix(code) : code)
+                .let(context.pop);
           }
         });
       },

--- a/lib/app/features/wallets/views/pages/wallet_scan_modal_page.dart
+++ b/lib/app/features/wallets/views/pages/wallet_scan_modal_page.dart
@@ -5,14 +5,19 @@ import 'package:ion/app/features/wallets/views/components/qr_scanner_bottom_shee
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 
 class WalletScanModalPage extends StatelessWidget {
-  const WalletScanModalPage({super.key});
+  const WalletScanModalPage({
+    super.key,
+    this.trimPrefix = true,
+  });
+
+  final bool trimPrefix;
 
   @override
   Widget build(BuildContext context) {
-    return const SheetContent(
+    return SheetContent(
       bottomPadding: 0,
       topPadding: 0,
-      body: QRScannerBottomSheet(),
+      body: QRScannerBottomSheet(shouldTrimPrefix: trimPrefix),
     );
   }
 }

--- a/test/app/features/wallets/utils/prefix_trimmer_test.dart
+++ b/test/app/features/wallets/utils/prefix_trimmer_test.dart
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ion/app/features/wallets/utils/prefix_trimmer.dart';
+
+import '../../../../test_utils.dart';
+
+void main() {
+  parameterizedGroup('default trimPrefix behavior', [
+    (value: 'abc', expected: 'abc'),
+    (value: 'abc:def', expected: 'def'),
+    (value: 'abc:', expected: ''),
+    (value: ':def', expected: 'def'),
+    (value: 'abc:def:ghi', expected: 'def:ghi'),
+  ], (t) {
+    test(
+      'trimPrefix(${t.value})',
+      () {
+        final result = trimPrefix(t.value);
+        expect(result, t.expected);
+      },
+    );
+  });
+  group(
+    'custom separator for trimPrefix',
+    () {
+      const value = 'abc,def';
+      const expected = 'def';
+      const separator = ',';
+      test('trimPrefix($value, separator=$separator)', () {
+        final result = trimPrefix(value, separator: separator);
+        expect(result, expected);
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Description
This PR fixes removes prefix for QR scanned codes. e.g. if scanner reads "prefix:thecode" it's gonna emmit "thecode" without the "prefix:" part. See tests for the function for better explanation

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
