### PR TITLE
feat: add refetch for unreachable relays

### DIFF
--- a/lib/app/exceptions/exceptions.dart
+++ b/lib/app/exceptions/exceptions.dart
@@ -496,3 +496,9 @@ class GetRelayInfoException extends IONException {
 class ConfigureFirebaseAppException extends IONException {
   ConfigureFirebaseAppException() : super(10098, 'Failed to configure firebase app');
 }
+
+class RelayUnreachableException extends IONException {
+  RelayUnreachableException(this.relayUrl) : super(10099, 'Unable to connect to relay: $relayUrl');
+
+  final String relayUrl;
+}

--- a/lib/app/features/chat/providers/user_chat_relays_provider.c.dart
+++ b/lib/app/features/chat/providers/user_chat_relays_provider.c.dart
@@ -4,9 +4,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.c.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
-import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.c.dart';
+import 'package:ion/app/features/ion_connect/providers/ion_connect_db_cache_notifier.c.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_notifier.c.dart';
 import 'package:ion/app/features/user/model/user_chat_relays.c.dart';
+import 'package:ion/app/features/user/providers/relays_reachability_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_chat_relays_provider.c.g.dart';
@@ -24,13 +25,15 @@ class UserChatRelaysManager extends _$UserChatRelaysManager {
   Future<UserChatRelaysEntity?> fetch(String pubkey) async {
     final eventReference =
         ReplaceableEventReference(pubkey: pubkey, kind: UserChatRelaysEntity.kind);
-    final entity = ref.read(
-      ionConnectCacheProvider.select(
-        cacheSelector(CacheableEntity.cacheKeyBuilder(eventReference: eventReference)),
-      ),
-    );
-    if (entity != null) {
-      return entity as UserChatRelaysEntity;
+    final entity = (await ref.read(ionConnectDbCacheProvider.notifier).get([eventReference]))
+        .cast<UserChatRelaysEntity?>()
+        .nonNulls
+        .firstOrNull;
+    final filteredRelayEntity =
+        ref.read(relayReachabilityProvider.notifier).getFilteredChatRelayEntity(entity);
+
+    if (filteredRelayEntity != null) {
+      return filteredRelayEntity;
     }
 
     final requestMessage = RequestMessage()
@@ -44,9 +47,27 @@ class UserChatRelaysManager extends _$UserChatRelaysManager {
           limit: 1,
         ),
       );
-    return ref.read(ionConnectNotifierProvider.notifier).requestEntity(
+    final relay = await ref.read(ionConnectNotifierProvider.notifier).requestEntity(
           requestMessage,
           actionSource: ActionSourceUser(eventReference.pubkey),
         );
+
+    if (relay != null && relay is UserChatRelaysEntity) {
+      await (
+        ref.read(ionConnectDbCacheProvider.notifier).save(relay),
+        _clearReachabilityInfoFor(relay.urls)
+      ).wait;
+    }
+
+    return relay as UserChatRelaysEntity?;
+  }
+
+  Future<void> _clearReachabilityInfoFor(
+    List<String> relaysUrls,
+  ) async {
+    final reachabilityInfoNotifier = ref.read(relayReachabilityProvider.notifier);
+    for (final url in relaysUrls) {
+      await reachabilityInfoNotifier.clear(url);
+    }
   }
 }

--- a/lib/app/features/ion_connect/providers/ion_connect_db_cache_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_db_cache_notifier.c.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:async/async.dart';
-import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
 import 'package:ion/app/features/ion_connect/model/event_serializable.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
@@ -40,14 +39,7 @@ class IonConnectDbCache extends _$IonConnectDbCache {
     if (eventSerializables.isEmpty) return;
     final eventMessages = await Future.wait(
       eventSerializables.map(
-        (eventSerializable) {
-          final eventMessage = eventSerializable.toEntityEventMessage();
-          if (eventMessage is Future) {
-            return eventMessage as Future<EventMessage>;
-          } else {
-            return Future<EventMessage>.value(eventMessage);
-          }
-        },
+        (eventSerializable) => Future.value(eventSerializable.toEntityEventMessage()),
       ),
     );
     final eventReferences = eventSerializables

--- a/lib/app/features/ion_connect/providers/ion_connect_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_notifier.c.dart
@@ -70,9 +70,15 @@ class IonConnectNotifier extends _$IonConnectNotifier {
         return null;
       },
       retryWhen: (error) =>
-          error is RelayRequestFailedException || RelayAuthService.isRelayAuthError(error),
-      onRetry: () {
-        if (relay != null) dislikedRelaysUrls.add(relay!.url);
+          error is RelayRequestFailedException ||
+          RelayAuthService.isRelayAuthError(error) ||
+          (error is RelayUnreachableException && !dislikedRelaysUrls.contains(error.relayUrl)),
+      onRetry: (error) {
+        if (relay != null) {
+          dislikedRelaysUrls.add(relay!.url);
+        } else if (error is RelayUnreachableException) {
+          dislikedRelaysUrls.add(error.relayUrl);
+        }
       },
     );
   }
@@ -151,9 +157,15 @@ class IonConnectNotifier extends _$IonConnectNotifier {
         }
       },
       retryWhen: (error) =>
-          error is RelayRequestFailedException || RelayAuthService.isRelayAuthError(error),
-      onRetry: () {
-        if (relay != null) dislikedRelaysUrls.add(relay!.url);
+          error is RelayRequestFailedException ||
+          RelayAuthService.isRelayAuthError(error) ||
+          (error is RelayUnreachableException && !dislikedRelaysUrls.contains(error.relayUrl)),
+      onRetry: (error) {
+        if (relay != null) {
+          dislikedRelaysUrls.add(relay!.url);
+        } else if (error is RelayUnreachableException) {
+          dislikedRelaysUrls.add(error.relayUrl);
+        }
       },
     );
   }

