### PR TITLE
fix: sync coin groups after transfer and wallets refresh

### DIFF
--- a/lib/app/features/wallets/data/database/wallets_database.c.dart
+++ b/lib/app/features/wallets/data/database/wallets_database.c.dart
@@ -99,6 +99,8 @@ class WalletsDatabase extends _$WalletsDatabase {
             asset_id, transferred_amount, transferred_amount_usd
           FROM $oldTransactionsTableName;
           ''');
+
+          await m.deleteTable(oldTransactionsTableName);
         },
         from7To8: (m, schema) async {
           await m.addColumn(schema.transactionsTableV2, schema.transactionsTableV2.eventId);

--- a/lib/app/features/wallets/domain/wallet_views/wallet_views_service.c.dart
+++ b/lib/app/features/wallets/domain/wallet_views/wallet_views_service.c.dart
@@ -181,6 +181,7 @@ class WalletViewsService {
           modifiedCoin = _applyExecutingTransactions(
             coinInWallet: modifiedCoin,
             transactions: transactions,
+            walletViewId: walletView.id,
           );
 
           totalGroupAmount += modifiedCoin.amount;
@@ -227,8 +228,9 @@ class WalletViewsService {
 
   /// Subtracts sent coins from the existing number of coins.
   CoinInWalletData _applyExecutingTransactions({
-    required Map<CoinData, List<TransactionData>> transactions,
+    required String walletViewId,
     required CoinInWalletData coinInWallet,
+    required Map<CoinData, List<TransactionData>> transactions,
   }) {
     var updatedCoin = coinInWallet;
 
@@ -245,9 +247,12 @@ class WalletViewsService {
 
       for (final transaction in coinTransactions) {
         final isTransactionRelatedToCoin = transaction.senderWalletAddress == wallet?.address;
+        final isTransactionRelatedToWalletView = transaction.walletViewId == walletViewId;
         final transactionCoin = transaction.cryptoAsset;
 
-        if (isTransactionRelatedToCoin && transactionCoin is CoinTransactionAsset) {
+        if (isTransactionRelatedToCoin &&
+            transactionCoin is CoinTransactionAsset &&
+            isTransactionRelatedToWalletView) {
           adjustedRawAmount -= BigInt.parse(transactionCoin.rawAmount);
         }
       }

--- a/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
@@ -20,6 +20,7 @@ import 'package:ion/app/features/wallets/model/transaction_status.c.dart';
 import 'package:ion/app/features/wallets/model/transaction_type.dart';
 import 'package:ion/app/features/wallets/model/transfer_result.c.dart';
 import 'package:ion/app/features/wallets/providers/send_asset_form_provider.c.dart';
+import 'package:ion/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
 import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/utils/retry.dart';
@@ -37,6 +38,8 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
   }
 
   Future<void> send(OnVerifyIdentity<Map<String, dynamic>> onVerifyIdentity) async {
+    if (state.isLoading) return;
+
     final form = ref.read(sendAssetFormControllerProvider);
 
     if (form.assetData is! CoinAssetToSendData) {
@@ -131,6 +134,12 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
 
       return details;
     });
+
+    unawaited(
+      ref.read(syncedCoinsBySymbolGroupNotifierProvider.notifier).refresh(
+        [coinAssetData.coinsGroup.symbolGroup],
+      ),
+    );
 
     if (state.hasError) {
       // Log to get the error stack trace

--- a/lib/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart
+++ b/lib/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart
@@ -5,51 +5,92 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/wallets/domain/coins/coins_comparator.dart';
 import 'package:ion/app/features/wallets/domain/coins/coins_service.c.dart';
+import 'package:ion/app/features/wallets/model/coin_data.c.dart';
 import 'package:ion/app/features/wallets/model/coin_in_wallet_data.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'synced_coins_by_symbol_group_provider.c.g.dart';
 
+typedef CoinCache = Map<String, List<CoinInWalletData>>;
+
 @Riverpod(keepAlive: true)
 class SyncedCoinsBySymbolGroupNotifier extends _$SyncedCoinsBySymbolGroupNotifier {
+  late final _coinsComparator = CoinsComparator();
+
   @override
-  FutureOr<Map<String, List<CoinInWalletData>>> build() async {
-    // Reset state when isAuthenticated is changed
+  FutureOr<CoinCache> build() async {
+    // Reset state when isAuthenticated changes
     await ref.watch(authProvider.selectAsync((state) => state.isAuthenticated));
+    // Reset state each time the wallet view changes
+    await ref.watch(currentWalletViewIdProvider.selectAsync((state) => state));
+
     return {};
   }
 
+  /// Retrieves coins for a specific symbol group, using cache when available
   Future<List<CoinInWalletData>> getCoins(String symbolGroup) async {
     final cachedData = state.value?[symbolGroup];
-    if (cachedData != null) {
-      return cachedData;
-    }
+    if (cachedData != null) return cachedData;
 
+    final updatedCoins = await _fetchAndProcessCoins(symbolGroup);
+    _updateCache({symbolGroup: updatedCoins});
+
+    return updatedCoins;
+  }
+
+  /// Refreshes coin data for specified symbol groups or all cached groups
+  Future<void> refresh([List<String>? symbolGroups]) async {
+    final currentCache = state.valueOrNull ?? {};
+    final groupsToUpdate = symbolGroups ?? currentCache.keys.toList();
+
+    final updates = await Future.wait(
+      groupsToUpdate.map((group) async {
+        final coins = await _fetchAndProcessCoins(group);
+        return MapEntry(group, coins);
+      }),
+    );
+
+    _updateCache(Map.fromEntries(updates));
+  }
+
+  Future<List<CoinInWalletData>> _fetchAndProcessCoins(String symbolGroup) async {
     final service = await ref.read(coinsServiceProvider.future);
     final coins = await service.getSyncedCoinsBySymbolGroup(symbolGroup);
-    final walletViewCoins =
-        await ref.read(currentWalletViewDataProvider.future).then((walletView) => walletView.coins);
+    final walletCoins = await _getWalletViewCoins();
 
-    final result = <CoinInWalletData>[];
-    for (final coin in coins) {
-      final fromWallet = walletViewCoins.firstWhereOrNull((e) => e.coin.id == coin.id);
-      result.add(fromWallet ?? CoinInWalletData(coin: coin));
-    }
-    result.sort(CoinsComparator().compareCoins);
+    return _processCoins(coins, walletCoins);
+  }
 
+  Future<List<CoinInWalletData>> _getWalletViewCoins() async {
+    return ref.read(currentWalletViewDataProvider.future).then((walletView) => walletView.coins);
+  }
+
+  List<CoinInWalletData> _processCoins(
+    Iterable<CoinData> coins,
+    Iterable<CoinInWalletData> walletCoins,
+  ) {
+    final result = coins.map((coin) {
+      final fromWallet = walletCoins.firstWhereOrNull((e) => e.coin.id == coin.id);
+      return fromWallet ?? CoinInWalletData(coin: coin);
+    }).toList();
+
+    return result..sort(_coinsComparator.compareCoins);
+  }
+
+  void _updateCache(Map<String, List<CoinInWalletData>> updates) {
     state = AsyncValue.data({
       ...state.valueOrNull ?? {},
-      symbolGroup: result,
+      ...updates,
     });
-
-    return result;
   }
 }
 
 @riverpod
-Future<List<CoinInWalletData>> syncedCoinsBySymbolGroup(Ref ref, String symbolGroup) async {
+Future<List<CoinInWalletData>> syncedCoinsBySymbolGroup(
+  Ref ref,
+  String symbolGroup,
+) async {
   final notifier = ref.watch(syncedCoinsBySymbolGroupNotifierProvider.notifier);
-  final coins = await notifier.getCoins(symbolGroup);
-  return coins;
+  return notifier.getCoins(symbolGroup);
 }

--- a/lib/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart
+++ b/lib/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart
@@ -12,14 +12,14 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'synced_coins_by_symbol_group_provider.c.g.dart';
 
-typedef CoinCache = Map<String, List<CoinInWalletData>>;
+typedef SyncedCoinsCache = Map<String, List<CoinInWalletData>>;
 
 @Riverpod(keepAlive: true)
 class SyncedCoinsBySymbolGroupNotifier extends _$SyncedCoinsBySymbolGroupNotifier {
   late final _coinsComparator = CoinsComparator();
 
   @override
-  FutureOr<CoinCache> build() async {
+  FutureOr<SyncedCoinsCache> build() async {
     // Reset state when isAuthenticated changes
     await ref.watch(authProvider.selectAsync((state) => state.isAuthenticated));
     // Reset state each time the wallet view changes

--- a/lib/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart
+++ b/lib/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart
@@ -23,7 +23,7 @@ class SyncedCoinsBySymbolGroupNotifier extends _$SyncedCoinsBySymbolGroupNotifie
     // Reset state when isAuthenticated changes
     await ref.watch(authProvider.selectAsync((state) => state.isAuthenticated));
     // Reset state each time the wallet view changes
-    await ref.watch(currentWalletViewIdProvider.selectAsync((state) => state));
+    await ref.watch(currentWalletViewIdProvider.future);
 
     return {};
   }

--- a/lib/app/features/wallets/views/pages/wallet_page.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page.dart
@@ -10,6 +10,7 @@ import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.c.dart'
 import 'package:ion/app/features/user/providers/follow_list_provider.c.dart';
 import 'package:ion/app/features/user/providers/friends_section_providers.c.dart';
 import 'package:ion/app/features/wallets/domain/transactions/sync_transactions_service.c.dart';
+import 'package:ion/app/features/wallets/providers/synced_coins_by_symbol_group_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/balance/balance.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/coins/coins_tab.dart';
@@ -92,6 +93,8 @@ class WalletPage extends HookConsumerWidget {
                 .then((service) => service.sync());
 
             ref.invalidate(walletViewsDataNotifierProvider);
+
+            await ref.read(syncedCoinsBySymbolGroupNotifierProvider.notifier).refresh();
           },
           builder: (context, slivers) => CustomScrollView(
             controller: scrollController,


### PR DESCRIPTION
## Description
1. Refresh synced coin groups after transfer/wallet page refresh.
2. Remove deprecated database table.
3. When request broadcasted transfers to apply balance fix, request only related to the current wallet view transfers.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore
