### PR TITLE
fix: resolve story deletion reference and data refresh issue

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/features/core/views/pages/unfollow_user_page.dart';
 import 'package:ion/app/features/feed/data/models/delete/delete_confirmation_type.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
 import 'package:ion/app/features/feed/stories/providers/story_pause_provider.c.dart';
+import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.c.dart';
 import 'package:ion/app/features/feed/views/pages/entity_delete_confirmation_modal/entity_delete_confirmation_modal.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/header/context_menu_item.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/header/context_menu_item_divider.dart';
@@ -42,10 +43,18 @@ class StoryContextMenu extends HookConsumerWidget {
       () async {
         isDeletingStory.value = true;
 
+        final storyState = ref.read(storyViewingControllerProvider(pubkey));
+        final currentStory = storyState.currentStory;
+        
+        if (currentStory == null) {
+          isDeletingStory.value = false;
+          return;
+        }
+
         final confirmed = await showSimpleBottomSheet<bool>(
           context: context,
           child: EntityDeleteConfirmationModal(
-            eventReference: post.toEventReference(),
+            eventReference: currentStory.toEventReference(),
             deleteConfirmationType: DeleteConfirmationType.story,
           ),
         );
@@ -58,7 +67,7 @@ class StoryContextMenu extends HookConsumerWidget {
 
         isDeletingStory.value = false;
       },
-      [],
+      [pubkey],
     );
 
     return OverlayMenu(

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
@@ -41,15 +41,12 @@ class StoryContextMenu extends HookConsumerWidget {
 
     final handleDeleteConfirmation = useCallback(
       () async {
-        isDeletingStory.value = true;
-
-        final storyState = ref.read(storyViewingControllerProvider(pubkey));
-        final currentStory = storyState.currentStory;
-
+        final currentStory = ref.read(storyViewingControllerProvider(pubkey)).currentStory;
         if (currentStory == null) {
-          isDeletingStory.value = false;
           return;
         }
+
+        isDeletingStory.value = true;
 
         final confirmed = await showSimpleBottomSheet<bool>(
           context: context,

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
@@ -45,7 +45,7 @@ class StoryContextMenu extends HookConsumerWidget {
 
         final storyState = ref.read(storyViewingControllerProvider(pubkey));
         final currentStory = storyState.currentStory;
-        
+
         if (currentStory == null) {
           isDeletingStory.value = false;
           return;

--- a/lib/app/features/feed/stories/views/pages/story_preview_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_preview_page.dart
@@ -10,11 +10,13 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/feed/create_post/model/create_post_option.dart';
 import 'package:ion/app/features/feed/create_post/providers/create_post_notifier.c.dart';
+import 'package:ion/app/features/feed/providers/feed_stories_data_source_provider.c.dart';
 import 'package:ion/app/features/feed/providers/selected_who_can_reply_option_provider.c.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_preview/actions/story_share_button.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_preview/media/story_image_preview.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart';
 import 'package:ion/app/features/feed/views/pages/who_can_reply_settings_modal/who_can_reply_settings_modal.dart';
+import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
@@ -43,6 +45,11 @@ class StoryPreviewPage extends HookConsumerWidget {
       ..listenSuccess(
         createPostNotifierProvider(CreatePostOption.story),
         (_) {
+          final dataSources = ref.read(feedStoriesDataSourceProvider) ?? [];
+          if (dataSources.isNotEmpty) {
+            ref.invalidate(entitiesPagedDataProvider(dataSources));
+          }
+
           if (context.mounted) {
             FeedRoute().go(context);
           }


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
- Improve the story deletion process by ensuring the current story is referenced
- Invalidate the stories' data source after successful story publication

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