--- a/lib/app/features/ion_connect/providers/mixins/relay_create_mixin.dart
+++ b/lib/app/features/ion_connect/providers/mixins/relay_create_mixin.dart
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/exceptions/exceptions.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/user/providers/relays_reachability_provider.c.dart';
+
+mixin RelayCreateMixin {
+  Future<IonConnectRelay> createRelay(Ref ref, String url) async {
+    final socket = WebSocket(Uri.parse(url));
+    final relay = IonConnectRelay(url: url, socket: socket);
+    final connectionState = await socket.connection.firstWhere(
+      (state) => state is Connected || state is Reconnected || state is Disconnected,
+    );
+    if (_isRelayUnreachable(connectionState)) {
+      socket.close();
+      await _updateRelayReachabilityInfo(ref, url);
+      throw RelayUnreachableException(url);
+    }
+    await ref.read(relayReachabilityProvider.notifier).clear(url);
+    return relay;
+  }
+
+  bool _isRelayUnreachable(ConnectionState connectionState) {
+    if (connectionState is! Disconnected) {
+      return false;
+    }
+    final error = connectionState.error;
+    if (error == null || error is! SocketException) {
+      return false;
+    }
+    final osError = error.osError;
+    if (osError == null) {
+      return false;
+    }
+    return _unreachableRelayErrorCodes.contains(osError.errorCode);
+  }
+
+  List<int> get _unreachableRelayErrorCodes => [
+        8, // android connection refused
+        61, // ios connection refused
+      ];
+
+  Future<void> _updateRelayReachabilityInfo(Ref ref, String url) async {
+    final relayReachabilityInfo = ref.read(relayReachabilityProvider.notifier).get(url);
+    final updatedReachabilityInfo = _getUpdatedReachabilityInfo(url, relayReachabilityInfo);
+    await ref.read(relayReachabilityProvider.notifier).save(updatedReachabilityInfo);
+  }
+
+  RelayReachabilityInfo _getUpdatedReachabilityInfo(
+    String url,
+    RelayReachabilityInfo? reachabilityInfo,
+  ) {
+    if (reachabilityInfo == null) {
+      return RelayReachabilityInfo(
+        relayUrl: url,
+        failedToReachCount: 1,
+        lastFailedToReachDate: DateTime.now(),
+      );
+    }
+    final timeDifference = DateTime.now().difference(reachabilityInfo.lastFailedToReachDate).abs();
+    if (timeDifference.inHours < 1) {
+      return reachabilityInfo;
+    }
+
+    return RelayReachabilityInfo(
+      relayUrl: url,
+      failedToReachCount: reachabilityInfo.failedToReachCount + 1,
+      lastFailedToReachDate: DateTime.now(),
+    );
+  }
+}

--- a/lib/app/features/ion_connect/providers/relay_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/relay_provider.c.dart
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:async';
-import 'dart:io';
 
