### PR TITLE
feat(wallet): toggle Search filed on Search icon tap

### DIFF
--- a/lib/app/features/wallets/views/pages/wallet_page/components/search_bar/search_bar.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/search_bar/search_bar.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/inputs/search_input/search_input.dart';
 import 'package:ion/app/features/wallets/providers/filtered_assets_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/filtered_wallet_coins_provider.c.dart';
+import 'package:ion/app/features/wallets/views/pages/wallet_page/helpers/cancel_search_helper.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/providers/search_visibility_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/tab_type.dart';
 
@@ -40,10 +41,7 @@ class WalletSearchBar extends ConsumerWidget {
         onTextChanged: (String newValue) {
           ref.read(searchQueryProvider.notifier).query = newValue;
         },
-        onCancelSearch: () {
-          ref.read(searchQueryProvider.notifier).query = '';
-          ref.read(searchVisibleProvider.notifier).isVisible = false;
-        },
+        onCancelSearch: () => cancelSearch(ref, tabType),
       ),
     );
   }

--- a/lib/app/features/wallets/views/pages/wallet_page/components/tabs/tabs_header.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/tabs/tabs_header.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/extensions/theme_data.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
 import 'package:ion/app/features/core/providers/feature_flags_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/tabs/tabs_header_tab.dart';
+import 'package:ion/app/features/wallets/views/pages/wallet_page/helpers/cancel_search_helper.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/providers/search_visibility_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/tab_type.dart';
 import 'package:ion/app/router/app_routes.c.dart';
@@ -64,7 +65,12 @@ class WalletTabsHeader extends ConsumerWidget {
           const Spacer(),
           TextButton(
             onPressed: () {
-              ref.read(searchVisibleProvider.notifier).isVisible = true;
+              final isSearchVisible = ref.read(searchVisibleProvider);
+              if (isSearchVisible) {
+                cancelSearch(ref, activeTab);
+              } else {
+                ref.read(searchVisibleProvider.notifier).isVisible = true;
+              }
             },
             child: Padding(
               padding: EdgeInsets.all(UiConstants.hitSlop),

--- a/lib/app/features/wallets/views/pages/wallet_page/helpers/cancel_search_helper.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/helpers/cancel_search_helper.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/wallets/providers/filtered_assets_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/providers/search_visibility_provider.c.dart';

--- a/lib/app/features/wallets/views/pages/wallet_page/helpers/cancel_search_helper.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/helpers/cancel_search_helper.dart
@@ -1,0 +1,12 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/wallets/providers/filtered_assets_provider.c.dart';
+import 'package:ion/app/features/wallets/views/pages/wallet_page/providers/search_visibility_provider.c.dart';
+import 'package:ion/app/features/wallets/views/pages/wallet_page/tab_type.dart';
+
+void cancelSearch(
+  WidgetRef ref,
+  WalletTabType tabType,
+) {
+  ref.read(walletSearchQueryControllerProvider(tabType.walletAssetType).notifier).query = '';
+  ref.read(walletSearchVisibilityProvider(tabType).notifier).isVisible = false;
+}


### PR DESCRIPTION
## Description
Previously, a user had to start typing into the Search field to let the "Cancel" button appear. On the "Cancel" tap, the Search field is hidden.
This PR adds ability to hide the Search field by tapping the Search icon the second time. See the GIF attached.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots 
![CleanShot 2025-04-25 at 23 13 06](https://github.com/user-attachments/assets/db6b8fc2-f82f-4a93-8ad5-83a458b2f967)
