### PR TITLE
fix: stop video from pausing in full screen when mute is toggled

### DIFF
--- a/lib/app/components/video_preview/video_preview.dart
+++ b/lib/app/components/video_preview/video_preview.dart
@@ -71,6 +71,7 @@ class VideoPreview extends HookConsumerWidget {
       [isFullyVisible, context],
     );
 
+    final wasOffScreen = useRef(false);
     useOnInit(
       () {
         if (controller == null || !controller.value.isInitialized) {
@@ -82,9 +83,10 @@ class VideoPreview extends HookConsumerWidget {
             (!isFullyVisible.value || !isRouteFocused.value) && controller.value.isPlaying;
         if (shouldBeActive) {
           controller.play();
-        } else if (shouldBePaused) {
+        } else if (shouldBePaused && !wasOffScreen.value) {
           controller.pause();
         }
+        wasOffScreen.value = !isFullyVisible.value || !isRouteFocused.value;
       },
       [isFullyVisible.value, isRouteFocused.value, controller],
     );

--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -50,7 +50,7 @@ class VideoPage extends HookConsumerWidget {
               authorPubkey: authorPubkey,
               autoPlay: true,
               looping: looping,
-              uniqueId: framedEventReference?.encode() ?? '',
+              uniqueId: "${framedEventReference?.encode() ?? ''}-video-page",
             ),
           ),
         )

--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -50,7 +50,7 @@ class VideoPage extends HookConsumerWidget {
               authorPubkey: authorPubkey,
               autoPlay: true,
               looping: looping,
-              uniqueId: "${framedEventReference?.encode() ?? ''}-video-page",
+              uniqueId: framedEventReference?.encode() ?? '',
             ),
           ),
         )


### PR DESCRIPTION
## Description
This PR fixes an issue where the video in full screen mode would pause when muted/unmuted

## Additional Notes
This issue is actually caused by the video_preview present inside feed cell underneath that uses the same video controller. It has a `onEffect` which pauses the video, because cell is not visible on the screen. By introducing a `wasOffScreen` flag we avoid video pausing after controller changes if the video_preview was already off screen before that.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