-import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_active_mixin.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_auth_mixin.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_closed_mixin.dart';
+import 'package:ion/app/features/ion_connect/providers/mixins/relay_create_mixin.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_timer_mixin.dart';
-import 'package:ion/app/features/user/providers/relays_reachability_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'relay_provider.c.g.dart';
@@ -18,10 +16,10 @@ typedef RelaysState = Map<String, IonConnectRelay>;
 
 @Riverpod(keepAlive: true)
 class Relay extends _$Relay
-    with RelayTimerMixin, RelayAuthMixin, RelayClosedMixin, RelayActiveMixin {
+    with RelayTimerMixin, RelayCreateMixin, RelayAuthMixin, RelayClosedMixin, RelayActiveMixin {
   @override
   Future<IonConnectRelay> build(String url, {bool anonymous = false}) async {
-    final relay = await _getRelay(url);
+    final relay = await createRelay(ref, url);
 
     trackRelayAsActive(relay, ref);
     initializeRelayTimer(relay, ref);
@@ -34,66 +32,5 @@ class Relay extends _$Relay
     ref.onDispose(relay.close);
 
     return relay;
-  }
-
-  Future<IonConnectRelay> _getRelay(String url) async {
-    final socket = WebSocket(Uri.parse(url));
-    final relay = IonConnectRelay(url: url, socket: socket);
-    final connectionState = await socket.connection.firstWhere(
-      (state) => state is Connected || state is Reconnected || state is Disconnected,
-    );
-    if (_isRelayUnreachable(connectionState)) {
-      socket.close();
-      await _updateRelayReachabilityInfo(url);
-      throw RelayUnreachableException(url);
-    }
-    await ref.read(relayReachabilityProvider.notifier).clear(url);
-    return relay;
-  }
-
-  bool _isRelayUnreachable(ConnectionState connectionState) {
-    if (connectionState is! Disconnected) {
-      return false;
-    }
-    final error = connectionState.error;
-    if (error == null || error is! SocketException) {
-      return false;
-    }
-    final osError = error.osError;
-    if (osError == null) {
-      return false;
-    }
-    return _unreachableRelayErrorCodes.contains(osError.errorCode);
-  }
-
-  List<int> get _unreachableRelayErrorCodes => [
-        8, // android connection refused
-        61, // ios connection refused
-      ];
-
-  Future<void> _updateRelayReachabilityInfo(String url) async {
-    final relayReachabilityInfo = ref.read(relayReachabilityProvider.notifier).get(url);
-    final updatedReachabilityInfo = _getUpdatedReachabilityInfo(relayReachabilityInfo);
-    await ref.read(relayReachabilityProvider.notifier).save(updatedReachabilityInfo);
-  }
-
-  RelayReachabilityInfo _getUpdatedReachabilityInfo(RelayReachabilityInfo? reachabilityInfo) {
-    if (reachabilityInfo == null) {
-      return RelayReachabilityInfo(
-        relayUrl: url,
-        failedToReachCount: 1,
-        lastFailedToReachDate: DateTime.now(),
-      );
-    }
-    final timeDifference = DateTime.now().difference(reachabilityInfo.lastFailedToReachDate).abs();
-    if (timeDifference.inHours < 1) {
-      return reachabilityInfo;
-    }
-
-    return RelayReachabilityInfo(
-      relayUrl: url,
-      failedToReachCount: reachabilityInfo.failedToReachCount + 1,
-      lastFailedToReachDate: DateTime.now(),
-    );
   }
 }

--- a/lib/app/features/ion_connect/providers/relay_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/relay_provider.c.dart
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:async';
+import 'dart:io';
 
+import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_active_mixin.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_auth_mixin.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_closed_mixin.dart';
 import 'package:ion/app/features/ion_connect/providers/mixins/relay_timer_mixin.dart';
+import 'package:ion/app/features/user/providers/relays_reachability_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'relay_provider.c.g.dart';
@@ -18,7 +21,7 @@ class Relay extends _$Relay
     with RelayTimerMixin, RelayAuthMixin, RelayClosedMixin, RelayActiveMixin {
   @override
   Future<IonConnectRelay> build(String url, {bool anonymous = false}) async {
-    final relay = await IonConnectRelay.connect(url);
+    final relay = await _getRelay(url);
 
     trackRelayAsActive(relay, ref);
     initializeRelayTimer(relay, ref);
@@ -31,5 +34,66 @@ class Relay extends _$Relay
     ref.onDispose(relay.close);
 
     return relay;
+  }
+
+  Future<IonConnectRelay> _getRelay(String url) async {
+    final socket = WebSocket(Uri.parse(url));
+    final relay = IonConnectRelay(url: url, socket: socket);
+    final connectionState = await socket.connection.firstWhere(
+      (state) => state is Connected || state is Reconnected || state is Disconnected,
+    );
+    if (_isRelayUnreachable(connectionState)) {
+      socket.close();
+      await _updateRelayReachabilityInfo(url);
+      throw RelayUnreachableException(url);
+    }
+    await ref.read(relayReachabilityProvider.notifier).clear(url);
+    return relay;
+  }
+
+  bool _isRelayUnreachable(ConnectionState connectionState) {
+    if (connectionState is! Disconnected) {
+      return false;
+    }
+    final error = connectionState.error;
+    if (error == null || error is! SocketException) {
+      return false;
+    }
+    final osError = error.osError;
+    if (osError == null) {
+      return false;
+    }
+    return _unreachableRelayErrorCodes.contains(osError.errorCode);
+  }
+
+  List<int> get _unreachableRelayErrorCodes => [
+        8, // android connection refused
+        61, // ios connection refused
+      ];
+
+  Future<void> _updateRelayReachabilityInfo(String url) async {
+    final relayReachabilityInfo = ref.read(relayReachabilityProvider.notifier).get(url);
+    final updatedReachabilityInfo = _getUpdatedReachabilityInfo(relayReachabilityInfo);
+    await ref.read(relayReachabilityProvider.notifier).save(updatedReachabilityInfo);
+  }
+
+  RelayReachabilityInfo _getUpdatedReachabilityInfo(RelayReachabilityInfo? reachabilityInfo) {
+    if (reachabilityInfo == null) {
+      return RelayReachabilityInfo(
+        relayUrl: url,
+        failedToReachCount: 1,
+        lastFailedToReachDate: DateTime.now(),
+      );
+    }
+    final timeDifference = DateTime.now().difference(reachabilityInfo.lastFailedToReachDate).abs();
+    if (timeDifference.inHours < 1) {
+      return reachabilityInfo;
+    }
+
+    return RelayReachabilityInfo(
+      relayUrl: url,
+      failedToReachCount: reachabilityInfo.failedToReachCount + 1,
+      lastFailedToReachDate: DateTime.now(),
+    );
   }
 }

--- a/lib/app/features/user/model/user_chat_relays.c.dart
+++ b/lib/app/features/user/model/user_chat_relays.c.dart
@@ -16,7 +16,8 @@ part 'user_chat_relays.c.freezed.dart';
 
 @Freezed(equal: false)
 class UserChatRelaysEntity
-    with IonConnectEntity, CacheableEntity, ReplaceableEntity, _$UserChatRelaysEntity {
+    with IonConnectEntity, CacheableEntity, ReplaceableEntity, _$UserChatRelaysEntity
+    implements EntityEventSerializable {
   const factory UserChatRelaysEntity({
     required String id,
     required String pubkey,
@@ -43,6 +44,9 @@ class UserChatRelaysEntity
       data: UserChatRelaysData.fromEventMessage(eventMessage),
     );
   }
+
+  @override
+  FutureOr<EventMessage> toEntityEventMessage() => toEventMessage(data);
 
   List<String> get urls => data.list.map((relay) => relay.url).toList();
 
@@ -95,5 +99,6 @@ class UserChatRelaysData
   }
 
   static List<String> toRelayTag(UserRelay relay) => ['relay', relay.url];
+
   static UserRelay fromRelayTag(List<String> tag) => UserRelay(url: tag[1]);
 }

--- a/lib/app/features/user/providers/user_relays_manager.c.dart
+++ b/lib/app/features/user/providers/user_relays_manager.c.dart
@@ -170,10 +170,7 @@ class UserRelaysManager extends _$UserRelaysManager {
     List<UserRelaysEntity> relays,
   ) async {
     final reachabilityInfoNotifier = ref.read(relayReachabilityProvider.notifier);
-    final relayUrls = relays
-        .map((relay) => relay.data.list.map((e) => e.url))
-        .expand((element) => element)
-        .toSet();
+    final relayUrls = relays.map((relay) => relay.urls).expand((element) => element).toSet();
     for (final url in relayUrls) {
       await reachabilityInfoNotifier.clear(url);
     }

--- a/lib/app/features/user/providers/user_relays_manager.c.dart
+++ b/lib/app/features/user/providers/user_relays_manager.c.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
@@ -80,9 +81,13 @@ class UserRelaysManager extends _$UserRelaysManager {
         .toList();
 
     for (final pubkey in pubkeys) {
-      final cached = dbCachedRelays.where((relay) => relay.pubkey == pubkey).firstOrNull;
-      if (cached != null && !_needsRefresh(cached)) {
-        result.add(cached);
+      final cachedRelaysEntity =
+          dbCachedRelays.where((relay) => relay.masterPubkey == pubkey).firstOrNull;
+      final filteredRelayEntity =
+          ref.read(relayReachabilityProvider.notifier).getFilteredRelayEntity(cachedRelaysEntity);
+
+      if (filteredRelayEntity != null) {
+        result.add(filteredRelayEntity);
       } else {
         pubkeysToFetch.add(pubkey);
       }
@@ -121,7 +126,10 @@ class UserRelaysManager extends _$UserRelaysManager {
     }
 
     if (fetchedRelays.isNotEmpty) {
-      await ref.read(ionConnectDbCacheProvider.notifier).saveAll(fetchedRelays);
+      await (
+        ref.read(ionConnectDbCacheProvider.notifier).saveAll(fetchedRelays),
+        _clearReachabilityInfoFor(fetchedRelays),
+      ).wait;
     }
 
     return result;
@@ -158,16 +166,16 @@ class UserRelaysManager extends _$UserRelaysManager {
     return userRelays;
   }
 
-  bool _needsRefresh(UserRelaysEntity relaysEntity) {
+  Future<void> _clearReachabilityInfoFor(
+    List<UserRelaysEntity> relays,
+  ) async {
     final reachabilityInfoNotifier = ref.read(relayReachabilityProvider.notifier);
-    final reachabilityInfos = relaysEntity.data.list
-        .map((relay) => reachabilityInfoNotifier.get(relay.url))
-        .whereType<RelayReachabilityInfo>();
-    final deadRelays = reachabilityInfos
-        .where((reachabilityInfo) => reachabilityInfo.failedToReachCount >= 3)
-        .toList();
-
-    // needs refresh when 50% + 1 or more are dead
-    return deadRelays.length >= (relaysEntity.data.list.length / 2 + 1).floor();
+    final relayUrls = relays
+        .map((relay) => relay.data.list.map((e) => e.url))
+        .expand((element) => element)
+        .toSet();
+    for (final url in relayUrls) {
+      await reachabilityInfoNotifier.clear(url);
+    }
   }
 }

--- a/lib/app/utils/retry.dart
+++ b/lib/app/utils/retry.dart
@@ -3,7 +3,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:ion/app/services/logger/logger.dart';
 
 Future<T> withRetry<T>(
@@ -14,7 +13,7 @@ Future<T> withRetry<T>(
   double multiplier = 3,
   double minJitter = 0.5,
   double maxJitter = 1.5,
-  VoidCallback? onRetry,
+  void Function(Object? error)? onRetry,
   bool Function(Object)? retryWhen,
 }) async {
   return withRetryStream<T>(
@@ -38,7 +37,7 @@ Stream<T> withRetryStream<T>(
   double multiplier = 3,
   double minJitter = 0.5,
   double maxJitter = 1.5,
-  VoidCallback? onRetry,
+  void Function(Object? error)? onRetry,
   bool Function(Object)? retryWhen,
 }) async* {
   var attempt = 0;
@@ -78,7 +77,7 @@ Stream<T> withRetryStream<T>(
       Logger.log('Retry #$attempt after ${delay.inMilliseconds}ms...');
       await Future<void>.delayed(delay);
     }
-    onRetry?.call();
+    onRetry?.call(lastError);
   }
 
   throw Exception('Unreachable');


### PR DESCRIPTION
## Description
This PR adds a mechanism for caching relays and refetching them when more than 50% of them are marked as dead.

## Additional Notes
Relay will marked as dead when there are 3 consecutive failed connection attempts with 1 hour between each one. 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
