### PR TITLE
feat: set SizedBox as an error widget for release builds

### DIFF
--- a/lib/app/features/core/providers/init_provider.c.dart
+++ b/lib/app/features/core/providers/init_provider.c.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/auth/providers/onboarding_complete_provider.c.dart';
@@ -11,6 +12,7 @@ import 'package:ion/app/features/core/permissions/providers/permissions_provider
 import 'package:ion/app/features/core/providers/feature_flags_provider.c.dart';
 import 'package:ion/app/features/core/providers/template_provider.c.dart';
 import 'package:ion/app/features/core/providers/window_manager_provider.c.dart';
+import 'package:ion/app/features/core/views/components/widget_error_builder.dart';
 import 'package:ion/app/features/feed/providers/feed_bookmarks_notifier.c.dart';
 import 'package:ion/app/features/force_update/providers/force_update_provider.c.dart';
 import 'package:ion/app/features/push_notifications/background/firebase_messaging_background_service.dart';
@@ -35,6 +37,8 @@ part 'init_provider.c.g.dart';
 Future<void> initApp(Ref ref) async {
   final featureFlagsNotifier = ref.read(featureFlagsProvider.notifier);
   final logIonConnect = featureFlagsNotifier.get(LoggerFeatureFlag.logIonConnect);
+
+  ErrorWidget.builder = WidgetErrorBuilder.new;
 
   IonConnect.initialize(logIonConnect ? IonConnectLogger() : null);
 

--- a/lib/app/features/core/views/components/widget_error_builder.dart
+++ b/lib/app/features/core/views/components/widget_error_builder.dart
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class WidgetErrorBuilder extends StatelessWidget {
+  const WidgetErrorBuilder(this.errorDetails, {super.key});
+
+  final FlutterErrorDetails errorDetails;
+
+  @override
+  Widget build(BuildContext context) {
+    if (kDebugMode) return ErrorWidget(errorDetails);
+    return const SizedBox.shrink();
+  }
+}


### PR DESCRIPTION
## Description
This PR sets a SizedBox as an ErrorWidget that will be rendered during build method exceptions in release mode.

## Additional Notes
This change prevents parts of the app from not being usable in case of any build error. For example, when exception was thrown during build method of a post cell on feed, whole feed became unusable. This change is going to prevent that from happening.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
Sample screenshot showcasing how feed will look like when post body fails to render.
![ScreenShot 2025-05-14 at 11 00 03@2x](https://github.com/user-attachments/assets/808508bf-2d23-49f7-8125-5ab9a946dd06)
