### PR TITLE
bugfix: audio message playback and media handling

### DIFF
--- a/lib/app/features/chat/providers/active_audio_message_provider.c.dart
+++ b/lib/app/features/chat/providers/active_audio_message_provider.c.dart
@@ -1,0 +1,11 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'active_audio_message_provider.c.g.dart';
+
+@riverpod
+class ActiveAudioMessage extends _$ActiveAudioMessage {
+  @override
+  String? build() => null;
+
+  set activeAudioMessage(String? eventMessageId) => state = eventMessageId;
+}

--- a/lib/app/features/chat/providers/active_audio_message_provider.c.dart
+++ b/lib/app/features/chat/providers/active_audio_message_provider.c.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'active_audio_message_provider.c.g.dart';

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
@@ -127,9 +127,11 @@ class AudioMessage extends HookConsumerWidget {
         audioPlaybackController.onPlayerStateChanged.listen((event) {
           if (event != PlayerState.stopped) {
             audioPlaybackState.value = event;
-          } else {
-            ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = null;
           }
+        });
+
+        audioPlaybackController.onCompletion.listen((event) {
+          ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = null;
         });
 
         return null;

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
@@ -98,7 +98,8 @@ class AudioMessage extends HookConsumerWidget {
     );
 
     final audioPlaybackState = useState<PlayerState?>(null);
-    final audioPlaybackController = useAudioWavePlaybackController();
+    final audioPlaybackController = useAudioWavePlaybackController()
+      ..setFinishMode(finishMode: FinishMode.pause);
 
     final playerWaveStyle = useMemoized(
       () => PlayerWaveStyle(
@@ -124,10 +125,10 @@ class AudioMessage extends HookConsumerWidget {
 
         // Listen to player state changes
         audioPlaybackController.onPlayerStateChanged.listen((event) {
-          if (event == PlayerState.stopped) {
-            audioPlaybackState.value = null;
-          } else {
+          if (event != PlayerState.stopped) {
             audioPlaybackState.value = event;
+          } else {
+            ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = null;
           }
         });
 

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
@@ -67,34 +67,16 @@ class AudioMessage extends HookConsumerWidget {
         )
             .then((value) {
           if (value != null) {
-            ref.read(audioCompressorProvider).compressAudioToWav(value.path).then((value) {
-              audioUrl.value = value;
-            });
+            if (context.mounted) {
+              ref.read(audioCompressorProvider).compressAudioToWav(value.path).then((value) {
+                audioUrl.value = value;
+              });
+            }
           }
         });
         return null;
       },
       [messageMedia?.cacheKey, mediaAttachment?.url],
-    );
-
-    useEffect(
-      () {
-        ref
-            .read(
-          chatMessageLoadMediaProvider(
-            entity: entity,
-            mediaAttachment: mediaAttachment,
-            cacheKey: messageMedia?.cacheKey,
-          ),
-        )
-            .then((value) {
-          if (context.mounted) {
-            audioUrl.value = value?.path;
-          }
-        });
-        return null;
-      },
-      [mediaAttachment?.thumb, messageMedia?.cacheKey],
     );
 
     final audioPlaybackState = useState<PlayerState?>(null);

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/audio_message.dart
@@ -124,7 +124,9 @@ class AudioMessage extends HookConsumerWidget {
 
         // Listen to player state changes
         audioPlaybackController.onPlayerStateChanged.listen((event) {
-          if (event != PlayerState.stopped) {
+          if (event == PlayerState.stopped) {
+            audioPlaybackState.value = null;
+          } else {
             audioPlaybackState.value = event;
           }
         });

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/components/play_pause_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/components/play_pause_button.dart
@@ -19,6 +19,7 @@ class _PlayPauseButton extends ConsumerWidget {
         if (audioPlaybackState.value?.isPlaying ?? false) {
           ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = null;
         } else {
+          ref.invalidate(activeAudioMessageProvider);
           ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = eventMessageId;
         }
       },

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/components/play_pause_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/components/play_pause_button.dart
@@ -19,7 +19,6 @@ class _PlayPauseButton extends ConsumerWidget {
         if (audioPlaybackState.value?.isPlaying ?? false) {
           ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = null;
         } else {
-          ref.invalidate(activeAudioMessageProvider);
           ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = eventMessageId;
         }
       },

--- a/lib/app/features/chat/views/components/message_items/message_types/audio_message/components/play_pause_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/audio_message/components/play_pause_button.dart
@@ -2,25 +2,24 @@
 
 part of '../audio_message.dart';
 
-class _PlayPauseButton extends StatelessWidget {
+class _PlayPauseButton extends ConsumerWidget {
   const _PlayPauseButton({
     required this.audioPlaybackController,
     required this.audioPlaybackState,
+    required this.eventMessageId,
   });
 
   final PlayerController audioPlaybackController;
   final ValueNotifier<PlayerState?> audioPlaybackState;
-
+  final String eventMessageId;
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return GestureDetector(
       onTap: () {
         if (audioPlaybackState.value?.isPlaying ?? false) {
-          audioPlaybackController.pausePlayer();
+          ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = null;
         } else {
-          audioPlaybackController
-            ..setFinishMode(finishMode: FinishMode.pause)
-            ..startPlayer();
+          ref.read(activeAudioMessageProvider.notifier).activeAudioMessage = eventMessageId;
         }
       },
       child: Container(

--- a/lib/app/features/chat/views/components/message_items/message_types/document_message/document_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/document_message/document_message.dart
@@ -101,6 +101,7 @@ class DocumentMessage extends HookConsumerWidget {
         children: [
           if (repliedMessageItem != null) ReplyMessage(messageItem, repliedMessageItem),
           GestureDetector(
+            behavior: HitTestBehavior.opaque,
             onTap: () {
               shareFile(localFile.value?.path ?? '', name: entity.data.content);
             },

--- a/lib/app/services/media_service/media_encryption_service.c.dart
+++ b/lib/app/services/media_service/media_encryption_service.c.dart
@@ -95,7 +95,7 @@ class MediaEncryptionService {
           final decryptedFile = await fileCacheService.putFile(
             url: url,
             bytes: decryptedFileBytes,
-            fileExtension: 'pdf',
+            fileExtension: fileExtension,
           );
           return decryptedFile;
         }


### PR DESCRIPTION
## Description
- Add active audio message provider to manage single audio playback
- Refactor audio message component to use load from message media table
- Improve document message tap behavior
- Update media encryption service to use correct file extensions

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/24871f82-da43-4fe0-b68b-e75be41d831e


