### PR TITLE
fix: skip display of address not found modal for ion network

### DIFF
--- a/lib/app/features/wallets/hooks/use_check_wallet_address_available.dart
+++ b/lib/app/features/wallets/hooks/use_check_wallet_address_available.dart
@@ -2,9 +2,12 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/components/verify_identity/verify_identity_prompt_dialog_helper.dart';
+import 'package:ion/app/features/wallets/model/network_data.c.dart';
 import 'package:ion/app/features/wallets/views/pages/coins_flow/receive_coins/providers/receive_coins_form_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/coins_flow/receive_coins/providers/wallet_address_notifier_provider.c.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
+import 'package:ion_identity_client/ion_identity.dart';
 
 void useCheckWalletAddressAvailable(
   WidgetRef ref, {
@@ -16,12 +19,45 @@ void useCheckWalletAddressAvailable(
       final network = ref.read(receiveCoinsFormControllerProvider).selectedNetwork;
       final address = await ref.read(walletAddressNotifierProvider.notifier).loadWalletAddress();
 
+      if (!ref.context.mounted) return;
+
       if (address != null) {
         ref.read(receiveCoinsFormControllerProvider.notifier).setWalletAddress(address);
-      } else if (address == null && network != null && ref.context.mounted) {
+      } else if (address == null && network?.displayName == 'ION') {
+        _createIonWallet(ref, network!);
+      } else if (address == null && network != null) {
         onAddressMissing();
       }
     },
     keys,
+  );
+}
+
+void _createIonWallet(
+  WidgetRef ref,
+  NetworkData network,
+) {
+  guardPasskeyDialog(
+    ref.context,
+    (child) {
+      return RiverpodVerifyIdentityRequestBuilder(
+        provider: walletAddressNotifierProvider,
+        requestWithVerifyIdentity: (OnVerifyIdentity<Wallet> onVerifyIdentity) async {
+          final address = await ref
+              .read(
+                walletAddressNotifierProvider.notifier,
+              )
+              .createWallet(
+                onVerifyIdentity: onVerifyIdentity,
+                network: network,
+              );
+
+          if (address != null) {
+            ref.read(receiveCoinsFormControllerProvider.notifier).setWalletAddress(address);
+          }
+        },
+        child: child,
+      );
+    },
   );
 }


### PR DESCRIPTION
## Description
This PR adds a logic where `AddresNotFoundModal` is not displayed for ION network and the wallet address is immediately created.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
