### PR TITLE
fix: adjust bottom padding in delete message modal

### DIFF
--- a/lib/app/features/chat/recent_chats/views/pages/delete_message_modal/delete_message_modal.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/delete_message_modal/delete_message_modal.dart
@@ -68,7 +68,7 @@ class DeleteMessageModal extends ConsumerWidget {
                 ),
               ],
             ),
-            SizedBox(height: MediaQuery.paddingOf(context).bottom + 16.0.s),
+            SizedBox(height: 16.0.s),
           ],
         ),
       ),


### PR DESCRIPTION
## Description
This PR addresses the issue by adjusting the bottom padding in the delete message modal.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
