### PR TITLE
fix: change internet availability checking strategy

### DIFF
--- a/lib/app/features/core/providers/internet_connection_checker_provider.c.dart
+++ b/lib/app/features/core/providers/internet_connection_checker_provider.c.dart
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+import 'package:ion/app/features/core/providers/env_provider.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'internet_connection_checker_provider.c.g.dart';
+
+const _checkInterval = Duration(seconds: 8);
+const _timeoutDuration = Duration(seconds: 5);
+
+@Riverpod(keepAlive: true)
+InternetConnection internetConnectionChecker(Ref ref) {
+  final env = ref.watch(envProvider.notifier);
+  final origin = env.get<String>(EnvVariable.ION_ORIGIN);
+
+  return InternetConnection.createInstance(
+    checkInterval: _checkInterval,
+    useDefaultOptions: false,
+    customCheckOptions: [
+      InternetCheckOption(
+        uri: Uri.parse(origin),
+        timeout: _timeoutDuration,
+        responseStatusFn: (response) => response.statusCode >= 200,
+      ),
+    ],
+  );
+}

--- a/lib/app/features/core/providers/internet_status_stream_provider.c.dart
+++ b/lib/app/features/core/providers/internet_status_stream_provider.c.dart
@@ -2,11 +2,12 @@
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+import 'package:ion/app/features/core/providers/internet_connection_checker_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'internet_status_stream_provider.c.g.dart';
 
 @Riverpod(keepAlive: true)
 Stream<InternetStatus> internetStatusStream(Ref ref) {
-  return InternetConnection().onStatusChange;
+  return ref.watch(internetConnectionCheckerProvider).onStatusChange;
 }


### PR DESCRIPTION
## Description
Users see the "no internet connection" notification even when the internet connection is there. I changed the url to knock to (our origin) and increased timeout from default 3 to 5 seconds. Also check interval is decreased from default 10 to 8 seconds.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
