### PR TITLE
fix: set max decimals number for coin input amount to 18

### DIFF
--- a/lib/app/utils/text_input_formatters.dart
+++ b/lib/app/utils/text_input_formatters.dart
@@ -11,7 +11,7 @@ TextInputFormatter decimalInputFormatter({required int maxDecimals}) {
 }
 
 class CoinInputFormatter extends TextInputFormatter {
-  static const int maxDecimalsNumber = 20;
+  static const int maxDecimalsNumber = 18;
   final _numberFormat = NumberFormat('#,###', 'en_US');
   final _commasRegex = RegExp('[^,]');
   final _validationRegex = RegExp(r'^[0-9.,]+$');

--- a/test/utils/text_input_formatters_test.dart
+++ b/test/utils/text_input_formatters_test.dart
@@ -55,7 +55,7 @@ void main() {
     test('limits decimal digits', () {
       const longDecimal = '1.12345678901234567890123';
       final result = applyFormatter('1.12345678901234567890', longDecimal);
-      expect(result.text, '1.12345678901234567890');
+      expect(result.text, '1.123456789012345678');
     });
 
     test('inserts decimal separator in middle of number', () {


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
