### PR TITLE
fix: displaying long coin names in Receive dialog

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/coin_receive_modal/components/coin_address_tile/coin_address_tile.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_receive_modal/components/coin_address_tile/coin_address_tile.dart
@@ -43,43 +43,40 @@ class CoinAddressTile extends HookConsumerWidget {
       ),
       child: Row(
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CoinIconWidget(
-                    imageUrl: coinsGroup.iconUrl,
-                    size: 16.0.s,
-                  ),
-                  SizedBox(
-                    width: 6.0.s,
-                  ),
-                  Text(
-                    context.i18n.wallet_coin_address(coinsGroup.name),
-                    style: context.theme.appTextThemes.body.copyWith(
-                      color: context.theme.appColors.primaryText,
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  children: [
+                    CoinIconWidget(
+                      imageUrl: coinsGroup.iconUrl,
+                      size: 16.0.s,
                     ),
-                  ),
-                  SizedBox(
-                    width: 6.0.s,
-                  ),
-                  Assets.svg.iconBlockInformation.icon(size: 20.0.s),
-                ],
-              ),
-              SizedBox(
-                height: 7.0.s,
-              ),
-              Text(
-                shortenAddress(address),
-                style: context.theme.appTextThemes.caption.copyWith(
-                  color: context.theme.appColors.tertararyText,
+                    SizedBox(width: 6.0.s),
+                    Expanded(
+                      child: Text(
+                        context.i18n.wallet_coin_address(coinsGroup.name),
+                        style: context.theme.appTextThemes.body.copyWith(
+                          color: context.theme.appColors.primaryText,
+                        ),
+                      ),
+                    ),
+                    SizedBox(width: 6.0.s),
+                    Assets.svg.iconBlockInformation.icon(size: 20.0.s),
+                    SizedBox(width: 6.0.s),
+                  ],
                 ),
-              ),
-            ],
+                SizedBox(height: 7.0.s),
+                Text(
+                  shortenAddress(address),
+                  style: context.theme.appTextThemes.caption.copyWith(
+                    color: context.theme.appColors.tertararyText,
+                  ),
+                ),
+              ],
+            ),
           ),
-          const Spacer(),
           Stack(
             clipBehavior: Clip.none,
             children: [
@@ -112,9 +109,7 @@ class CoinAddressTile extends HookConsumerWidget {
               ),
             ],
           ),
-          SizedBox(
-            width: 16.0.s,
-          ),
+          SizedBox(width: 16.0.s),
           NavigationButton(
             size: buttonSize,
             icon: Assets.svg.iconButtonQrcode.icon(


### PR DESCRIPTION
## Description
This PR fixes displaying a coin with a long name in the Receive dialog.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9c9278a4-6bc1-42da-b34a-cf17ca7c8675"/>

After:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/71e93217-82f8-4c7e-8f2a-79f4f8dafc5d"/>
