### PR TITLE
fix: prevent overlap issue when text message has a new line char

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -167,19 +167,14 @@ class _TextMessageContent extends HookWidget {
       final wouldOverlap =
           lineMetrics.last.width.s > (maxAvailableWidth - metadataWidth.value.s + 32.0.s);
 
-      final maxLineWidth = lineMetrics.map((e) => e.width).reduce((a, b) => a > b ? a : b);
-      final wouldPadding = () {
-        if (maxLineWidth.s > maxAvailableWidth) {
-          return 0.0.s;
-        }
-        return metadataWidth.value.s + 8.0.s;
-      }();
+      final contentPadding =
+          _calculateContentPadding(lineMetrics, maxAvailableWidth, metadataWidth.value);
 
       return Stack(
         alignment: AlignmentDirectional.bottomEnd,
         children: [
           Padding(
-            padding: EdgeInsetsDirectional.only(end: wouldPadding),
+            padding: EdgeInsetsDirectional.only(end: contentPadding),
             child:
                 _TextRichContent(text: wouldOverlap ? '$content\n' : content, textStyle: textStyle),
           ),
@@ -190,6 +185,18 @@ class _TextMessageContent extends HookWidget {
         ],
       );
     }
+  }
+
+  double _calculateContentPadding(
+    List<LineMetrics> lineMetrics,
+    double maxAvailableWidth,
+    double metadataWidth,
+  ) {
+    final maxLineWidth = lineMetrics.map((e) => e.width).reduce((a, b) => a > b ? a : b);
+    if (maxLineWidth.s > maxAvailableWidth) {
+      return 0.0.s;
+    }
+    return metadataWidth.s + 8.0.s;
   }
 }
 

--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -159,16 +159,34 @@ class _TextMessageContent extends HookWidget {
         text: TextSpan(text: content, style: textStyle),
         textDirection: TextDirection.ltr,
         textWidthBasis: TextWidthBasis.longestLine,
-      )..layout(maxWidth: maxAvailableWidth);
+        textScaler: MediaQuery.textScalerOf(context),
+      )..layout(maxWidth: maxAvailableWidth + 32.0.s);
 
       final lineMetrics = multiLineTextPainter.computeLineMetrics();
-      final wouldOverlap = lineMetrics.last.width > 184.0.s;
+
+      final wouldOverlap =
+          lineMetrics.last.width.s > (maxAvailableWidth - metadataWidth.value.s + 32.0.s);
+
+      final maxLineWidth = lineMetrics.map((e) => e.width).reduce((a, b) => a > b ? a : b);
+      final wouldPadding = () {
+        if (maxLineWidth.s > maxAvailableWidth) {
+          return 0.0.s;
+        }
+        return metadataWidth.value.s + 8.0.s;
+      }();
 
       return Stack(
         alignment: AlignmentDirectional.bottomEnd,
         children: [
-          _TextRichContent(text: wouldOverlap ? '$content\n' : content, textStyle: textStyle),
-          MessageMetaData(eventMessage: eventMessage, key: metadataRef.value),
+          Padding(
+            padding: EdgeInsets.only(right: wouldPadding),
+            child:
+                _TextRichContent(text: wouldOverlap ? '$content\n' : content, textStyle: textStyle),
+          ),
+          MessageMetaData(
+            eventMessage: eventMessage,
+            key: metadataRef.value,
+          ),
         ],
       );
     }

--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -179,7 +179,7 @@ class _TextMessageContent extends HookWidget {
         alignment: AlignmentDirectional.bottomEnd,
         children: [
           Padding(
-            padding: EdgeInsets.only(right: wouldPadding),
+            padding: EdgeInsetsDirectional.only(end: wouldPadding),
             child:
                 _TextRichContent(text: wouldOverlap ? '$content\n' : content, textStyle: textStyle),
           ),


### PR DESCRIPTION
## Description
This PR fixes an issue where text messages containing newline characters would cause layout overlap with the message metadata.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<img width="180" alt="image" src="https://github.com/user-attachments/assets/d274f4d0-36fe-416f-844e-6860aa43cad5">