### PR TITLE
fix: prevent resetting chat text field when user switch to initial view

### DIFF
--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
@@ -13,7 +13,6 @@ import 'package:ion/app/features/core/permissions/data/models/permissions_types.
 import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/permission_request_sheet.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_dialogs/settings_redirect_sheet.dart';
-import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -46,15 +45,6 @@ class BottomBarInitialView extends HookConsumerWidget {
         }
       },
       [controller],
-    );
-
-    useOnInit(
-      () {
-        if (bottomBarState.isText) {
-          controller.clear();
-        }
-      },
-      [bottomBarState.isText],
     );
 
     return Column(


### PR DESCRIPTION
## Description
This PR fixes the chat text field from resetting when the user switches to the initial view.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
