### PR TITLE
fix(wallet): send coins fee

### DIFF
--- a/lib/app/features/wallets/domain/coins/coins_service.c.dart
+++ b/lib/app/features/wallets/domain/coins/coins_service.c.dart
@@ -83,11 +83,13 @@ class CoinsService {
     required String receiverAddress,
     required WalletAsset sendableAsset,
     required OnVerifyIdentity<Map<String, dynamic>> onVerifyIdentity,
+    NetworkFeeType? feeType,
   }) async {
     final transfer = _TransferFactory().create(
       receiverAddress: receiverAddress,
       amountValue: amount,
       sendableAsset: sendableAsset,
+      networkFeeType: feeType,
     );
     final result = await _ionIdentityClient.wallets.makeTransfer(
       senderWallet,

--- a/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_coins_notifier_provider.c.dart
@@ -50,6 +50,7 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
     final coinAssetData = form.assetData as CoinAssetToSendData;
     final sendableAsset = coinAssetData.associatedAssetWithSelectedOption;
     final senderWallet = form.senderWallet;
+    final feeType = form.selectedNetworkFeeOption?.type;
 
     if (senderWallet == null || sendableAsset == null) {
       final missingComponent = senderWallet == null ? 'senderWallet' : 'sendableAsset';
@@ -71,6 +72,7 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
         sendableAsset: sendableAsset,
         onVerifyIdentity: onVerifyIdentity,
         receiverAddress: form.receiverAddress,
+        feeType: feeType,
       );
 
       bool isRetryStatus(TransactionStatus status) =>

--- a/lib/app/features/wallets/views/components/arrival_time/network_fee_selector.dart
+++ b/lib/app/features/wallets/views/components/arrival_time/network_fee_selector.dart
@@ -28,18 +28,22 @@ class NetworkFeeSelector extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
+    final showSlider = options.length > 2;
+
     return Padding(
       padding: padding ?? EdgeInsets.zero,
       child: Column(
         children: [
           ArrivalTime(option: selectedOption!),
-          SizedBox(height: 12.0.s),
-          AppSlider(
-            maxValue: options.length - 1,
-            stops: List.generate(options.length, (i) => i.toDouble()),
-            initialValue: options.indexOf(selectedOption!).toDouble(),
-            onChanged: (value) => onChanged?.call(value.toInt()),
-          ),
+          if (showSlider) ...[
+            SizedBox(height: 12.0.s),
+            AppSlider(
+              maxValue: options.length - 1,
+              stops: List.generate(options.length, (i) => i.toDouble()),
+              initialValue: options.indexOf(selectedOption!).toDouble(),
+              onChanged: (value) => onChanged?.call(value.toInt()),
+            ),
+          ],
           SizedBox(height: 8.0.s),
           NetworkFeeOptionWidget(feeOption: selectedOption!),
         ],

--- a/lib/app/features/wallets/views/components/arrival_time/network_fee_selector.dart
+++ b/lib/app/features/wallets/views/components/arrival_time/network_fee_selector.dart
@@ -28,7 +28,7 @@ class NetworkFeeSelector extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final showSlider = options.length > 2;
+    final showSlider = options.length > 1;
 
     return Padding(
       padding: padding ?? EdgeInsets.zero,


### PR DESCRIPTION
## Description
This PR fixes 2 issues related to fee in Send Coins flow:
- hides network fee slider if we have only 1 network fee option (screenshot 1). previously the app crashed on this step.
- adds network fee for the supported transfers

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/23254b21-adb7-4f2d-91ec-f6f973619df9">