### PR TITLE
fix: apply balance hack only for tier 1 networks

### DIFF
--- a/lib/app/features/wallets/data/mappers/transaction_mapper.dart
+++ b/lib/app/features/wallets/data/mappers/transaction_mapper.dart
@@ -12,10 +12,7 @@ import 'package:ion/app/features/wallets/model/transaction_details.c.dart';
 import 'package:ion/app/features/wallets/model/transaction_type.dart';
 
 class CoinTransactionsMapper {
-  db.Transaction fromTransactionDetails({
-    required TransactionDetails details,
-    String? balanceBeforeTransactions,
-  }) {
+  db.Transaction fromTransactionDetails(TransactionDetails details) {
     final coinAssetData = details.assetData as CoinAssetToSendData;
 
     return db.Transaction(
@@ -70,9 +67,7 @@ class CoinTransactionsMapper {
         );
       }).toList();
 
-  List<db.Transaction> fromDomainToDB(
-    Iterable<TransactionData> transactions,
-  ) =>
+  List<db.Transaction> fromDomainToDB(Iterable<TransactionData> transactions) =>
       transactions.map((transaction) {
         final coinTransactionAsset = transaction.cryptoAsset.as<CoinTransactionAsset>();
 

--- a/lib/app/features/wallets/data/repository/transactions_repository.c.dart
+++ b/lib/app/features/wallets/data/repository/transactions_repository.c.dart
@@ -60,14 +60,8 @@ class TransactionsRepository {
     return _transactionsDao.getFirstCreatedAt(after: after);
   }
 
-  Future<void> saveTransactionDetails({
-    required TransactionDetails details,
-    String? balanceBeforeTransfer,
-  }) async {
-    final mapped = _coinMapper.fromTransactionDetails(
-      details: details,
-      balanceBeforeTransactions: balanceBeforeTransfer,
-    );
+  Future<void> saveTransactionDetails(TransactionDetails details) async {
+    final mapped = _coinMapper.fromTransactionDetails(details);
     await _transactionsDao.save([mapped]);
   }
 

--- a/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
@@ -142,10 +142,7 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
   }) async {
     // Save transaction into DB
     await ref.read(transactionsRepositoryProvider.future).then(
-          (repo) => repo.saveTransactionDetails(
-            details: details,
-            balanceBeforeTransfer: sendableAsset.balance,
-          ),
+          (repo) => repo.saveTransactionDetails(details),
         );
 
     if (details.participantPubkey == null) return;


### PR DESCRIPTION
## Description
ion service apply similar balance hack itself for tier 2 networks, so we don't need to do it on the mobile side.

## Additional Notes
1. Fix balance hack.
2. Remove `balanceBeforeTransactions`, since it isn't used anymore.
3. Fix issue with `SyncedCoinsBySymbolGroupNotifier`. Earlier because of the state type it was recreated before each call.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore
