### PR TITLE
fix: unify cashtag regex across the app, allow numbers and dashes in cashtags in addition to letters

### DIFF
--- a/lib/app/components/text_editor/components/cashtags_suggestions.dart
+++ b/lib/app/components/text_editor/components/cashtags_suggestions.dart
@@ -33,6 +33,7 @@ class CashtagsSuggestions extends StatelessWidget {
                 final suggestion = suggestions[index];
                 return GestureDetector(
                   onTap: () => onSuggestionSelected(suggestion),
+                  behavior: HitTestBehavior.opaque,
                   child: ScreenSideOffset.small(
                     child: Container(
                       alignment: AlignmentDirectional.centerStart,

--- a/lib/app/components/text_editor/components/hashtags_suggestions.dart
+++ b/lib/app/components/text_editor/components/hashtags_suggestions.dart
@@ -35,9 +35,8 @@ class HashtagsSuggestions extends StatelessWidget {
               itemBuilder: (context, index) {
                 final suggestion = suggestions[index];
                 return GestureDetector(
-                  onTap: () {
-                    onSuggestionSelected(suggestion);
-                  },
+                  onTap: () => onSuggestionSelected(suggestion),
+                  behavior: HitTestBehavior.opaque,
                   child: ScreenSideOffset.small(
                     child: Container(
                       alignment: AlignmentDirectional.centerStart,

--- a/lib/app/components/text_editor/utils/mentions_hashtags_handler.dart
+++ b/lib/app/components/text_editor/utils/mentions_hashtags_handler.dart
@@ -7,6 +7,7 @@ import 'package:ion/app/components/text_editor/components/custom_blocks/text_edi
 import 'package:ion/app/components/text_editor/utils/text_editor_typing_listener.dart';
 import 'package:ion/app/features/feed/providers/suggestions/suggestions_notifier_provider.c.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
+import 'package:ion/app/services/text_parser/model/text_matcher.dart';
 
 class MentionsHashtagsHandler extends TextEditorTypingListener {
   MentionsHashtagsHandler({
@@ -117,7 +118,9 @@ class MentionsHashtagsHandler extends TextEditorTypingListener {
   }
 
   List<_TagInfo> _extractTags(String text) {
-    final regex = RegExp(r'(?:(?<=\s)|^)[@#$]\w+');
+    final regex = RegExp(
+      '${const CashtagMatcher().pattern}|${const HashtagMatcher().pattern}|${const MentionMatcher().pattern}',
+    );
     final matches = regex.allMatches(text);
 
     return matches.map((match) {

--- a/lib/app/services/text_parser/model/text_matcher.dart
+++ b/lib/app/services/text_parser/model/text_matcher.dart
@@ -32,5 +32,5 @@ class CashtagMatcher extends TextMatcher {
   const CashtagMatcher();
 
   @override
-  String get pattern => r'\$[A-Za-z]+\b';
+  String get pattern => r'\$(?=[\w-]*[A-Za-z])\w+(?:-\w+)*\b';
 }


### PR DESCRIPTION
## Description
This PR:
1. unifies regex for cashtags (different ones were used in different places)
2. updates the regex to allow numbers and dashes inside cashtags (don't allow numbers only)

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
 
![ScreenShot 2025-05-16 at 13 50 30@2x](https://github.com/user-attachments/assets/64eb442a-e5f7-4e20-9c1a-bd393db8cedb)
