### PR TITLE
feat: sentry init only in release mode

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -505,7 +505,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  audio_waveforms: cd736909ebc6b6a164eb74701d8c705ce3241e1c
+  audio_waveforms: a6dde7fe7c0ea05f06ffbdb0f7c1b2b2ba6cedcf
   BanubaARCloudSDK: 34549c4ae8634d9e31fc80ff3f706b45b533668d
   BanubaAudioBrowserSDK: 383031135fe8be4e6cce45a77d2be89eef2bfb1c
   BanubaLicenseServicingSDK: 64a57a86b74b327cddc0412b1e348233d19e3475
@@ -515,8 +515,8 @@ SPEC CHECKSUMS:
   BanubaUtilities: 6291027414c4c1b0b9e6e304771e483514d498fd
   BanubaVideoEditorCore: b1a4e7356d5c8bcb86ac8ea4c5379aed0f7f2d64
   BanubaVideoEditorSDK: 2fb5846e999059340910f0f3148888fab388c54d
-  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
-  blurhash_ffi: 4831b96320d4273876c9a2fd3f7d50b8a3a53509
+  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
+  blurhash_ffi: 87aab623d744d4d6cd6057d285bd2258df904786
   BNBAcneEyebagsRemoval: 552d5da9993f5bc5840b3414ffb26726265bd660
   BNBBackground: cdbc07dc698d2d094cc676e0e77845e219d9e2ba
   BNBEffectPlayer: d5813b05afce282f0959e31fda877a06dbed1bce
@@ -529,18 +529,18 @@ SPEC CHECKSUMS:
   BNBSdkApi: a05a2201214e3e7f8920f645fbb98d5b8df4fe19
   BNBSdkCore: 90da0c0c1fe1f10377d4ab1e00aa701926faea17
   BNBSkin: 1f6ff9507b1e35af1469e4fc91270154149ab673
-  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  camera_avfoundation: 04b44aeb14070126c6529e5ab82cc7c9fca107cf
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  external_app_launcher: ad55ac844aa21f2d2197d7cec58ff0d0dc40bbc0
-  ffmpeg_kit_flutter: 1a001ee5bc75256bb9eaf34971b4779a629f4cb6
-  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
-  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
+  external_app_launcher: 3411245965270a74040a3de17e27bd02b8abb905
+  ffmpeg_kit_flutter: 03e1c7562aee29a33b03def7b10a2fbc0456c63d
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
   Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
-  firebase_core: 432718558359a8c08762151b5f49bb0f093eb6e0
-  firebase_messaging: 3b99522baf7480dfb4b7683d2b34e842d577c362
+  firebase_core: 2d4534e7b489907dcede540c835b48981d890943
+  firebase_messaging: 75bc93a4df25faccad67f6662ae872ac9ae69b64
   FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
   FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
   FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
@@ -557,38 +557,38 @@ SPEC CHECKSUMS:
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  icloud_storage: d9ac7a33ced81df08ba7ea1bf3099cc0ee58f60a
-  image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
-  ion_screenshot_detector: 8332b6aedff48dc5dedc0c5a0be24aa5acff9ac9
-  local_auth_crypto: 3ee858ca5d40c9da56dcd1fe8d814e92438a9371
-  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
+  icloud_storage: e55639f0c0d7cb2b0ba9c0b3d5968ccca9cd9aa2
+  image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
+  ion_screenshot_detector: 12965038c2274b1876c39ee328507e8bb9c7b794
+  local_auth_crypto: 0f489ce05f51504fc091a53ce357e98313696085
+  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  passkeys_ios: 939d7d44f825048c8dffd4644f52444164c80ecd
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  photo_manager: d2fbcc0f2d82458700ee6256a15018210a81d413
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  qr_code_scanner_plus: 3bfe4deb7f28996a63a2a580819d49dae80d5ed3
-  quill_native_bridge_ios: 2b01d585fcc73d0f5eed78c0bd244ee564b06f5a
+  qr_code_scanner_plus: 7e087021bc69873140e0754750eb87d867bed755
+  quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SecureBiometricSwift: f8a373c07fb46c9ca1b2b53be51a485d2828a3d8
-  sensors_plus: 7229095999f30740798f0eeef5cd120357a8f4f2
+  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
   Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
-  sentry_flutter: 2df8b0aab7e4aba81261c230cbea31c82a62dd1b
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  sentry_flutter: 27892878729f42701297c628eb90e7c6529f3684
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   sqlite3: fc1400008a9b3525f5914ed715a5d1af0b8f4983
-  sqlite3_flutter_libs: 487032b9008b28de37c72a3aa66849ef3745f3e6
+  sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  ua_client_hints: aeabd123262c087f0ce151ef96fa3ab77bfc8b38
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
-  wakelock_plus: 373cfe59b235a6dd5837d0fb88791d2f13a90d56
+  ua_client_hints: 92fe0d139619b73ec9fcb46cc7e079a26178f586
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
+  wakelock_plus: 04623e3f525556020ebd4034310f20fe7fda8b49
 
 PODFILE CHECKSUM: a753d646f209b6e47f0d25090773c2f4adbab59f
 

--- a/lib/app/services/sentry/sentry_service.dart
+++ b/lib/app/services/sentry/sentry_service.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/providers/env_provider.c.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -9,6 +10,12 @@ mixin SentryService {
     required ProviderContainer container,
     required AppRunner appRunner,
   }) async {
+    // Initialize Sentry only in release mode
+    if (!kReleaseMode) {
+      appRunner();
+      return;
+    }
+
     await SentryFlutter.init(
       (options) {
         options

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,9 +31,7 @@ void main() async {
     appRunner: () => runApp(
       UncontrolledProviderScope(
         container: container,
-        child: SentryWidget(
-          child: const IONApp(),
-        ),
+        child: const IONApp(),
       ),
     ),
   );


### PR DESCRIPTION
## Description
Small improve to init sentry only for release builds
Also remove `SentryWidget` cuz we don't needed

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore