### PR TITLE
fix: adjust message reaction dialog positioning logic

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_reaction_dialog/message_reaction_dialog.dart
+++ b/lib/app/features/chat/views/components/message_items/message_reaction_dialog/message_reaction_dialog.dart
@@ -85,17 +85,21 @@ class MessageReactionDialog extends HookConsumerWidget {
 
     /// The overflow size of the message content in the dialog
     final overflowBottomSize = MediaQuery.sizeOf(context).height -
-        // bottomdY -
         (position.dy > 0 ? (isHugeComponent ? 0 : bottomdY) : bottomdY) -
         contextMenuHeight.value -
         MediaQuery.paddingOf(context).bottom;
 
     /// The y-coordinate of the top of the message content in the dialog
-    final topY = isHugeComponent
+    var topY = isHugeComponent
         ? null
         : overflowBottomSize < 0
             ? null
             : position.dy - MessageReactionEmojiBar.height - 2;
+
+    // if the y position exceeds the safe area, set the y position to the safe area
+    if (topY != null && topY < MediaQuery.paddingOf(context).top) {
+      topY = MediaQuery.paddingOf(context).top;
+    }
 
     return Stack(
       children: [


### PR DESCRIPTION
## Description
Updated the calculation for the top y-coordinate in the message reaction dialog to ensure it respects the top padding of the media query

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/902e3992-86f4-41e1-a02a-0c1fbce3c15b

