### PR TITLE
feat: optimize event links

### DIFF
--- a/lib/app/features/feed/create_article/providers/create_article_provider.c.dart
+++ b/lib/app/features/feed/create_article/providers/create_article_provider.c.dart
@@ -106,7 +106,6 @@ class CreateArticle extends _$CreateArticle {
         title: title,
         summary: summary,
         image: imageUrl,
-        content: deltaToMarkdown(updatedContent),
         media: {
           for (final attachment in mediaAttachments) attachment.url: attachment,
         },
@@ -147,7 +146,6 @@ class CreateArticle extends _$CreateArticle {
         title: null,
         summary: null,
         image: null,
-        content: '',
         relatedHashtags: [],
         media: {},
         colorLabel: null,
@@ -256,7 +254,6 @@ class CreateArticle extends _$CreateArticle {
         title: title,
         summary: summary,
         image: imageUrlToUpload,
-        content: deltaToMarkdown(updatedContent),
         media: cleanedMedia,
         relatedHashtags: relatedHashtags,
         relatedPubkeys: mentions,
@@ -384,7 +381,7 @@ class CreateArticle extends _$CreateArticle {
             operationData[textEditorSingleImageKey] != null &&
             uploadedUrls.containsKey(operationData[textEditorSingleImageKey])) {
           return Operation.insert(
-            uploadedUrls[operationData[textEditorSingleImageKey]],
+            ' ',
             {textEditorSingleImageKey: uploadedUrls[operationData[textEditorSingleImageKey]]},
           );
         }

--- a/lib/app/features/feed/create_article/providers/create_article_provider.c.dart
+++ b/lib/app/features/feed/create_article/providers/create_article_provider.c.dart
@@ -146,6 +146,7 @@ class CreateArticle extends _$CreateArticle {
         title: null,
         summary: null,
         image: null,
+        textContent: '',
         relatedHashtags: [],
         media: {},
         colorLabel: null,
@@ -254,6 +255,7 @@ class CreateArticle extends _$CreateArticle {
         title: title,
         summary: summary,
         image: imageUrlToUpload,
+        textContent: '',
         media: cleanedMedia,
         relatedHashtags: relatedHashtags,
         relatedPubkeys: mentions,
@@ -361,7 +363,7 @@ class CreateArticle extends _$CreateArticle {
       updatedContent = _replaceImagePathsWithUrls(updatedContent, uploadedUrls);
     }
 
-    return updatedContent;
+    return withFlattenLinks(updatedContent);
   }
 
   List<RelatedPubkey> _buildMentions(Delta content) {

--- a/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
@@ -79,10 +79,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       final mentions = _buildMentions(postContent);
 
       final postData = ModifiablePostData(
-        content: await _buildContentWithMediaLinks(
-          content: postContent,
-          media: media.values.toList(),
-        ),
+        // content: '',
         media: media,
         replaceableEventId: ReplaceableEventIdentifier.generate(),
         publishedAt: _buildEntityPublishedAt(),
@@ -148,10 +145,10 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       final modifiedMedia = Map<String, MediaAttachment>.from(mediaAttachments)..addAll(media);
 
       final postData = modifiedEntity.data.copyWith(
-        content: await _buildContentWithMediaLinks(
-          content: postContent,
-          media: modifiedMedia.values.toList(),
-        ),
+        // content: await _buildContentWithMediaLinks(
+        //   content: postContent,
+        //   media: modifiedMedia.values.toList(),
+        // ),
         richText: await _buildRichTextContentWithMediaLinks(
           content: postContent,
           media: modifiedMedia.values.toList(),
@@ -203,7 +200,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       }
 
       final postData = entity.data.copyWith(
-        content: '',
+        // content: '',
         editingEndedAt: null,
         relatedHashtags: [],
         relatedPubkeys: [],
@@ -374,7 +371,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
     return Delta.fromOperations(
       media
           .map(
-            (mediaItem) => Operation.insert(mediaItem.url, {Attribute.link.key: mediaItem.url}),
+            (mediaItem) => Operation.insert(' ', {Attribute.link.key: mediaItem.url}),
           )
           .toList(),
     ).concat(newContentDelta);

--- a/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
@@ -365,8 +365,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
     required Delta content,
     required List<MediaAttachment> media,
   }) async {
-    final currentOperations = content.operations.toList();
-    final newContentDelta = Delta.fromOperations(currentOperations);
+    final newContentDelta = flattenLinks(content);
 
     return Delta.fromOperations(
       media

--- a/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
@@ -79,7 +79,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       final mentions = _buildMentions(postContent);
 
       final postData = ModifiablePostData(
-        // content: '',
+        textContent: '',
         media: media,
         replaceableEventId: ReplaceableEventIdentifier.generate(),
         publishedAt: _buildEntityPublishedAt(),
@@ -145,10 +145,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       final modifiedMedia = Map<String, MediaAttachment>.from(mediaAttachments)..addAll(media);
 
       final postData = modifiedEntity.data.copyWith(
-        // content: await _buildContentWithMediaLinks(
-        //   content: postContent,
-        //   media: modifiedMedia.values.toList(),
-        // ),
+        textContent: '',
         richText: await _buildRichTextContentWithMediaLinks(
           content: postContent,
           media: modifiedMedia.values.toList(),
@@ -200,7 +197,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       }
 
       final postData = entity.data.copyWith(
-        // content: '',
+        textContent: '',
         editingEndedAt: null,
         relatedHashtags: [],
         relatedPubkeys: [],
@@ -350,22 +347,11 @@ class CreatePostNotifier extends _$CreatePostNotifier {
     return richText;
   }
 
-  Future<String> _buildContentWithMediaLinks({
-    required Delta content,
-    required List<MediaAttachment> media,
-  }) async {
-    final contentWithMediaAndMentions = await _buildContentWithMediaLinksDelta(
-      content: content,
-      media: media,
-    );
-    return deltaToMarkdown(contentWithMediaAndMentions);
-  }
-
   Future<Delta> _buildContentWithMediaLinksDelta({
     required Delta content,
     required List<MediaAttachment> media,
   }) async {
-    final newContentDelta = flattenLinks(content);
+    final newContentDelta = withFlattenLinks(content);
 
     return Delta.fromOperations(
       media

--- a/lib/app/features/feed/data/models/entities/article_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/article_data.c.dart
@@ -78,7 +78,6 @@ class ArticleData
         _$ArticleData
     implements EventSerializable, ReplaceableEntityData {
   const factory ArticleData({
-    required String content,
     required Map<String, MediaAttachment> media,
     required ReplaceableEventIdentifier replaceableEventId,
     required EntityPublishedAt publishedAt,
@@ -104,7 +103,6 @@ class ArticleData
     final mediaAttachments = _buildMedia(tags[MediaAttachment.tagName]);
 
     return ArticleData(
-      content: eventMessage.content,
       media: mediaAttachments,
       title: title,
       image: image,
@@ -125,7 +123,6 @@ class ArticleData
   }
 
   factory ArticleData.fromData({
-    required String content,
     required Map<String, MediaAttachment> media,
     String? title,
     String? image,
@@ -139,7 +136,6 @@ class ArticleData
     EntityEditingEndedAt? editingEndedAt,
   }) {
     return ArticleData(
-      content: content,
       media: media,
       title: title,
       image: image,
@@ -156,6 +152,9 @@ class ArticleData
   }
 
   @override
+  String get content => richText?.content ?? '';
+
+  @override
   FutureOr<EventMessage> toEventMessage(
     EventSigner signer, {
     List<List<String>> tags = const [],
@@ -165,6 +164,7 @@ class ArticleData
       signer: signer,
       createdAt: createdAt,
       kind: ArticleEntity.kind,
+      content: richText != null ? '' : content,
       tags: [
         ...tags,
         replaceableEventId.toTag(),
@@ -181,7 +181,6 @@ class ArticleData
         if (richText != null) richText!.toTag(),
         if (editingEndedAt != null) editingEndedAt!.toTag(),
       ],
-      content: content,
     );
   }
 

--- a/lib/app/features/feed/data/models/entities/article_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/article_data.c.dart
@@ -78,6 +78,7 @@ class ArticleData
         _$ArticleData
     implements EventSerializable, ReplaceableEntityData {
   const factory ArticleData({
+    required String textContent,
     required Map<String, MediaAttachment> media,
     required ReplaceableEventIdentifier replaceableEventId,
     required EntityPublishedAt publishedAt,
@@ -103,6 +104,7 @@ class ArticleData
     final mediaAttachments = _buildMedia(tags[MediaAttachment.tagName]);
 
     return ArticleData(
+      textContent: eventMessage.content,
       media: mediaAttachments,
       title: title,
       image: image,
@@ -136,6 +138,7 @@ class ArticleData
     EntityEditingEndedAt? editingEndedAt,
   }) {
     return ArticleData(
+      textContent: '',
       media: media,
       title: title,
       image: image,
@@ -152,7 +155,7 @@ class ArticleData
   }
 
   @override
-  String get content => richText?.content ?? '';
+  String get content => richText?.content ?? textContent;
 
   @override
   FutureOr<EventMessage> toEventMessage(
@@ -164,7 +167,7 @@ class ArticleData
       signer: signer,
       createdAt: createdAt,
       kind: ArticleEntity.kind,
-      content: richText != null ? '' : content,
+      content: richText != null ? '' : textContent,
       tags: [
         ...tags,
         replaceableEventId.toTag(),

--- a/lib/app/features/feed/data/models/entities/modifiable_post_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/modifiable_post_data.c.dart
@@ -87,7 +87,6 @@ class ModifiablePostData
         _$ModifiablePostData
     implements EventSerializable, ReplaceableEntityData {
   const factory ModifiablePostData({
-    required String content,
     required Map<String, MediaAttachment> media,
     required ReplaceableEventIdentifier replaceableEventId,
     required EntityPublishedAt publishedAt,
@@ -108,7 +107,6 @@ class ModifiablePostData
         tags[QuotedImmutableEvent.tagName] ?? tags[QuotedReplaceableEvent.tagName];
 
     return ModifiablePostData(
-      content: eventMessage.content,
       media: EntityDataWithMediaContent.parseImeta(tags[MediaAttachment.tagName]),
       replaceableEventId:
           ReplaceableEventIdentifier.fromTag(tags[ReplaceableEventIdentifier.tagName]!.first),
@@ -134,6 +132,9 @@ class ModifiablePostData
   const ModifiablePostData._();
 
   @override
+  String get content => richText?.content ?? '';
+
+  @override
   FutureOr<EventMessage> toEventMessage(
     EventSigner signer, {
     List<List<String>> tags = const [],
@@ -143,7 +144,7 @@ class ModifiablePostData
       signer: signer,
       createdAt: createdAt,
       kind: ModifiablePostEntity.kind,
-      content: content,
+      content: '',
       tags: [
         ...tags,
         replaceableEventId.toTag(),
@@ -173,6 +174,6 @@ class ModifiablePostData
 
   @override
   String toString() {
-    return 'ModifiablePostData($content)';
+    return 'ModifiablePostData(${richText?.content})';
   }
 }

--- a/lib/app/features/feed/data/models/entities/modifiable_post_data.c.dart
+++ b/lib/app/features/feed/data/models/entities/modifiable_post_data.c.dart
@@ -87,6 +87,7 @@ class ModifiablePostData
         _$ModifiablePostData
     implements EventSerializable, ReplaceableEntityData {
   const factory ModifiablePostData({
+    required String textContent,
     required Map<String, MediaAttachment> media,
     required ReplaceableEventIdentifier replaceableEventId,
     required EntityPublishedAt publishedAt,
@@ -107,6 +108,7 @@ class ModifiablePostData
         tags[QuotedImmutableEvent.tagName] ?? tags[QuotedReplaceableEvent.tagName];
 
     return ModifiablePostData(
+      textContent: eventMessage.content,
       media: EntityDataWithMediaContent.parseImeta(tags[MediaAttachment.tagName]),
       replaceableEventId:
           ReplaceableEventIdentifier.fromTag(tags[ReplaceableEventIdentifier.tagName]!.first),
@@ -132,7 +134,7 @@ class ModifiablePostData
   const ModifiablePostData._();
 
   @override
-  String get content => richText?.content ?? '';
+  String get content => richText?.content ?? textContent;
 
   @override
   FutureOr<EventMessage> toEventMessage(
@@ -144,7 +146,7 @@ class ModifiablePostData
       signer: signer,
       createdAt: createdAt,
       kind: ModifiablePostEntity.kind,
-      content: '',
+      content: richText != null ? '' : content,
       tags: [
         ...tags,
         replaceableEventId.toTag(),
@@ -174,6 +176,6 @@ class ModifiablePostData
 
   @override
   String toString() {
-    return 'ModifiablePostData(${richText?.content})';
+    return 'ModifiablePostData(${richText?.content ?? content})';
   }
 }

--- a/lib/app/features/ion_connect/model/media_attachment.dart
+++ b/lib/app/features/ion_connect/model/media_attachment.dart
@@ -17,8 +17,6 @@ class MediaAttachment {
     required this.mimeType,
     required this.dimension,
     required this.alt,
-    required this.torrentInfoHash,
-    required this.fileHash,
     required this.originalFileHash,
     this.encryptionKey,
     this.encryptionNonce,
@@ -35,8 +33,6 @@ class MediaAttachment {
       mimeType: mediaFile.mimeType ?? '',
       dimension: '${mediaFile.width}x${mediaFile.height}',
       alt: FileAlt.message,
-      torrentInfoHash: '',
-      fileHash: '',
       originalFileHash: '',
       image: mediaFile.path,
       blurhash: mediaFile.blurhash,
@@ -57,8 +53,6 @@ class MediaAttachment {
     String? thumb;
     String? image;
     String? alt;
-    String? torrentInfoHash;
-    String? fileHash;
     String? originalFileHash;
     String? encryptionKey;
     String? encryptionNonce;
@@ -87,10 +81,6 @@ class MediaAttachment {
           alt = value;
         case 'blurhash':
           blurhash = value;
-        case 'i':
-          torrentInfoHash = value;
-        case 'x':
-          fileHash = value;
         case 'ox':
           originalFileHash = value;
         case 'encryption-key':
@@ -110,8 +100,6 @@ class MediaAttachment {
       mimeType: mimeType!,
       dimension: dimension!,
       alt: EnumExtensions.fromShortString(FileAlt.values, alt!),
-      torrentInfoHash: torrentInfoHash ?? '',
-      fileHash: fileHash!,
       originalFileHash: originalFileHash!,
       thumb: thumb,
       image: image,
@@ -129,8 +117,6 @@ class MediaAttachment {
         mimeType: json['mimeType'] as String,
         dimension: json['dimension'] as String,
         alt: EnumExtensions.fromShortString(FileAlt.values, json['alt'] as String),
-        torrentInfoHash: json['torrentInfoHash'] as String,
-        fileHash: json['fileHash'] as String,
         originalFileHash: json['originalFileHash'] as String,
         encryptionKey: json['encryptionKey'] as String?,
         encryptionNonce: json['encryptionNonce'] as String?,
@@ -146,8 +132,6 @@ class MediaAttachment {
         'mimeType': mimeType,
         'dimension': dimension,
         'alt': alt.toShortString(),
-        'torrentInfoHash': torrentInfoHash,
-        'fileHash': fileHash,
         'originalFileHash': originalFileHash,
         'encryptionKey': encryptionKey,
         'encryptionNonce': encryptionNonce,
@@ -165,11 +149,7 @@ class MediaAttachment {
 
   final FileAlt alt;
 
-  final String fileHash;
-
   final String originalFileHash;
-
-  final String torrentInfoHash;
 
   final String? thumb;
 
@@ -227,9 +207,7 @@ class MediaAttachment {
       'url $url',
       'm $mimeType',
       'dim $dimension',
-      'i $torrentInfoHash',
       'alt ${alt.toShortString()}',
-      'x $fileHash',
       'ox $originalFileHash',
       if (encryptionKey != null && encryptionNonce != null)
         'encryption-key $encryptionKey $encryptionNonce $encryptionMac aes-gcm',
@@ -244,7 +222,7 @@ class MediaAttachment {
 
   @override
   String toString() {
-    return 'MediaAttachment(url: $url, mimeType: $mimeType, dimension: $dimension, alt: $alt, fileHash: $fileHash, originalFileHash: $originalFileHash, torrentInfoHash: $torrentInfoHash, thumb: $thumb, image: $image, blurhash: $blurhash, duration: $duration)';
+    return 'MediaAttachment(url: $url, mimeType: $mimeType, dimension: $dimension, alt: $alt, originalFileHash: $originalFileHash, thumb: $thumb, image: $image, blurhash: $blurhash, duration: $duration)';
   }
 
   MediaAttachment copyWith({
@@ -252,9 +230,7 @@ class MediaAttachment {
     String? mimeType,
     String? dimension,
     FileAlt? alt,
-    String? fileHash,
     String? originalFileHash,
-    String? torrentInfoHash,
     String? thumb,
     String? image,
     String? encryptionKey,
@@ -268,9 +244,7 @@ class MediaAttachment {
       mimeType: mimeType ?? this.mimeType,
       dimension: dimension ?? this.dimension,
       alt: alt ?? this.alt,
-      fileHash: fileHash ?? this.fileHash,
       originalFileHash: originalFileHash ?? this.originalFileHash,
-      torrentInfoHash: torrentInfoHash ?? this.torrentInfoHash,
       thumb: thumb ?? this.thumb,
       image: image ?? this.image,
       encryptionKey: encryptionKey ?? this.encryptionKey,

--- a/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
@@ -67,8 +67,6 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
       url: fileMetadata.url,
       mimeType: fileMetadata.mimeType,
       dimension: dimension,
-      torrentInfoHash: fileMetadata.torrentInfoHash,
-      fileHash: fileMetadata.fileHash,
       originalFileHash: fileMetadata.originalFileHash,
       alt: alt,
       thumb: fileMetadata.thumb,

--- a/lib/app/services/markdown/quill.dart
+++ b/lib/app/services/markdown/quill.dart
@@ -115,7 +115,7 @@ Delta markdownToDelta(String markdown) {
     }
   }
 
-  return processedDelta;
+  return recoverFlattenLinks(processedDelta);
 }
 
 void _processMatches(Operation op, Delta processedDelta) {
@@ -160,7 +160,7 @@ Delta processDelta(Delta delta) {
     }
   }
 
-  return newDelta;
+  return recoverFlattenLinks(delta);
 }
 
 Delta parseAndConvertDelta(String? deltaContent, String fallbackMarkdown) {
@@ -186,4 +186,30 @@ Delta processDeltaMatches(Delta delta) {
     _processMatches(op, newDelta);
   }
   return newDelta;
+}
+
+Delta flattenLinks(Delta delta) {
+  final out = Delta();
+  for (final op in delta.toList()) {
+    final href = op.attributes?[Attribute.link.key];
+    if (href != null && op.value is String && op.value == href) {
+      out.push(Operation.insert(' ', {Attribute.link.key: href}));
+    } else {
+      out.push(op);
+    }
+  }
+  return out;
+}
+
+Delta recoverFlattenLinks(Delta delta) {
+  final out = Delta();
+  for (final op in delta.toList()) {
+    final href = op.attributes?[Attribute.link.key];
+    if (href != null && op.value is String && op.value == ' ') {
+      out.push(Operation.insert(href, {Attribute.link.key: href}));
+    } else {
+      out.push(op);
+    }
+  }
+  return out;
 }

--- a/lib/app/services/markdown/quill.dart
+++ b/lib/app/services/markdown/quill.dart
@@ -115,7 +115,7 @@ Delta markdownToDelta(String markdown) {
     }
   }
 
-  return recoverFlattenLinks(processedDelta);
+  return withFullLinks(processedDelta);
 }
 
 void _processMatches(Operation op, Delta processedDelta) {
@@ -160,7 +160,7 @@ Delta processDelta(Delta delta) {
     }
   }
 
-  return recoverFlattenLinks(delta);
+  return withFullLinks(delta);
 }
 
 Delta parseAndConvertDelta(String? deltaContent, String fallbackMarkdown) {
@@ -188,7 +188,7 @@ Delta processDeltaMatches(Delta delta) {
   return newDelta;
 }
 
-Delta flattenLinks(Delta delta) {
+Delta withFlattenLinks(Delta delta) {
   final out = Delta();
   for (final op in delta.toList()) {
     final href = op.attributes?[Attribute.link.key];
@@ -201,7 +201,7 @@ Delta flattenLinks(Delta delta) {
   return out;
 }
 
-Delta recoverFlattenLinks(Delta delta) {
+Delta withFullLinks(Delta delta) {
   final out = Delta();
   for (final op in delta.toList()) {
     final href = op.attributes?[Attribute.link.key];


### PR DESCRIPTION
## Description
This PR:
1. Removes `x` and `i` fields from `imeta` tag
2. Sets empty `content` inside posts/article when `richText` is not empty during creation
3. Introduces a logic to flatten links inside content of posts/articles if they are the same as text (e.x. "*[someLink]*(someLink)")  to avoid duplication

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
