### PR TITLE
fix: add IPs to check, add lifecycle check

### DIFF
--- a/lib/app/features/core/providers/internet_status_stream_provider.c.dart
+++ b/lib/app/features/core/providers/internet_status_stream_provider.c.dart
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:ui';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+import 'package:ion/app/features/core/providers/app_lifecycle_provider.c.dart';
 import 'package:ion/app/features/core/providers/internet_connection_checker_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'internet_status_stream_provider.c.g.dart';
 
 @Riverpod(keepAlive: true)
-Stream<InternetStatus> internetStatusStream(Ref ref) {
-  return ref.watch(internetConnectionCheckerProvider).onStatusChange;
+Stream<InternetStatus> internetStatusStream(Ref ref) async* {
+  final lifecycleState = ref.watch(appLifecycleProvider);
+  if (lifecycleState != AppLifecycleState.resumed) {
+    yield InternetStatus.connected;
+    return;
+  }
+  yield* ref.watch(internetConnectionCheckerProvider).onStatusChange;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1432,10 +1432,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
We still have the false "No internet connection" banner shown in the app. This PR tries to fix it by adding more URIs to check and increasing timeout.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
