### PR TITLE
fix: refresh followers count

### DIFF
--- a/lib/app/features/user/pages/profile_page/profile_page.dart
+++ b/lib/app/features/user/pages/profile_page/profile_page.dart
@@ -18,9 +18,7 @@ import 'package:ion/app/features/user/pages/profile_page/components/tabs/tab_ent
 import 'package:ion/app/features/user/pages/profile_page/components/tabs/tabs_header/tabs_header.dart';
 import 'package:ion/app/features/user/pages/profile_page/hooks/use_animated_opacity_on_scroll.dart';
 import 'package:ion/app/features/user/providers/block_list_notifier.c.dart';
-import 'package:ion/app/features/user/providers/followers_count_provider.c.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
-import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 
 class ProfilePage extends HookConsumerWidget {
@@ -52,12 +50,6 @@ class ProfilePage extends HookConsumerWidget {
     if (!userMetadata.hasValue || isBlockedOrBlocking) {
       return const CantFindProfilePage();
     }
-
-    useOnInit(
-      () {
-        ref.invalidate(followersCountProvider(pubkey: pubkey));
-      },
-    );
 
     final scrollController = useScrollController();
     final (:opacity) = useAnimatedOpacityOnScroll(scrollController, topOffset: paddingTop);

--- a/lib/app/features/user/providers/followers_count_provider.c.dart
+++ b/lib/app/features/user/providers/followers_count_provider.c.dart
@@ -11,7 +11,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'followers_count_provider.c.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 FutureOr<int?> followersCount(
   Ref ref, {
   required String pubkey,


### PR DESCRIPTION
## Description
Remove keep alive for `followersCount` provider, to get new state on profile page instead cached.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore