### PR TITLE
fix: make coin amount input field the same as on the web

### DIFF
--- a/lib/app/components/coins/coin_icon.dart
+++ b/lib/app/components/coins/coin_icon.dart
@@ -28,7 +28,6 @@ class CoinIconWidget extends StatelessWidget {
         width: iconSize,
         height: iconSize,
         decoration: BoxDecoration(
-          shape: BoxShape.circle,
           image: DecorationImage(
             image: imageProvider,
           ),

--- a/lib/app/features/wallets/providers/send_asset_form_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_asset_form_provider.c.dart
@@ -152,7 +152,7 @@ class SendAssetFormController extends _$SendAssetFormController {
 
   void setCoinsAmount(String amount) {
     if (state.assetData case final CoinAssetToSendData coin) {
-      final parsedAmount = parseAmount(amount.replaceAll(',', '')) ?? 0.0;
+      final parsedAmount = parseAmount(amount) ?? 0.0;
       state = state.copyWith(
         assetData: coin.copyWith(
           amount: parsedAmount,

--- a/lib/app/features/wallets/providers/send_asset_form_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_asset_form_provider.c.dart
@@ -152,7 +152,7 @@ class SendAssetFormController extends _$SendAssetFormController {
 
   void setCoinsAmount(String amount) {
     if (state.assetData case final CoinAssetToSendData coin) {
-      final parsedAmount = parseAmount(amount) ?? 0.0;
+      final parsedAmount = parseAmount(amount.replaceAll(',', '')) ?? 0.0;
       state = state.copyWith(
         assetData: coin.copyWith(
           amount: parsedAmount,

--- a/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/balance/coin_usd_amount.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_details/components/balance/coin_usd_amount.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/features/wallets/model/balance_display_order.dart';
 import 'package:ion/app/features/wallets/model/coins_group.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/user_preferences_selectors.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/wallet_user_preferences_provider.c.dart';
+import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -21,7 +22,7 @@ class CoinUsdAmount extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final coinText = '${formatDouble(coinsGroup.totalAmount)} ${coinsGroup.abbreviation}';
+    final coinText = '${formatCrypto(coinsGroup.totalAmount)} ${coinsGroup.abbreviation}';
     final usdText = context.i18n.wallet_approximate_in_usd(
       formatUSD(coinsGroup.totalBalanceUSD),
     );

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -5,7 +5,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ion/app/components/inputs/text_input/text_input.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/views/utils/amount_parser.dart';
-import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 import 'package:ion/app/utils/text_input_formatters.dart';
 
@@ -68,7 +67,12 @@ class CoinAmountInput extends HookWidget {
                   padding: EdgeInsetsDirectional.only(end: 16.0.s),
                   child: TextButton(
                     onPressed: () {
-                      controller.text = formatCrypto(maxValue ?? 0);
+                      var converted = (maxValue ?? 0).toStringAsFixed(18);
+
+                      // Trim trailing zeroes but leave at least one digit after decimal
+                      converted = converted.replaceFirst(RegExp(r'\.?0+$'), '');
+
+                      controller.text = converted;
                     },
                     child: Text(
                       locale.wallet_max,

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ion/app/components/inputs/text_input/text_input.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/features/wallets/views/utils/amount_parser.dart';
+import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 import 'package:ion/app/utils/text_input_formatters.dart';
 
@@ -42,7 +42,8 @@ class CoinAmountInput extends HookWidget {
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
           onValidated: (isValid) => isValidInput.value = isValid,
           inputFormatters: [
-            decimalInputFormatter(maxDecimals: 18),
+            // decimalInputFormatter(maxDecimals: 18),
+            CoinInputFormatter(),
           ],
           validator: (value) {
             final trimmedValue = value?.trim() ?? '';
@@ -50,8 +51,10 @@ class CoinAmountInput extends HookWidget {
               return null;
             }
 
-            final parsed = parseAmount(trimmedValue);
-            if (parsed == null) return '';
+            final parsed = double.tryParse(trimmedValue.replaceAll(',', ''));
+            if (parsed == null) {
+              return '';
+            }
 
             if (maxValue != null && (parsed > maxValue! || parsed < 0)) {
               return locale.wallet_coin_amount_insufficient_funds;
@@ -67,12 +70,8 @@ class CoinAmountInput extends HookWidget {
                   padding: EdgeInsetsDirectional.only(end: 16.0.s),
                   child: TextButton(
                     onPressed: () {
-                      var converted = (maxValue ?? 0).toStringAsFixed(18);
-
-                      // Trim trailing zeroes but leave at least one digit after decimal
-                      converted = converted.replaceFirst(RegExp(r'\.?0+$'), '');
-
-                      controller.text = converted;
+                      // TODO: Not implemented
+                      controller.text = formatCrypto(maxValue ?? 0);
                     },
                     child: Text(
                       locale.wallet_max,

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ion/app/components/inputs/text_input/text_input.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/wallets/views/utils/amount_parser.dart';
 import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 import 'package:ion/app/utils/text_input_formatters.dart';
@@ -42,19 +43,14 @@ class CoinAmountInput extends HookWidget {
           keyboardType: const TextInputType.numberWithOptions(decimal: true),
           onValidated: (isValid) => isValidInput.value = isValid,
           inputFormatters: [
-            // decimalInputFormatter(maxDecimals: 18),
             CoinInputFormatter(),
           ],
           validator: (value) {
             final trimmedValue = value?.trim() ?? '';
-            if (trimmedValue.isEmpty) {
-              return null;
-            }
+            if (trimmedValue.isEmpty) return null;
 
-            final parsed = double.tryParse(trimmedValue.replaceAll(',', ''));
-            if (parsed == null) {
-              return '';
-            }
+            final parsed = parseAmount(trimmedValue);
+            if (parsed == null) return '';
 
             if (maxValue != null && (parsed > maxValue! || parsed < 0)) {
               return locale.wallet_coin_amount_insufficient_funds;
@@ -70,7 +66,6 @@ class CoinAmountInput extends HookWidget {
                   padding: EdgeInsetsDirectional.only(end: 16.0.s),
                   child: TextButton(
                     onPressed: () {
-                      // TODO: Not implemented
                       controller.text = formatCrypto(maxValue ?? 0);
                     },
                     child: Text(

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -62,18 +62,8 @@ class SendCoinsForm extends HookConsumerWidget {
 
     final amount = coin?.amount ?? 0.0;
     final amountController = useTextEditingController();
-    final isAmountControllerInitialized = useRef(false);
 
-    useEffect(
-      () {
-        if (!isAmountControllerInitialized.value) {
-          amountController.text = amount == 0.0 ? '' : formatCrypto(amount);
-          isAmountControllerInitialized.value = true;
-        }
-        return null;
-      },
-      [],
-    );
+    useOnInit(() => amountController.text = amount == 0.0 ? '' : formatCrypto(amount), []);
 
     if (formController.isContactPreselected) {
       _listenContactWallet(ref, formController.contactPubkey);
@@ -82,7 +72,7 @@ class SendCoinsForm extends HookConsumerWidget {
     useOnInit(
       () {
         void listener() {
-          final numValue = parseAmount(amountController.value.text.replaceAll(',', ''));
+          final numValue = parseAmount(amountController.value.text);
           final isValidAmount = numValue != null && numValue <= maxAmount && numValue > 0;
           notifier.setCoinsAmount(isValidAmount ? amountController.text : '');
         }

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -61,10 +61,18 @@ class SendCoinsForm extends HookConsumerWidget {
     final maxAmount = coin?.selectedOption?.amount ?? 0;
 
     final amount = coin?.amount ?? 0.0;
-    final amountController = useTextEditingController.fromValue(
-      TextEditingValue(
-        text: amount == 0.0 ? '' : formatCrypto(amount),
-      ),
+    final amountController = useTextEditingController();
+    final isAmountControllerInitialized = useRef(false);
+
+    useEffect(
+      () {
+        if (!isAmountControllerInitialized.value) {
+          amountController.text = amount == 0.0 ? '' : formatCrypto(amount);
+          isAmountControllerInitialized.value = true;
+        }
+        return null;
+      },
+      [],
     );
 
     if (formController.isContactPreselected) {
@@ -74,7 +82,7 @@ class SendCoinsForm extends HookConsumerWidget {
     useOnInit(
       () {
         void listener() {
-          final numValue = parseAmount(amountController.value.text);
+          final numValue = parseAmount(amountController.value.text.replaceAll(',', ''));
           final isValidAmount = numValue != null && numValue <= maxAmount && numValue > 0;
           notifier.setCoinsAmount(isValidAmount ? amountController.text : '');
         }

--- a/lib/app/features/wallets/views/utils/amount_parser.dart
+++ b/lib/app/features/wallets/views/utils/amount_parser.dart
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
 double? parseAmount(String? amount) {
-  return double.tryParse(amount?.replaceAll(',', '.') ?? '');
+  return double.tryParse(amount?.replaceAll(',', '') ?? '');
 }

--- a/lib/app/utils/text_input_formatters.dart
+++ b/lib/app/utils/text_input_formatters.dart
@@ -21,11 +21,11 @@ class CoinInputFormatter extends TextInputFormatter {
       return _handleDeletion(oldValue, newValue);
     }
 
-    final enteredChar = _getEnteredCharacter(oldValue, newValue);
-    if (enteredChar == null) return oldValue;
+    final enteredSymbol = _getEnteredSymbol(oldValue, newValue);
+    if (enteredSymbol == null) return oldValue;
 
-    if (_isDecimalSeparator(enteredChar.newSymbol)) {
-      return _handleDecimalSeparator(oldValue, newValue, enteredChar.index);
+    if (_isDecimalSeparator(enteredSymbol.newSymbol)) {
+      return _handleDecimalSeparator(oldValue, newValue, enteredSymbol.index);
     }
 
     return _handleDigitInput(oldValue, newValue);
@@ -35,9 +35,7 @@ class CoinInputFormatter extends TextInputFormatter {
     final cursorPos = newValue.selection.end;
     final normalized = _normalizeInput(newValue.text);
 
-    if (_isSpecialDecimalDeletion(oldValue, newValue)) {
-      return newValue;
-    }
+    if (_isSpecialDecimalDeletion(oldValue, newValue)) return newValue;
 
     if (normalized.isEmpty) {
       return TextEditingValue(
@@ -65,9 +63,7 @@ class CoinInputFormatter extends TextInputFormatter {
     TextEditingValue newValue,
     int index,
   ) {
-    if (oldValue.text.contains('.')) {
-      return oldValue;
-    }
+    if (oldValue.text.contains('.')) return oldValue;
 
     final normalized = _normalizeInput(newValue.text);
     final isAppending = index == newValue.text.length - 1;
@@ -199,7 +195,7 @@ class CoinInputFormatter extends TextInputFormatter {
     return newPos;
   }
 
-  ({int index, String newSymbol})? _getEnteredCharacter(
+  ({int index, String newSymbol})? _getEnteredSymbol(
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {

--- a/lib/app/utils/text_input_formatters.dart
+++ b/lib/app/utils/text_input_formatters.dart
@@ -1,7 +1,271 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:math';
+
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 
 TextInputFormatter decimalInputFormatter({required int maxDecimals}) {
   return FilteringTextInputFormatter.allow(RegExp('^\\d*\\,?\\d{0,$maxDecimals}'));
+}
+
+class CoinInputFormatter extends TextInputFormatter {
+  // Maximum number of decimal places allowed (to avoid RangeError)
+  static const int maxDecimalsNumber = 20;
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    // Handle the removed symbol
+    if (newValue.text.length < oldValue.text.length) {
+      final cursorPos = newValue.selection.end;
+      final normalized = newValue.text.replaceAll(',', '');
+      final decimalsNumber = _countDecimals(newValue.text);
+
+      // Handle special case when removing character after the decimal point
+      if (oldValue.text.contains('.') && newValue.text.contains('.')) {
+        final oldDecimalPart = oldValue.text.split('.')[1];
+        final newDecimalPart = newValue.text.split('.')[1];
+
+        if (newDecimalPart.length < oldDecimalPart.length) {
+          if (decimalsNumber > 0 || newValue.text.endsWith('.')) {
+            return newValue;
+          }
+        }
+      }
+
+      // If not all symbols were removed
+      if (normalized.isNotEmpty) {
+        // Don't use double.tryParse here to preserve exact decimal digits
+        // Just reformat with commas as needed
+        if (normalized.contains('.')) {
+          final parts = normalized.split('.');
+          final intPart = parts[0].isEmpty ? '0' : parts[0];
+          final decimalPart = parts.length > 1 ? parts[1] : '';
+
+          try {
+            final formattedIntPart =
+                intPart == '0' ? '0' : NumberFormat('#,###', 'en_US').format(int.parse(intPart));
+
+            final toDisplay = decimalPart.isNotEmpty || normalized.endsWith('.')
+                ? '$formattedIntPart.$decimalPart'
+                : formattedIntPart;
+
+            // Calculate new cursor position
+            var newCursorPos = cursorPos;
+            final commasRegex = RegExp('[^,]');
+            final oldCommaCount =
+                oldValue.text.substring(0, cursorPos).replaceAll(commasRegex, '').length;
+            final newCommaCount = toDisplay
+                .substring(0, min(cursorPos, toDisplay.length))
+                .replaceAll(commasRegex, '')
+                .length;
+            newCursorPos += newCommaCount - oldCommaCount;
+
+            return TextEditingValue(
+              text: toDisplay,
+              selection:
+                  TextSelection.collapsed(offset: min(toDisplay.length, max(0, newCursorPos))),
+            );
+          } catch (e, st) {
+            return newValue;
+          }
+        } else {
+          // Just integers, no decimal part
+          try {
+            final toDisplay = normalized == '0'
+                ? '0'
+                : NumberFormat('#,###', 'en_US').format(int.parse(normalized));
+
+            // Calculate new cursor position
+            var newCursorPos = cursorPos;
+            final commasRegex = RegExp('[^,]');
+            final oldCommaCount =
+                oldValue.text.substring(0, cursorPos).replaceAll(commasRegex, '').length;
+            final newCommaCount = toDisplay
+                .substring(0, min(cursorPos, toDisplay.length))
+                .replaceAll(commasRegex, '')
+                .length;
+            newCursorPos += newCommaCount - oldCommaCount;
+
+            return TextEditingValue(
+              text: toDisplay,
+              selection:
+                  TextSelection.collapsed(offset: min(toDisplay.length, max(0, newCursorPos))),
+            );
+          } catch (e, st) {
+            return newValue;
+          }
+        }
+      }
+
+      // If nothing left or couldn't parse
+      return TextEditingValue(
+        text: normalized,
+        selection: TextSelection.collapsed(offset: cursorPos),
+      );
+    }
+
+    // Handle addition of characters
+    final newText = newValue.text;
+    final enteredCharResult = _getEnteredCharacter(oldValue, newValue);
+
+    // If no new character identified, return old value
+    if (enteredCharResult == null) {
+      return oldValue;
+    }
+
+    final index = enteredCharResult.index;
+    final newSymbol = enteredCharResult.newSymbol;
+    final isNewSymbolDecimalsSeparator = newSymbol == ',' || newSymbol == '.';
+    final isTheLastCharEntered = index == newValue.text.length - 1;
+
+    // Handle insertion of decimal separator
+    if (isNewSymbolDecimalsSeparator) {
+      // Old value already contains the decimals separator. It can be only one.
+      if (oldValue.text.contains('.')) {
+        return oldValue;
+      }
+
+      // Insert decimal separator at the proper position
+      if (isTheLastCharEntered) {
+        // Handle appending decimal at the end
+        final normalized = newText.substring(0, newText.length - 1).replaceAll(',', '');
+
+        try {
+          final intValue = normalized.isEmpty ? 0 : int.parse(normalized);
+          final formattedText = '${NumberFormat('#,###', 'en_US').format(intValue)}.';
+
+          return TextEditingValue(
+            text: formattedText,
+            selection: TextSelection.collapsed(offset: formattedText.length),
+          );
+        } catch (e, st) {
+          return oldValue;
+        }
+      } else {
+        // Handle inserting decimal in the middle
+        // Extract parts before and after the insertion point
+        final beforePart = newText.substring(0, index).replaceAll(',', '');
+        final afterPart = newText.substring(index + 1).replaceAll(',', '');
+
+        try {
+          // Format the integer part
+          final intValue = beforePart.isEmpty ? 0 : int.parse(beforePart);
+          final formattedIntPart = NumberFormat('#,###', 'en_US').format(intValue);
+
+          // Combine with decimal part
+          final formattedText = '$formattedIntPart.$afterPart';
+
+          // Find position of the decimal point in formatted text
+          final decimalPos = formattedText.indexOf('.');
+
+          return TextEditingValue(
+            text: formattedText,
+            selection: TextSelection.collapsed(offset: decimalPos + 1),
+          );
+        } catch (e, st) {
+          return oldValue;
+        }
+      }
+    }
+
+    // Handle regular digit input
+    final normalized = newValue.text.replaceAll(',', '');
+
+    // Check if we're dealing with a decimal number
+    if (normalized.contains('.')) {
+      final parts = normalized.split('.');
+      final intPart = parts[0].isEmpty ? '0' : parts[0];
+      final decimalPart = parts.length > 1 ? parts[1] : '';
+
+      // Limit the decimal places to avoid errors
+      final limitedDecimalPart = decimalPart.length > maxDecimalsNumber
+          ? decimalPart.substring(0, maxDecimalsNumber)
+          : decimalPart;
+
+      try {
+        final formattedIntPart =
+            intPart == '0' ? '0' : NumberFormat('#,###', 'en_US').format(int.parse(intPart));
+
+        final toDisplay = '$formattedIntPart.$limitedDecimalPart';
+
+        // Calculate new cursor position
+        var newCursorPos = newValue.selection.end;
+        final oldCommaCount = oldValue.text
+            .substring(0, min(oldValue.text.length, newValue.selection.end - 1))
+            .replaceAll(RegExp('[^,]'), '')
+            .length;
+        final newCommaCount = toDisplay
+            .substring(0, min(toDisplay.length, newValue.selection.end))
+            .replaceAll(RegExp('[^,]'), '')
+            .length;
+        newCursorPos += newCommaCount - oldCommaCount;
+
+        // Adjust cursor if we've limited decimal places
+        if (decimalPart.length > maxDecimalsNumber && newCursorPos > toDisplay.length) {
+          newCursorPos = toDisplay.length;
+        }
+
+        return TextEditingValue(
+          text: toDisplay,
+          selection: TextSelection.collapsed(offset: min(toDisplay.length, max(0, newCursorPos))),
+        );
+      } catch (e, st) {
+        return oldValue;
+      }
+    } else {
+      // Integer part only
+      try {
+        // Avoid double conversion to preserve exact input
+        final toDisplay =
+            normalized == '0' ? '0' : NumberFormat('#,###', 'en_US').format(int.parse(normalized));
+
+        // Calculate new cursor position
+        var newCursorPos = newValue.selection.end;
+        final oldCommaCount = oldValue.text
+            .substring(0, min(oldValue.text.length, newValue.selection.end - 1))
+            .replaceAll(RegExp('[^,]'), '')
+            .length;
+        final newCommaCount = toDisplay
+            .substring(0, min(toDisplay.length, newValue.selection.end))
+            .replaceAll(RegExp('[^,]'), '')
+            .length;
+        newCursorPos += newCommaCount - oldCommaCount;
+
+        return TextEditingValue(
+          text: toDisplay,
+          selection: TextSelection.collapsed(offset: min(toDisplay.length, max(0, newCursorPos))),
+        );
+      } catch (e, st) {
+        return oldValue;
+      }
+    }
+  }
+
+  ({int index, String newSymbol})? _getEnteredCharacter(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final oldText = oldValue.text;
+    final newText = newValue.text;
+    final oldLength = oldText.length;
+    final newLength = newText.length;
+
+    // Check if a single character was added
+    if (newLength == oldLength + 1) {
+      for (var i = 0; i < newLength; i++) {
+        if (i >= oldLength || oldText[i] != newText[i]) {
+          return (index: i, newSymbol: newText[i]);
+        }
+      }
+    }
+    return null;
+  }
+
+  int _countDecimals(String value) {
+    // Should be only one dot according to the selected format
+    final dotIndex = value.indexOf('.');
+    if (dotIndex == -1) return 0; // No decimal point
+    return value.length - dotIndex - 1;
+  }
 }

--- a/test/utils/text_input_formatters_test.dart
+++ b/test/utils/text_input_formatters_test.dart
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ion/app/utils/text_input_formatters.dart';
+
+void main() {
+  group('CoinInputFormatter', () {
+    final formatter = CoinInputFormatter();
+
+    TextEditingValue applyFormatter(String oldText, String newText, {int cursorOffset = -1}) {
+      final oldValue = TextEditingValue(
+        text: oldText,
+        selection: TextSelection.collapsed(offset: oldText.length),
+      );
+      final newValue = TextEditingValue(
+        text: newText,
+        selection: TextSelection.collapsed(
+          offset: cursorOffset == -1 ? newText.length : cursorOffset,
+        ),
+      );
+      return formatter.formatEditUpdate(oldValue, newValue);
+    }
+
+    test('adds commas correctly to integer input', () {
+      final result = applyFormatter('1,000', '1,0000');
+      expect(result.text, '10,000');
+    });
+
+    test('replaces old comma with decimal separator correctly', () {
+      final result = applyFormatter('1,000', '1,,000');
+      expect(result.text, '1.000');
+    });
+
+    test('appends decimal separator', () {
+      final result = applyFormatter('10,000', '10,000,');
+      expect(result.text, '10,000.');
+    });
+
+    test('formats decimal input with commas', () {
+      final result = applyFormatter('10,000.5', '10,000.50');
+      expect(result.text, '10,000.50');
+    });
+
+    test('deletes digits properly', () {
+      final result = applyFormatter('10,000.50', '10,00.50');
+      expect(result.text, '1,000.50');
+    });
+
+    test('handles input starting with zero', () {
+      final result = applyFormatter('0', '00');
+      expect(result.text, '0');
+    });
+
+    test('limits decimal digits', () {
+      const longDecimal = '1.12345678901234567890123';
+      final result = applyFormatter('1.12345678901234567890', longDecimal);
+      expect(result.text, '1.12345678901234567890');
+    });
+
+    test('inserts decimal separator in middle of number', () {
+      final result = applyFormatter('12,345', '12,34,5', cursorOffset: 5);
+      expect(result.text, '1,234.5');
+    });
+
+    test('removes comma safely', () {
+      final result = applyFormatter('1,234.5', '1234.5');
+      expect(result.text, '1,234.5');
+    });
+  });
+}


### PR DESCRIPTION
## Description
So, the main purpose of new text formatter is to use comma as delimiter between int digits. So, if I input `9999`, then the text field should show `9,999`. So complex logic is necessary, cos iOS, for example, use comma as delimiter between ints and decimals, so we need to handle such cases.

Fixed bugs:
- Removed rounding for the coin icons.
- Used correct formatting for the coin balance on the `CoinDetails` page.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
https://github.com/user-attachments/assets/94ff3d1a-fc28-4993-963a-ed73150bbdbe


