### PR TITLE
fix(wallet): wait for request to complete before going away from dialog

### DIFF
--- a/lib/app/features/wallets/providers/delete_wallet_view_provider.c.dart
+++ b/lib/app/features/wallets/providers/delete_wallet_view_provider.c.dart
@@ -8,11 +8,9 @@ part 'delete_wallet_view_provider.c.g.dart';
 @riverpod
 class DeleteWalletViewNotifier extends _$DeleteWalletViewNotifier {
   @override
-  Future<void> build() async {
-    state = const AsyncData(null);
-  }
+  FutureOr<void> build({required String walletViewId}) {}
 
-  Future<void> delete({required String walletViewId}) async {
+  Future<void> delete() async {
     if (state.isLoading) return;
 
     state = const AsyncLoading();

--- a/lib/app/features/wallets/views/pages/create_new_wallet_modal.dart
+++ b/lib/app/features/wallets/views/pages/create_new_wallet_modal.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/inputs/text_input/components/text_input_clear_button.dart';
 import 'package:ion/app/components/inputs/text_input/components/text_input_icons.dart';
 import 'package:ion/app/components/inputs/text_input/text_input.dart';
+import 'package:ion/app/components/progress_bar/ion_loading_indicator.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/providers/create_wallet_view_provider.c.dart';
@@ -22,6 +23,8 @@ class CreateNewWalletModal extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final walletName = useState('');
     final controller = useTextEditingController();
+
+    final isCreating = ref.watch(createWalletViewNotifierProvider).isLoading;
 
     return SheetContent(
       body: SingleChildScrollView(
@@ -53,16 +56,21 @@ class CreateNewWalletModal extends HookConsumerWidget {
             ),
             ScreenSideOffset.small(
               child: Button(
-                onPressed: () {
-                  if (walletName.value.isNotEmpty) {
-                    ref
-                        .read(createWalletViewNotifierProvider.notifier)
-                        .createWalletView(name: walletName.value);
+                onPressed: () async {
+                  if (walletName.value.isEmpty) {
+                    return;
+                  }
+                  await ref
+                      .read(createWalletViewNotifierProvider.notifier)
+                      .createWalletView(name: walletName.value);
+
+                  if (context.mounted) {
                     context.pop();
                   }
                 },
+                trailingIcon: isCreating ? const IONLoadingIndicator() : null,
                 label: Text(context.i18n.wallet_create),
-                disabled: walletName.value.isEmpty,
+                disabled: walletName.value.isEmpty || isCreating,
                 mainAxisSize: MainAxisSize.max,
               ),
             ),

--- a/lib/app/features/wallets/views/pages/delete_wallet_modal.dart
+++ b/lib/app/features/wallets/views/pages/delete_wallet_modal.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
+import 'package:ion/app/components/progress_bar/ion_loading_indicator.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/asset_gen_image.dart';
 import 'package:ion/app/extensions/build_context.dart';
@@ -24,6 +25,9 @@ class DeleteWalletModal extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final buttonMinimalSize = Size(buttonsSize, buttonsSize);
+
+    final isDeleting =
+        ref.watch(deleteWalletViewNotifierProvider(walletViewId: walletId)).isLoading;
 
     return SheetContent(
       body: ScreenSideOffset.small(
@@ -75,14 +79,17 @@ class DeleteWalletModal extends ConsumerWidget {
                 ),
                 Expanded(
                   child: Button.compact(
-                    label: Text(
-                      context.i18n.button_delete,
-                    ),
-                    onPressed: () {
-                      ref
-                          .read(deleteWalletViewNotifierProvider.notifier)
-                          .delete(walletViewId: walletId);
-                      context.pop();
+                    label: Text(context.i18n.button_delete),
+                    disabled: isDeleting,
+                    trailingIcon: isDeleting ? const IONLoadingIndicator() : null,
+                    onPressed: () async {
+                      await ref
+                          .read(deleteWalletViewNotifierProvider(walletViewId: walletId).notifier)
+                          .delete();
+
+                      if (context.mounted) {
+                        context.pop();
+                      }
                     },
                     minimumSize: buttonMinimalSize,
                     backgroundColor: context.theme.appColors.attentionRed,


### PR DESCRIPTION
## Description
This PR adds `await` for deleting and creating WalletViews. Previously the app was closing the dialog right after the button is pressed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
![image](https://github.com/user-attachments/assets/755605b8-2239-4d4b-a9e6-91d511877fb1)
![image](https://github.com/user-attachments/assets/4bd0a863-1e4c-4b0b-a2ac-5eede496fa2f)

