### PR TITLE
fix(wallet): set initial amount value to ''

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -50,12 +50,10 @@ class CoinAmountInput extends HookWidget {
             final parsed = parseAmount(trimmedValue);
             if (parsed == null) return '';
 
-            if (maxValue != null && (parsed > maxValue! || parsed <= 0)) {
+            if (maxValue != null && (parsed > maxValue! || parsed < 0)) {
               return locale.wallet_coin_amount_insufficient_funds;
             } else if (parsed < 0) {
               return locale.wallet_coin_amount_must_be_positive;
-            } else if (parsed == 0) {
-              return '';
             }
 
             return null;

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -59,9 +59,10 @@ class SendCoinsForm extends HookConsumerWidget {
     final coin = formController.assetData.as<CoinAssetToSendData>();
     final maxAmount = coin?.selectedOption?.amount ?? 0;
 
+    final amount = coin?.amount ?? 0.0;
     final amountController = useTextEditingController.fromValue(
       TextEditingValue(
-        text: formatCrypto(coin?.amount ?? 0),
+        text: amount == 0.0 ? '' : formatCrypto(amount),
       ),
     );
 


### PR DESCRIPTION
## Description
This PR fixes this issue: when a user opens "send coins" form, the amount field has `0.00` value. Also, the zero value (like `0` or `0.0`) issued "insufficient funds" validation error.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
<img width="250" alt="image" src="https://github.com/user-attachments/assets/0fdc76c5-f6f8-4940-83a4-e38b6d1f77d9">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/30336bfc-3145-492c-bd7c-207c6c22727b">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/07b9a324-b715-47ce-8337-58537c92d813">
