### PR TITLE
fix(chat): remove rounding for asset amount

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/components/amount_display.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/components/amount_display.dart
@@ -35,10 +35,7 @@ class _AmountDisplay extends HookWidget {
         Row(
           children: [
             Text(
-              NumberFormat.currency(
-                symbol: coin.emptyOrValue.isEmpty ? '' : '$coin ',
-                decimalDigits: 2,
-              ).format(amount),
+              formatCrypto(amount, coin.emptyOrValue.isEmpty ? '' : '$coin '),
               style: context.theme.appTextThemes.subtitle3.copyWith(color: textColor),
             ),
             SizedBox(width: 4.0.s),

--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/extensions/object.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
@@ -24,6 +23,7 @@ import 'package:ion/app/features/wallets/model/network_data.c.dart';
 import 'package:ion/app/features/wallets/providers/coins_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/networks_provider.c.dart';
 import 'package:ion/app/features/wallets/views/components/network_icon_widget.dart';
+import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/date.dart';
 import 'package:ion/app/utils/num.dart';
 
@@ -191,6 +191,7 @@ class _MoneyMessageContent extends HookConsumerWidget {
   final String eventId;
   final Widget button;
   final VoidCallback? onTapReply;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final textColor = switch (isMe) {


### PR DESCRIPTION
## Description
Fix for asset amount rounding in MoneyMessage. e.g. previously if I sent 0.005 it was shown as 0.01.


## Type of Change
- [x] Bug fix

## Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/89493f70-d013-4263-8e54-05650d7a0dad">