### PR TITLE
fix: video/image stories shrinking when keyboard appears

### DIFF
--- a/lib/app/features/feed/stories/hooks/use_keyboard_height.dart
+++ b/lib/app/features/feed/stories/hooks/use_keyboard_height.dart
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+double _logicalInset(FlutterView view) => view.viewInsets.bottom / view.devicePixelRatio;
+
+double useKeyboardHeight() {
+  final dispatcher = WidgetsBinding.instance.platformDispatcher;
+  final height = useState<double>(_logicalInset(dispatcher.views.first));
+
+  useEffect(
+    () {
+      final obs = _MetricsObserver(
+        onMetricsChanged: () => height.value = _logicalInset(dispatcher.views.first),
+      );
+
+      WidgetsBinding.instance.addObserver(obs);
+      return () => WidgetsBinding.instance.removeObserver(obs);
+    },
+    [dispatcher],
+  );
+
+  return height.value;
+}
+
+class _MetricsObserver with WidgetsBindingObserver {
+  _MetricsObserver({required this.onMetricsChanged});
+  final VoidCallback onMetricsChanged;
+
+  @override
+  void didChangeMetrics() => onMetricsChanged();
+}

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
@@ -12,6 +12,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
 import 'package:ion/app/features/feed/providers/can_reply_notifier.c.dart';
+import 'package:ion/app/features/feed/stories/hooks/use_keyboard_height.dart';
 import 'package:ion/app/features/feed/stories/providers/emoji_reaction_provider.c.dart';
 import 'package:ion/app/features/feed/stories/providers/story_pause_provider.c.dart';
 import 'package:ion/app/features/feed/stories/providers/story_reply_provider.c.dart';
@@ -128,12 +129,9 @@ class _StoryControlsPanel extends HookConsumerWidget {
     final keyboardHeight = useKeyboardHeight();
     final safeArea = MediaQuery.viewPaddingOf(context).bottom;
 
-    const baselineInset = 16.0;
-    final baseline = safeArea + baselineInset.s;
+    final baseline = safeArea + 16.0.s;
     final linear = keyboardHeight + safeArea - controlsHeight.value;
     final bottomPadding = math.max(baseline, linear);
-
-    dumpMetrics('_StoryControls', keyboardHeight, safeArea, bottomPadding);
 
     Future<void> onSubmit(String? txt) async {
       if (txt == null || txt.isEmpty) return;
@@ -177,35 +175,4 @@ class _StoryControlsPanel extends HookConsumerWidget {
       ],
     );
   }
