### PR TITLE
fix: identity key name validation on continue tap

### DIFF
--- a/lib/app/features/auth/views/components/identity_key_name_input/identity_key_name_input.dart
+++ b/lib/app/features/auth/views/components/identity_key_name_input/identity_key_name_input.dart
@@ -61,7 +61,8 @@ class IdentityKeyNameInput extends StatelessWidget {
       labelText: context.i18n.common_identity_key_name,
       controller: controller,
       validator: (String? value) {
-        if (Validators.isInvalidIdentityName(value) && !Validators.isEmpty(value)) {
+        if (Validators.isEmpty(value)) return '';
+        if (Validators.isInvalidIdentityName(value)) {
           return context.i18n.error_identity_name_invalid;
         }
         return null;


### PR DESCRIPTION
## Description
This PR fixes an issue where continue button could be tapped and register logic was initiated with empty input field

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/310baf65-c82f-4c1f-8b76-f560a7e03eca

