### PR TITLE
fix: make video thumbnail cover the whole width in post media

### DIFF
--- a/lib/app/components/video_preview/video_preview.dart
+++ b/lib/app/components/video_preview/video_preview.dart
@@ -132,7 +132,7 @@ class VideoPreview extends HookConsumerWidget {
                 isLoading: !(controller?.value.hasError ?? false),
               ),
             ),
-          if (controller != null && !controller.value.hasError)
+          if (controller != null && controller.value.isInitialized && !controller.value.hasError)
             Positioned.fill(
               child: FittedBox(
                 fit: BoxFit.cover,
@@ -147,7 +147,7 @@ class VideoPreview extends HookConsumerWidget {
             const Positioned.fill(
               child: IonPlaceholder(),
             ),
-          if (controller != null)
+          if (controller != null && controller.value.isInitialized)
             PositionedDirectional(
               bottom: 5.0.s,
               start: 5.0.s,
@@ -264,13 +264,15 @@ class _BlurredThumbnail extends HookWidget {
 
     return Stack(
       children: [
-        AnimatedOpacity(
-          duration: const Duration(milliseconds: 100),
-          opacity: isImageLoaded.value ? 1 : 0,
-          child: IonConnectNetworkImage(
-            imageUrl: thumbnailUrl,
-            authorPubkey: authorPubkey,
-            fit: BoxFit.cover,
+        Positioned.fill(
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 100),
+            opacity: isImageLoaded.value ? 1 : 0,
+            child: IonConnectNetworkImage(
+              imageUrl: thumbnailUrl,
+              authorPubkey: authorPubkey,
+              fit: BoxFit.cover,
+            ),
           ),
         ),
         if (isLoading)


### PR DESCRIPTION
## Description
This PR fixes an issue where the video thumbnail (during video loading) was only taking half of the available width.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
![ScreenShot 2025-05-19 at 11 39 54@2x](https://github.com/user-attachments/assets/83de86e9-6dbe-44b7-bfad-044270578d9c)