-}
-
-double _logicalInset(FlutterView v) => v.viewInsets.bottom / v.devicePixelRatio;
-
-double useKeyboardHeight() {
-  final dispatcher = WidgetsBinding.instance.platformDispatcher;
-  final height = useState<double>(_logicalInset(dispatcher.views.first));
-
-  useEffect(
-    () {
-      final obs = _MetricsObserver(
-        onMetricsChanged: () => height.value = _logicalInset(dispatcher.views.first),
-      );
-      WidgetsBinding.instance.addObserver(obs);
-      return () => WidgetsBinding.instance.removeObserver(obs);
-    },
-    [dispatcher],
-  );
-
-  return height.value;
-}
-
-class _MetricsObserver with WidgetsBindingObserver {
-  _MetricsObserver({required this.onMetricsChanged});
-  final VoidCallback onMetricsChanged;
-  @override
-  void didChangeMetrics() => onMetricsChanged();
-}
-
-void dumpMetrics(String tag, double kh, double safe, double pad) {
-  debugPrint('$tag  keyboard=$kh  safe=$safe  bottomPadding=$pad');
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
@@ -3,7 +3,6 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -16,7 +15,9 @@ import 'package:ion/app/features/feed/stories/providers/emoji_reaction_provider.
 import 'package:ion/app/features/feed/stories/providers/story_pause_provider.c.dart';
 import 'package:ion/app/features/feed/stories/providers/story_reply_provider.c.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/components.dart';
-import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/header/header.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/header/story_header_gradient.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/header/story_viewer_header.dart';
+import 'package:ion/app/utils/future.dart';
 
 class StoryContent extends HookConsumerWidget {
   const StoryContent({
@@ -109,8 +110,7 @@ class _FooterArea extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final bottomPadding =
-        isKeyboardShown ? MediaQuery.viewInsetsOf(context).bottom + 16.0.s : 16.0.s;
+    final bottomPadding = isKeyboardShown ? 250.0.s : 16.0.s;
 
     Future<void> onSubmit(String? txt) async {
       if (txt == null || txt.isEmpty) return;

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_input_field.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_input_field.dart
@@ -15,13 +15,11 @@ import 'package:ion/app/hooks/use_on_init.dart';
 class StoryInputField extends HookConsumerWidget {
   const StoryInputField({
     required this.controller,
-    required this.bottomPadding,
     required this.onSubmitted,
     super.key,
   });
 
   final TextEditingController controller;
-  final double bottomPadding;
   final ValueChanged<String?> onSubmitted;
 
   @override
@@ -43,84 +41,71 @@ class StoryInputField extends HookConsumerWidget {
 
     useEffect(
       () {
-        void onTextChanged() {
-          isTextNotEmpty.value = controller.text.isNotEmpty;
-        }
-
+        void onTextChanged() => isTextNotEmpty.value = controller.text.isNotEmpty;
         controller.addListener(onTextChanged);
-
-        return () {
-          controller.removeListener(onTextChanged);
-        };
+        return () => controller.removeListener(onTextChanged);
       },
       [controller],
     );
 
-    return PositionedDirectional(
-      bottom: bottomPadding,
-      start: 16.0.s,
-      end: 68.0.s,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: EdgeInsetsDirectional.only(
-              start: 16.0.s,
-              end: 16.0.s,
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(16.0.s),
-              child: Container(
-                constraints: BoxConstraints(
-                  minHeight: 36.0.s,
-                ),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 3, sigmaY: 3),
-                  child: Stack(
-                    children: [
-                      TextField(
-                        minLines: 1,
-                        maxLines: 4,
-                        scrollPhysics: const BouncingScrollPhysics(),
-                        cursorColor: onPrimaryAccent,
-                        controller: controller,
-                        focusNode: focusNode,
-                        decoration: InputDecoration(
-                          filled: true,
-                          fillColor: appColors.primaryText.withValues(alpha: 0.5),
-                          contentPadding: EdgeInsetsDirectional.only(
-                            start: 12.0.s,
-                            top: 9.0.s,
-                            bottom: 9.0.s,
-                            end: 58.0.s,
-                          ),
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(16.0.s),
-                            borderSide: BorderSide.none,
-                          ),
-                          hintText: context.i18n.write_a_message,
-                          hintStyle: body2.copyWith(color: onPrimaryAccent),
-                          isDense: true,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: EdgeInsetsDirectional.only(
+            start: 16.0.s,
+            end: 16.0.s,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16.0.s),
+            child: Container(
+              constraints: BoxConstraints(minHeight: 36.0.s),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 3, sigmaY: 3),
+                child: Stack(
+                  children: [
+                    TextField(
+                      minLines: 1,
+                      maxLines: 4,
+                      scrollPhysics: const BouncingScrollPhysics(),
+                      cursorColor: onPrimaryAccent,
+                      controller: controller,
+                      focusNode: focusNode,
+                      decoration: InputDecoration(
+                        filled: true,
+                        fillColor: appColors.primaryText.withValues(alpha: 0.5),
+                        contentPadding: EdgeInsetsDirectional.only(
+                          start: 12.0.s,
+                          top: 9.0.s,
+                          bottom: 9.0.s,
+                          end: 58.0.s,
                         ),
-                        style: body2.copyWith(color: onPrimaryAccent),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(16.0.s),
+                          borderSide: BorderSide.none,
+                        ),
+                        hintText: context.i18n.write_a_message,
+                        hintStyle: body2.copyWith(color: onPrimaryAccent),
+                        isDense: true,
                       ),
-                      if (isTextNotEmpty.value)
-                        PositionedDirectional(
-                          bottom: 4.0.s,
-                          end: 4.0.s,
-                          child: ToolbarSendButton(
-                            enabled: true,
-                            onPressed: () => onSubmitted(controller.text),
-                          ),
+                      style: body2.copyWith(color: onPrimaryAccent),
+                    ),
+                    if (isTextNotEmpty.value)
+                      PositionedDirectional(
+                        bottom: 4.0.s,
+                        end: 4.0.s,
+                        child: ToolbarSendButton(
+                          enabled: true,
+                          onPressed: () => onSubmitted(controller.text),
                         ),
-                    ],
-                  ),
+                      ),
+                  ],
                 ),
               ),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_viewer_action_buttons.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_viewer_action_buttons.dart
@@ -17,45 +17,40 @@ import 'package:ion/generated/assets.gen.dart';
 class StoryViewerActionButtons extends ConsumerWidget {
   const StoryViewerActionButtons({
     required this.post,
-    required this.bottomPadding,
     super.key,
   });
 
   final ModifiablePostEntity post;
-  final double bottomPadding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final shareColor = context.theme.appColors.onPrimaryAccent;
 
-    return PositionedDirectional(
-      bottom: bottomPadding,
-      end: 16.0.s,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _SoundButton(post: post),
-          SizedBox(height: 16.0.s),
-          StoryControlButton(
-            borderRadius: 16.0.s,
-            iconPadding: 8.0.s,
-            icon: Assets.svg.iconBlockShare.icon(
-              color: shareColor,
-              size: 20.0.s,
-            ),
-            onPressed: () async {
-              ref.read(storyPauseControllerProvider.notifier).paused = true;
-
-              await ShareViaMessageModalRoute(eventReference: post.toEventReference().encode())
-                  .push<void>(context);
-
-              ref.read(storyPauseControllerProvider.notifier).paused = false;
-            },
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _SoundButton(post: post),
+        SizedBox(height: 16.0.s),
+        StoryControlButton(
+          borderRadius: 16.0.s,
+          iconPadding: 8.0.s,
+          icon: Assets.svg.iconBlockShare.icon(
+            color: shareColor,
+            size: 20.0.s,
           ),
-          SizedBox(height: 16.0.s),
-          _LikeButton(post: post),
-        ],
-      ),
+          onPressed: () async {
+            ref.read(storyPauseControllerProvider.notifier).paused = true;
+
+            await ShareViaMessageModalRoute(
+              eventReference: post.toEventReference().encode(),
+            ).push<void>(context);
+
+            ref.read(storyPauseControllerProvider.notifier).paused = false;
+          },
+        ),
+        SizedBox(height: 16.0.s),
+        _LikeButton(post: post),
+      ],
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/reactions/story_reaction_overlay.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/reactions/story_reaction_overlay.dart
@@ -49,35 +49,31 @@ class StoryReactionOverlay extends HookConsumerWidget {
       [textController],
     );
 
-    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
     final screenHeight = MediaQuery.sizeOf(context).height;
-    final contentPadding = (screenHeight - keyboardHeight) * 0.25;
+    final contentPadding = screenHeight * 0.48;
 
     return KeyboardVisibilityBuilder(
       builder: (context, isKeyboardVisible) {
-        return Stack(
-          children: [
-            if (isKeyboardVisible)
-              PositionedDirectional(
-                bottom: keyboardHeight + contentPadding,
-                start: 0,
-                end: 0,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    _EmojiRow(
-                      emojis: emojis.sublist(0, 3),
-                      onEmojiSelected: handleEmojiSelected,
-                    ),
-                    SizedBox(height: 40.0.s),
-                    _EmojiRow(
-                      emojis: emojis.sublist(3, 6),
-                      onEmojiSelected: handleEmojiSelected,
-                    ),
-                  ],
-                ),
+        if (!isKeyboardVisible) return const SizedBox.shrink();
+
+        return PositionedDirectional(
+          bottom: contentPadding,
+          start: 0,
+          end: 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _EmojiRow(
+                emojis: emojis.sublist(0, 3),
+                onEmojiSelected: handleEmojiSelected,
               ),
-          ],
+              SizedBox(height: 40.0.s),
+              _EmojiRow(
+                emojis: emojis.sublist(3, 6),
+                onEmojiSelected: handleEmojiSelected,
+              ),
+            ],
+          ),
         );
       },
     );

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/reactions/story_reaction_overlay.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/reactions/story_reaction_overlay.dart
@@ -49,8 +49,9 @@ class StoryReactionOverlay extends HookConsumerWidget {
       [textController],
     );
 
+    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
     final screenHeight = MediaQuery.sizeOf(context).height;
-    final contentPadding = screenHeight * 0.48;
+    final contentPadding = (screenHeight - keyboardHeight) * 0.45.s;
 
     return KeyboardVisibilityBuilder(
       builder: (context, isKeyboardVisible) {

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -67,6 +67,7 @@ class StoryViewerPage extends HookConsumerWidget {
             statusBarBrightness: Brightness.dark,
           ),
           child: MediaQuery(
+            // Prevent story's content from shrinking on keyboard open
             data: media
                 .removeViewInsets(removeBottom: true)
                 .removeViewPadding(removeBottom: true, removeTop: true),
@@ -83,22 +84,6 @@ class StoryViewerPage extends HookConsumerWidget {
                       pubkey: pubkey,
                       userStories: storyViewerState.userStories,
                       currentUserIndex: storyViewerState.currentUserIndex,
-                    ),
-                  ),
-                  PositionedDirectional(
-                    start: 0,
-                    end: 0,
-                    bottom: 0,
-                    height: footerHeight,
-                    child: AnimatedOpacity(
-                      opacity: isKeyboardVisible ? 0 : 1,
-                      duration: const Duration(milliseconds: 150),
-                      child: IgnorePointer(
-                        ignoring: isKeyboardVisible,
-                        child: ColoredBox(
-                          color: context.theme.appColors.primaryText,
-                        ),
-                      ),
                     ),
                   ),
                   PositionedDirectional(

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -53,34 +53,64 @@ class StoryViewerPage extends HookConsumerWidget {
       [currentStory?.id],
     );
 
-    return Material(
-      color: Colors.transparent,
-      child: AnnotatedRegion<SystemUiOverlayStyle>(
-        value: SystemUiOverlayStyle(
-          statusBarColor: context.theme.appColors.primaryText,
-          statusBarIconBrightness: Brightness.light,
-          statusBarBrightness: Brightness.dark,
-        ),
-        child: Scaffold(
-          resizeToAvoidBottomInset: false,
-          backgroundColor: context.theme.appColors.primaryText,
-          body: KeyboardVisibilityBuilder(
-            builder: (context, isKeyboardVisible) {
-              return SafeArea(
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: StoriesSwiper(
-                        pubkey: pubkey,
-                        userStories: storyViewerState.userStories,
-                        currentUserIndex: storyViewerState.currentUserIndex,
-                      ),
+    return KeyboardVisibilityBuilder(
+      builder: (context, isKeyboardVisible) {
+        final media = MediaQuery.of(context);
+        final fixedTop = MediaQuery.paddingOf(context).top;
+        final size = MediaQuery.sizeOf(context);
+        final footerHeight = 82.0.s;
+
+        return AnnotatedRegion<SystemUiOverlayStyle>(
+          value: SystemUiOverlayStyle(
+            statusBarColor: context.theme.appColors.primaryText,
+            statusBarIconBrightness: Brightness.light,
+            statusBarBrightness: Brightness.dark,
+          ),
+          child: MediaQuery(
+            data: media
+                .removeViewInsets(removeBottom: true)
+                .removeViewPadding(removeBottom: true, removeTop: true),
+            child: Scaffold(
+              resizeToAvoidBottomInset: false,
+              backgroundColor: context.theme.appColors.primaryText,
+              body: Stack(
+                children: [
+                  PositionedDirectional(
+                    top: fixedTop,
+                    width: size.width,
+                    height: size.height - fixedTop - footerHeight,
+                    child: StoriesSwiper(
+                      pubkey: pubkey,
+                      userStories: storyViewerState.userStories,
+                      currentUserIndex: storyViewerState.currentUserIndex,
                     ),
-                    AnimatedOpacity(
+                  ),
+                  PositionedDirectional(
+                    start: 0,
+                    end: 0,
+                    bottom: 0,
+                    height: footerHeight,
+                    child: AnimatedOpacity(
                       opacity: isKeyboardVisible ? 0 : 1,
                       duration: const Duration(milliseconds: 150),
                       child: IgnorePointer(
                         ignoring: isKeyboardVisible,
+                        child: ColoredBox(
+                          color: context.theme.appColors.primaryText,
+                        ),
+                      ),
+                    ),
+                  ),
+                  PositionedDirectional(
+                    start: 0,
+                    end: 0,
+                    bottom: 0,
+                    height: footerHeight,
+                    child: IgnorePointer(
+                      ignoring: isKeyboardVisible,
+                      child: AnimatedOpacity(
+                        opacity: isKeyboardVisible ? 0 : 1,
+                        duration: const Duration(milliseconds: 150),
                         child: Column(
                           mainAxisSize: MainAxisSize.min,
                           children: [
@@ -91,13 +121,13 @@ class StoryViewerPage extends HookConsumerWidget {
                         ),
                       ),
                     ),
-                  ],
-                ),
-              );
-            },
+                  ),
+                ],
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
This PR fixes a visual issue where both video and image stories lost their aspect ratio after the keyboard was opened. The root cause was related to layout constraints and incorrect rebuild areas reacting to MediaQuery's insets and paddings.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

- Adjusted the layout on StoryViewerPage to ignore bottom insets and paddings when the keyboard is visible.
- Reworked the bottom overlay footer and progress bar area to correctly respond to keyboard visibility 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->

https://github.com/user-attachments/assets/3e2413a9-b201-4424-b047-06f50a9d42aa


