### PR TITLE
fix: update messaging bottom bar logic to handle text input state

### DIFF
--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
@@ -8,7 +8,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/e2ee/model/entities/private_direct_message_data.c.dart';
 import 'package:ion/app/features/chat/model/upload_limit_modal_type.dart';
-import 'package:ion/app/features/chat/providers/messaging_bottom_bar_state_provider.c.dart';
 import 'package:ion/app/features/chat/views/pages/upload_limit_reached_modal/upload_limit_reached_modal.dart';
 import 'package:ion/app/features/core/permissions/data/models/permissions_types.dart';
 import 'package:ion/app/features/core/permissions/views/components/permission_aware_widget.dart';
@@ -111,7 +110,6 @@ class MoreContentView extends ConsumerWidget {
                     );
 
                     unawaited(onSubmitted(content: eventReference.encode()));
-                    ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
                   }
                 },
               ),
@@ -150,8 +148,6 @@ class MoreContentView extends ConsumerWidget {
                         ],
                       ),
                     );
-
-                    ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
                   }
                 },
               ),

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar_initial.dart
@@ -96,6 +96,8 @@ class BottomBarInitialView extends HookConsumerWidget {
                   onTap: () {
                     if (controller.text.isEmpty) {
                       ref.read(messagingBottomBarActiveStateProvider.notifier).setText();
+                    } else {
+                      ref.read(messagingBottomBarActiveStateProvider.notifier).setHasText();
                     }
                   },
                   onChanged: onTextChanged,


### PR DESCRIPTION
## Description
This PR fixes the messaging text field logic to clear it after a message is sent, and it includes a text display action button.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
