### PR TITLE
feat: add a provider for long living subscription relays

### DIFF
--- a/lib/app/features/feed/providers/feed_bookmarks_notifier.c.dart
+++ b/lib/app/features/feed/providers/feed_bookmarks_notifier.c.dart
@@ -50,7 +50,6 @@ Stream<BookmarksCollectionEntity?> bookmarksCollectionStream(
   final events = ref.watch(
     ionConnectEventsSubscriptionProvider(
       request,
-      actionSource: ActionSourceUser(pubkey),
       onEndOfStoredEvents: onEndOfStoredEvents,
     ),
   );

--- a/lib/app/features/ion_connect/model/disliked_relay_urls_collection.c.dart
+++ b/lib/app/features/ion_connect/model/disliked_relay_urls_collection.c.dart
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'disliked_relay_urls_collection.c.freezed.dart';
+
+@freezed
+class DislikedRelayUrlsCollection with _$DislikedRelayUrlsCollection {
+  const factory DislikedRelayUrlsCollection(
+    Set<String> urls,
+  ) = _DislikedRelayUrlsCollection;
+
+  const DislikedRelayUrlsCollection._();
+
+  bool contains(String url) {
+    return urls.contains(url);
+  }
+}

--- a/lib/app/features/ion_connect/providers/long_living_subscription_relay_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/long_living_subscription_relay_provider.c.dart
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:async';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/ion_connect/model/action_source.c.dart';
+import 'package:ion/app/features/ion_connect/model/disliked_relay_urls_collection.c.dart';
+import 'package:ion/app/features/ion_connect/providers/relay_creation_provider.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'long_living_subscription_relay_provider.c.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<IonConnectRelay> longLivingSubscriptionRelay(
+  Ref ref,
+  ActionSource actionSource, {
+  DislikedRelayUrlsCollection dislikedUrls = const DislikedRelayUrlsCollection({}),
+}) async {
+  onLogout(ref, () {
+    ref.invalidateSelf();
+  });
+
+  final relay = await ref.read(relayCreationProvider.notifier).getRelay(
+        actionSource,
+        dislikedUrls: dislikedUrls,
+      );
+  unawaited(
+    relay.onClose.first.then((_) {
+      ref.invalidateSelf();
+    }),
+  );
+
+  return relay;
+}

--- a/lib/app/features/ion_connect/providers/relay_creation_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/relay_creation_provider.c.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/features/chat/providers/user_chat_relays_provider.c.dart
 import 'package:ion/app/features/ion_connect/ion_connect.dart' hide requestEvents;
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.c.dart';
+import 'package:ion/app/features/ion_connect/model/disliked_relay_urls_collection.c.dart';
 import 'package:ion/app/features/ion_connect/providers/active_relays_provider.c.dart';
 import 'package:ion/app/features/ion_connect/providers/relay_provider.c.dart';
 import 'package:ion/app/features/user/model/user_chat_relays.c.dart';
@@ -26,7 +27,7 @@ class RelayCreation extends _$RelayCreation {
 
   Future<IonConnectRelay> getRelay(
     ActionSource actionSource, {
-    Set<String> dislikedUrls = const {},
+    DislikedRelayUrlsCollection dislikedUrls = const DislikedRelayUrlsCollection({}),
   }) async {
     switch (actionSource) {
       case ActionSourceCurrentUser():
@@ -137,7 +138,7 @@ class RelayCreation extends _$RelayCreation {
 
   Future<IonConnectRelay?> _getLastUsedRelay(
     List<String> userRelays,
-    Set<String> dislikedUrls,
+    DislikedRelayUrlsCollection dislikedUrls,
     bool anonymous,
   ) async {
     final activeRelaysSet = ref.read(activeRelaysProvider);
@@ -194,14 +195,17 @@ class RelayCreation extends _$RelayCreation {
 
   List<UserRelay> _userRelaysAvoidingDislikedUrls(
     List<UserRelay> relays,
-    Set<String> dislikedRelaysUrls,
+    DislikedRelayUrlsCollection dislikedRelaysUrls,
   ) {
     final urls = relays.where((relay) => !dislikedRelaysUrls.contains(relay.url)).toList();
     if (urls.isEmpty) return relays;
     return urls;
   }
 
-  List<String> _indexersAvoidingDislikedUrls(List<String> indexers, Set<String> dislikedUrls) {
+  List<String> _indexersAvoidingDislikedUrls(
+    List<String> indexers,
+    DislikedRelayUrlsCollection dislikedUrls,
+  ) {
     var urls = indexers.where((indexer) => !dislikedUrls.contains(indexer)).toList();
     if (urls.isEmpty) {
       urls = indexers;


### PR DESCRIPTION
## Description
This PR adds a provider managing relays for long living subscription so that we can avoid multiple relays being used for the same pubkey subscriptions.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
