### PR TITLE
fix: request funds amount validation

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -42,12 +42,21 @@ class CoinAmountInput extends HookWidget {
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
           onValidated: (isValid) => isValidInput.value = isValid,
           validator: (value) {
-            final parsed = parseAmount(value);
+            final trimmedValue = value?.trim() ?? '';
+            if (trimmedValue.isEmpty) {
+              return null;
+            }
 
-            final error = locale.wallet_coin_amount_insufficient_funds;
+            final parsed = parseAmount(trimmedValue);
+            if (parsed == null) return '';
 
-            if (parsed == null) return error;
-            if ((maxValue != null && parsed > maxValue!) || parsed < 0) return error;
+            if (maxValue != null && (parsed > maxValue! || parsed <= 0)) {
+              return locale.wallet_coin_amount_insufficient_funds;
+            } else if (parsed < 0) {
+              return locale.wallet_coin_amount_must_be_positive;
+            } else if (parsed == 0) {
+              return '';
+            }
 
             return null;
           },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -391,6 +391,7 @@
   "wallet_approximate_in_usd": "~ ${amount}",
   "wallet_coin_amount": "{coin} amount",
   "wallet_coin_amount_insufficient_funds": "Insufficient funds",
+  "wallet_coin_amount_must_be_positive": "Amount must be positive",
   "wallet_address_is_invalid": "Invalid address",
   "wallet_import_token_title": "Import token",
   "wallet_import_token_address_label": "Token address",


### PR DESCRIPTION
## Description
This PR fixes the amount field validation in the Request Funds form. Also, we use this component in the Send Funds form, that's why there're additional checks for `maxValue` (we don't use `maxValue` for funds request).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/c39a357d-16c2-414e-b33b-2bbb25d06838" />

