### PR TITLE
feat: update post and article content text color

### DIFF
--- a/lib/app/components/text_editor/utils/text_editor_styles.dart
+++ b/lib/app/components/text_editor/utils/text_editor_styles.dart
@@ -6,7 +6,7 @@ import 'package:ion/app/components/text_editor/attributes.dart';
 import 'package:ion/app/extensions/extensions.dart';
 
 DefaultStyles textEditorStyles(BuildContext context, {Color? color}) {
-  final textColor = color ?? context.theme.appColors.secondaryText;
+  final textColor = color ?? context.theme.appColors.postContent;
   return DefaultStyles(
     paragraph: DefaultTextBlockStyle(
       context.theme.appTextThemes.body2.copyWith(

--- a/lib/app/templates/basic.json
+++ b/lib/app/templates/basic.json
@@ -27,7 +27,8 @@
         "quaternaryText": "#727689",
         "attentionBlock": "#EEF1FF",
         "pink": "#A640FF",
-        "medBlue": "#4340FF"
+        "medBlue": "#4340FF",
+        "postContent": "#0F1419"
       },
       "dark": {
         "primaryAccent": "#0166FF",
@@ -55,7 +56,8 @@
         "quaternaryText": "#727689",
         "attentionBlock": "#EEF1FF",
         "pink": "#A640FF",
-        "medBlue": "#4340FF"
+        "medBlue": "#4340FF",
+        "postContent": "#0F1419"
       }
     },
     "textThemes": {

--- a/lib/app/templates/template.c.dart
+++ b/lib/app/templates/template.c.dart
@@ -39,11 +39,13 @@ class TemplateColors with _$TemplateColors {
     Color attentionBlock,
     Color pink,
     Color medBlue,
+    Color postContent,
   ) = _TemplateColors;
 
   factory TemplateColors.fromJson(Map<String, dynamic> json) => _$TemplateColorsFromJson(json);
 
   factory TemplateColors.empty() => const TemplateColors(
+        Colors.transparent,
         Colors.transparent,
         Colors.transparent,
         Colors.transparent,

--- a/lib/app/theme/app_colors.dart
+++ b/lib/app/theme/app_colors.dart
@@ -31,6 +31,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
     required this.attentionBlock,
     required this.pink,
     required this.medBlue,
+    required this.postContent,
   });
 
   factory AppColorsExtension.fromTemplate(TemplateColors templateColors) {
@@ -61,6 +62,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       attentionBlock: templateColors.attentionBlock,
       pink: templateColors.pink,
       medBlue: templateColors.medBlue,
+      postContent: templateColors.postContent,
     );
   }
 
@@ -92,6 +94,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       attentionBlock: const Color(0xFFEEF1FF),
       pink: const Color(0xFFA640FF),
       medBlue: const Color(0xFF4340FF),
+      postContent: const Color(0xFF0F1419),
     );
   }
 
@@ -121,6 +124,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
   final Color attentionBlock;
   final Color pink;
   final Color medBlue;
+  final Color postContent;
 
   @override
   ThemeExtension<AppColorsExtension> copyWith({
@@ -150,6 +154,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
     Color? attentionBlock,
     Color? pink,
     Color? medBlue,
+    Color? postContent,
   }) {
     return AppColorsExtension(
       primaryAccent: primaryAccent ?? this.primaryAccent,
@@ -178,6 +183,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       attentionBlock: attentionBlock ?? this.attentionBlock,
       pink: pink ?? this.pink,
       medBlue: medBlue ?? this.medBlue,
+      postContent: postContent ?? this.postContent,
     );
   }
 
@@ -217,6 +223,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       attentionBlock: Color.lerp(attentionBlock, other.attentionBlock, t)!,
       pink: Color.lerp(pink, other.pink, t)!,
       medBlue: Color.lerp(medBlue, other.medBlue, t)!,
+      postContent: Color.lerp(postContent, other.postContent, t)!,
     );
   }
 }


### PR DESCRIPTION
## Description
This PR changes text color only for post and articles content

## Additional Notes
Added new color to avoid breaking other places in the app using the same font as post/article content

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
