### PR TITLE
feat: fetch user relays from db instead of memory cache, add refetch logic when most of the cached relays are dead

### DIFF
--- a/lib/app/features/ion_connect/providers/ion_connect_db_cache_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_db_cache_notifier.c.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:async/async.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
 import 'package:ion/app/features/ion_connect/model/event_serializable.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
@@ -12,16 +14,45 @@ part 'ion_connect_db_cache_notifier.c.g.dart';
 @riverpod
 class IonConnectDbCache extends _$IonConnectDbCache {
   @override
-  Stream<List<IonConnectEntity>> build(List<EventReference> eventReferences) {
+  FutureOr<void> build() async {}
+
+  Stream<List<IonConnectEntity>> watch(List<EventReference> eventReferences) {
     final eventMessagesStream =
         ref.watch(eventMessagesRepositoryProvider).watchAll(eventReferences);
     final parser = ref.read(eventParserProvider);
     return eventMessagesStream.map((eventMessages) => eventMessages.map(parser.parse).toList());
   }
 
+  Future<List<IonConnectEntity>> get(List<EventReference> eventReferences) async {
+    final eventMessages =
+        await ref.read(eventMessagesRepositoryProvider).watchAll(eventReferences).firstOrNull;
+    final parser = ref.read(eventParserProvider);
+    return eventMessages?.map(parser.parse).toList() ?? [];
+  }
+
   Future<void> save(EntityEventSerializable eventSerializable) async {
     final eventMessage = await eventSerializable.toEntityEventMessage();
     final eventReference = eventSerializable.toEventReference();
     await ref.read(eventMessagesRepositoryProvider).save(eventMessage, eventReference);
+  }
+
+  Future<void> saveAll(List<EntityEventSerializable> eventSerializables) async {
+    if (eventSerializables.isEmpty) return;
+    final eventMessages = await Future.wait(
+      eventSerializables.map(
+        (eventSerializable) {
+          final eventMessage = eventSerializable.toEntityEventMessage();
+          if (eventMessage is Future) {
+            return eventMessage as Future<EventMessage>;
+          } else {
+            return Future<EventMessage>.value(eventMessage);
+          }
+        },
+      ),
+    );
+    final eventReferences = eventSerializables
+        .map((eventSerializable) => eventSerializable.toEventReference())
+        .toList();
+    await ref.read(eventMessagesRepositoryProvider).saveAll(eventMessages, eventReferences);
   }
 }

--- a/lib/app/features/user/providers/relays_reachability_provider.c.dart
+++ b/lib/app/features/user/providers/relays_reachability_provider.c.dart
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:ion/app/services/storage/local_storage.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'relays_reachability_provider.c.g.dart';
+
+final class RelayReachabilityInfo {
+  const RelayReachabilityInfo({
+    required this.relayUrl,
+    required this.failedToReachCount,
+    required this.lastFailedToReachDate,
+  });
+
+  final String relayUrl;
+  final int failedToReachCount;
+  final DateTime lastFailedToReachDate;
+}
+
+@riverpod
+class RelayReachability extends _$RelayReachability {
+  @override
+  FutureOr<void> build() async {}
+
+  RelayReachabilityInfo? get(String relayUrl) {
+    final localStorage = ref.read(localStorageProvider);
+
+    final key = _getKey(relayUrl);
+    final reachabilityInfo = localStorage.getStringList(key);
+    if (reachabilityInfo == null || reachabilityInfo.isEmpty) {
+      return null;
+    }
+    final failedToReachCount = int.parse(reachabilityInfo[0]);
+    final lastFailedToReachDate = DateTime.parse(reachabilityInfo[1]);
+    return RelayReachabilityInfo(
+      relayUrl: relayUrl,
+      failedToReachCount: failedToReachCount,
+      lastFailedToReachDate: lastFailedToReachDate,
+    );
+  }
+
+  void save(RelayReachabilityInfo relayReachabilityInfo) {
+    final localStorage = ref.read(localStorageProvider);
+    final key = _getKey(relayReachabilityInfo.relayUrl);
+    localStorage.setStringList(
+      key,
+      [
+        relayReachabilityInfo.failedToReachCount.toString(),
+        relayReachabilityInfo.lastFailedToReachDate.toIso8601String(),
+      ],
+    );
+  }
+
+  String _getKey(String relayUrl) {
+    return 'relay_reachability_info_$relayUrl';
+  }
+}


### PR DESCRIPTION
## Description
This PR migrates `UserRelaysManager` to use db cache instead of memory cache. 
It also adds logic to refetch the relays if most of them are marked as dead

## Additional Notes
Relays will be marked as dead when there are three consecutive failed attempts to reach them with 1 hour passing between each attempt. This will be implemented as part of the next PR.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
