### PR TITLE
fix: unify usd amount display for all coins to always display $ sign instead of USD postfix

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/components/amount_display.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/components/amount_display.dart
@@ -43,7 +43,9 @@ class _AmountDisplay extends HookWidget {
             ),
             SizedBox(width: 4.0.s),
             Text(
-              '~ ${formatUSD(equivalentUsd)} USD',
+              context.i18n.wallet_approximate_in_usd(
+                formatUSD(equivalentUsd),
+              ),
               style: context.theme.appTextThemes.body2.copyWith(color: secondaryTextColor),
             ),
           ],

--- a/lib/app/features/wallets/providers/wallet_user_preferences/wallet_user_preferences_provider.c.dart
+++ b/lib/app/features/wallets/providers/wallet_user_preferences/wallet_user_preferences_provider.c.dart
@@ -106,7 +106,7 @@ class WalletUserPreferencesNotifier extends _$WalletUserPreferencesNotifier {
     state = state.copyWith(
       balanceDisplayOrder: state.balanceDisplayOrder.toggled,
     );
-    userPreferencesService.setValue(
+    userPreferencesService.setEnum<BalanceDisplayOrder>(
       balanceDisplayOrderKey,
       state.balanceDisplayOrder,
     );

--- a/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/balance/coin_usd_amount.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/balance/coin_usd_amount.dart
@@ -22,7 +22,9 @@ class CoinUsdAmount extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final coinText = '${formatDouble(coinsGroup.totalAmount)} ${coinsGroup.abbreviation}';
-    final usdText = '~ ${formatToCurrency(coinsGroup.totalBalanceUSD)}';
+    final usdText = context.i18n.wallet_approximate_in_usd(
+      formatUSD(coinsGroup.totalBalanceUSD),
+    );
     final displayOrder = ref.watch(balanceDisplayOrderProvider);
 
     return Column(

--- a/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/transaction_list_item/transaction_list_item.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/transaction_list_item/transaction_list_item.dart
@@ -67,7 +67,9 @@ class TransactionListItem extends StatelessWidget {
             ),
           ),
           Text(
-            '~ ${formatToCurrency(transactionData.usdAmount)}',
+            context.i18n.wallet_approximate_in_usd(
+              formatUSD(transactionData.usdAmount),
+            ),
             style: context.theme.appTextThemes.caption3.copyWith(
               color: context.theme.appColors.secondaryText,
             ),

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_amount_summary.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_amount_summary.dart
@@ -42,7 +42,9 @@ class TransactionAmountSummary extends StatelessWidget {
         ),
         SizedBox(height: 4.0.s),
         Text(
-          context.i18n.wallet_transaction_summary_usd_amount(formatUSD(usdAmount)),
+          context.i18n.wallet_approximate_in_usd(
+            formatUSD(usdAmount),
+          ),
           style: textTheme.caption2.copyWith(
             color: colors.secondaryText,
           ),


### PR DESCRIPTION


## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
