### PR TITLE
fix: show reply and reactions content for money messages

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart
+++ b/lib/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart
@@ -235,9 +235,14 @@ ChatMessageInfoItem? getRepliedMessageListItem({
     MessageType.profile => null,
     MessageType.sharedPost => null,
     MessageType.visualMedia => null,
-    // TODO: implement replied for money message
-    MessageType.requestFunds => null,
-    MessageType.moneySent => null,
+    MessageType.requestFunds => MoneyItem(
+        eventMessage: repliedEventMessage,
+        contentDescription: ref.context.i18n.chat_money_request_title,
+      ),
+    MessageType.moneySent => MoneyItem(
+        eventMessage: repliedEventMessage,
+        contentDescription: ref.context.i18n.chat_money_received_title,
+      ),
     MessageType.text => TextItem(
         eventMessage: repliedEventMessage,
         contentDescription: repliedEntity.data.content,

--- a/lib/app/features/chat/views/components/message_items/message_reaction_dialog/components/message_reaction_context_menu.dart
+++ b/lib/app/features/chat/views/components/message_items/message_reaction_dialog/components/message_reaction_context_menu.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/chat/e2ee/providers/e2ee_delete_event_provider.
 import 'package:ion/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart';
 import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
 import 'package:ion/app/features/chat/model/message_list_item.c.dart';
+import 'package:ion/app/features/chat/model/message_type.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/selected_edit_message_provider.c.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/selected_reply_message_provider.c.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
@@ -46,7 +47,8 @@ class MessageReactionContextMenu extends HookConsumerWidget {
     final canEdit = entityData.editingEndedAt.value.isAfter(DateTime.now());
     final hideChatBookmark =
         ref.watch(featureFlagsProvider.notifier).get(ChatFeatureFlag.hideChatBookmark);
-    final canCopy = messageItem.eventMessage.content.isNotEmpty;
+    final canCopy =
+        entityData.messageType == MessageType.text || entityData.messageType == MessageType.emoji;
 
     return Padding(
       padding: EdgeInsetsDirectional.only(top: 6.0.s),

--- a/lib/app/features/chat/views/components/message_items/message_reaction_dialog/components/message_reaction_context_menu.dart
+++ b/lib/app/features/chat/views/components/message_items/message_reaction_dialog/components/message_reaction_context_menu.dart
@@ -15,7 +15,6 @@ import 'package:ion/app/features/chat/e2ee/providers/e2ee_delete_event_provider.
 import 'package:ion/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.c.dart';
 import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
 import 'package:ion/app/features/chat/model/message_list_item.c.dart';
-import 'package:ion/app/features/chat/model/message_type.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/selected_edit_message_provider.c.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/selected_reply_message_provider.c.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
@@ -47,8 +46,7 @@ class MessageReactionContextMenu extends HookConsumerWidget {
     final canEdit = entityData.editingEndedAt.value.isAfter(DateTime.now());
     final hideChatBookmark =
         ref.watch(featureFlagsProvider.notifier).get(ChatFeatureFlag.hideChatBookmark);
-    final canCopy =
-        entityData.messageType == MessageType.text || entityData.messageType == MessageType.emoji;
+    final canCopy = messageItem.eventMessage.content.isNotEmpty;
 
     return Padding(
       padding: EdgeInsetsDirectional.only(top: 6.0.s),

--- a/lib/app/features/chat/views/components/message_items/message_types/reply_message/reply_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/reply_message/reply_message.dart
@@ -132,7 +132,7 @@ class ReplyMessage extends HookConsumerWidget {
         PostItem _ => null,
         TextItem _ => null,
         EmojiItem _ => null,
-        MoneyItem _ => null,
+        MoneyItem _ => Assets.svg.iconProfileTips,
         DocumentItem _ => Assets.svg.iconChatFile,
         MediaItem _ => Assets.svg.iconProfileCamera,
         AudioItem _ => Assets.svg.iconChatVoicemessage,


### PR DESCRIPTION
## Description
This PR fix displays reply and reaction content for money messages.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

<img width="180" alt="image" src="https://github.com/user-attachments/assets/30e1c773-6a9f-4978-947c-49457ab8cfc0"> 
<img width="180" alt="image" src="https://github.com/user-attachments/assets/051465af-ad4c-43b5-98e7-9f89a78d915d"> 
