### PR TITLE
fix: put system language at the top of the list if selected, second place if not

### DIFF
--- a/lib/app/features/auth/views/pages/select_languages/select_languages.dart
+++ b/lib/app/features/auth/views/pages/select_languages/select_languages.dart
@@ -25,7 +25,7 @@ class SelectLanguages extends HookConsumerWidget {
 
     final (selectedLanguages, toggleLanguageSelection) = useSelectedState(
       ref.watch(onboardingDataProvider).languages ??
-          [ref.watch(localePreferredLanguageProvider).isoCode],
+          [ref.watch(localePreferredLanguagesProvider).first.isoCode],
     );
 
     final userIdentity = ref.watch(currentUserIdentityProvider).valueOrNull;

--- a/lib/app/features/auth/views/pages/select_languages/select_languages.dart
+++ b/lib/app/features/auth/views/pages/select_languages/select_languages.dart
@@ -22,10 +22,10 @@ class SelectLanguages extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final finishNotifier = ref.watch(onboardingCompleteNotifierProvider);
     ref.displayErrors(onboardingCompleteNotifierProvider);
+    final preferredLanguages = ref.watch(localePreferredContentLanguagesProvider);
 
     final (selectedLanguages, toggleLanguageSelection) = useSelectedState(
-      ref.watch(onboardingDataProvider).languages ??
-          [ref.watch(localePreferredLanguagesProvider).first.isoCode],
+      ref.watch(onboardingDataProvider).languages ?? [preferredLanguages.first.isoCode],
     );
 
     final userIdentity = ref.watch(currentUserIdentityProvider).valueOrNull;
@@ -35,6 +35,7 @@ class SelectLanguages extends HookConsumerWidget {
       description: context.i18n.select_languages_description,
       toggleLanguageSelection: toggleLanguageSelection,
       selectedLanguages: selectedLanguages,
+      preferredLanguages: preferredLanguages,
       continueButton: Button(
         disabled: finishNotifier.isLoading,
         trailingIcon: finishNotifier.isLoading ? const IONLoadingIndicator() : null,

--- a/lib/app/features/core/providers/app_locale_provider.c.dart
+++ b/lib/app/features/core/providers/app_locale_provider.c.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -30,7 +31,7 @@ class AppLocale extends _$AppLocale {
   }
 
   Locale _getSystemLocale() {
-    return _validateLocale(PlatformDispatcher.instance.locale);
+    return _validateLocale(_systemLocale());
   }
 
   Locale _validateLocale(Locale locale) {
@@ -67,7 +68,25 @@ class AppLocale extends _$AppLocale {
 }
 
 @riverpod
-Language localePreferredLanguage(Ref ref) {
+List<Language> localePreferredLanguages(Ref ref) {
   final appLocale = ref.watch(appLocaleProvider);
-  return Language.fromIsoCode(appLocale.languageCode) ?? Language.english;
+  final systemLocale = _systemLocale();
+  final appLocaleLanguage = Language.fromIsoCode(appLocale.languageCode) ?? Language.english;
+  final systemLocaleLanguage = Language.fromIsoCode(systemLocale.languageCode);
+  return {
+    appLocaleLanguage,
+    systemLocaleLanguage,
+    Language.english,
+  }.nonNulls.toList();
+}
+
+Locale _systemLocale() {
+  final localeString = Platform.localeName;
+  final localeCodes = localeString.split('_');
+  final languageCode = localeCodes.first;
+  final countryCode = localeCodes.length > 1 ? localeCodes[1] : null;
+  return Locale(
+    languageCode,
+    countryCode,
+  );
 }

--- a/lib/app/features/core/providers/app_locale_provider.c.dart
+++ b/lib/app/features/core/providers/app_locale_provider.c.dart
@@ -80,6 +80,16 @@ List<Language> localePreferredLanguages(Ref ref) {
   }.nonNulls.toList();
 }
 
+@riverpod
+List<Language> localePreferredContentLanguages(Ref ref) {
+  final systemLocale = _systemLocale();
+  final systemLocaleLanguage = Language.fromIsoCode(systemLocale.languageCode);
+  return {
+    systemLocaleLanguage,
+    Language.english,
+  }.nonNulls.toList();
+}
+
 Locale _systemLocale() {
   final localeString = Platform.localeName;
   final localeCodes = localeString.split('_');

--- a/lib/app/features/core/views/pages/language_selector_page.dart
+++ b/lib/app/features/core/views/pages/language_selector_page.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/views/components/auth_scrolled_body/auth_header.dart';
 import 'package:ion/app/features/auth/views/pages/select_languages/language_list_item.dart';
+import 'package:ion/app/features/core/model/language.dart';
 import 'package:ion/app/features/core/providers/app_locale_provider.c.dart';
 import 'package:ion/app/hooks/use_languages.dart';
 import 'package:ion/app/router/components/navigation_app_bar/collapsing_app_bar.dart';
@@ -23,6 +24,7 @@ class LanguageSelectorPage extends HookConsumerWidget {
     required this.toggleLanguageSelection,
     this.appBar,
     this.continueButton,
+    this.preferredLanguages,
     super.key,
   });
 
@@ -31,12 +33,14 @@ class LanguageSelectorPage extends HookConsumerWidget {
   final Widget? appBar;
   final Widget? continueButton;
   final List<String> selectedLanguages;
+  final List<Language>? preferredLanguages;
   final void Function(String) toggleLanguageSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final searchQuery = useState('');
-    final preferredLangs = ref.watch(localePreferredLanguagesProvider);
+    final localePreferredLanguages = ref.watch(localePreferredContentLanguagesProvider);
+    final preferredLangs = preferredLanguages ?? localePreferredLanguages;
     final languages = useLanguages(query: searchQuery.value, preferredLangs: preferredLangs);
 
     final mayContinue = selectedLanguages.isNotEmpty;

--- a/lib/app/features/core/views/pages/language_selector_page.dart
+++ b/lib/app/features/core/views/pages/language_selector_page.dart
@@ -36,8 +36,8 @@ class LanguageSelectorPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final searchQuery = useState('');
-    final preferredLang = ref.watch(localePreferredLanguageProvider);
-    final languages = useLanguages(query: searchQuery.value, preferredLang: preferredLang);
+    final preferredLangs = ref.watch(localePreferredLanguagesProvider);
+    final languages = useLanguages(query: searchQuery.value, preferredLangs: preferredLangs);
 
     final mayContinue = selectedLanguages.isNotEmpty;
 

--- a/lib/app/features/optimistic_ui/features/language/language_sync_strategy_provider.c.dart
+++ b/lib/app/features/optimistic_ui/features/language/language_sync_strategy_provider.c.dart
@@ -102,7 +102,7 @@ class ToggleLanguageNotifier extends _$ToggleLanguageNotifier {
 ContentLangSet _initialLangSet(Ref ref) {
   final pubkey = ref.read(currentPubkeySelectorProvider)!;
   final entity = ref.read(currentUserInterestsSetProvider(InterestSetType.languages)).value;
-  final appIso = ref.read(localePreferredLanguageProvider).isoCode;
+  final appIso = ref.read(localePreferredLanguagesProvider).first.isoCode;
 
   return ContentLangSet(
     pubkey: pubkey,

--- a/lib/app/features/settings/views/account_settings_modal.dart
+++ b/lib/app/features/settings/views/account_settings_modal.dart
@@ -61,7 +61,7 @@ class AccountSettingsModal extends HookConsumerWidget {
                   icon: Assets.svg.iconSelectLanguage.icon(color: primaryColor),
                   label: context.i18n.settings_app_language,
                   trailing: Text(
-                    ref.watch(localePreferredLanguageProvider).name,
+                    ref.watch(localePreferredLanguagesProvider).first.name,
                     style: context.theme.appTextThemes.caption.copyWith(color: primaryColor),
                   ),
                   onTap: () => AppLanguagesRoute().push<void>(context),
@@ -111,6 +111,7 @@ class AccountSettingsModal extends HookConsumerWidget {
 
 class _RemainingLanguagesLabel extends StatelessWidget {
   const _RemainingLanguagesLabel({required this.value});
+
   final int value;
 
   @override

--- a/lib/app/hooks/use_languages.dart
+++ b/lib/app/hooks/use_languages.dart
@@ -6,16 +6,15 @@ import 'package:ion/app/features/core/model/language.dart';
 /// A hook that returns a filtered list of languages based on a search query.
 ///
 /// If the [query] is empty, it returns the full list of languages.
-/// If [preferredLang] is provided, it is moved to the top of the list.
-List<Language> useLanguages({String query = '', Language? preferredLang}) {
+/// If [preferredLangs] are provided, they are moved to the top of the list.
+List<Language> useLanguages({String query = '', List<Language> preferredLangs = const []}) {
   final languagesList = useMemoized(
     () {
-      if (preferredLang == null) return Language.values;
-      return [...Language.values]
-        ..remove(preferredLang)
-        ..insert(0, preferredLang);
+      if (preferredLangs.isEmpty) return Language.values;
+      final languagesSet = {...Language.values}..removeAll(preferredLangs);
+      return languagesSet.toList()..insertAll(0, preferredLangs);
     },
-    [preferredLang],
+    [preferredLangs],
   );
 
   return useMemoized(


### PR DESCRIPTION
## Description
This PR adds a logic that displays the system locale at the top of the language selector, or at second place, if a different language is already selected.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![ScreenShot 2025-05-10 at 14 37 53@2x](https://github.com/user-attachments/assets/fba37bf8-f924-4dbe-a5e2-52c6479e0bce)
![ScreenShot 2025-05-10 at 14 37 58@2x](https://github.com/user-attachments/assets/e8fc49fc-e5c8-4f7d-8833-db6450b3e0e5)

