### PR TITLE
fix: normalize URLs before opening in app browser

### DIFF
--- a/lib/app/components/text_span_builder/text_span_builder.dart
+++ b/lib/app/components/text_span_builder/text_span_builder.dart
@@ -7,6 +7,7 @@ import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/services/browser/browser.dart';
 import 'package:ion/app/services/text_parser/model/text_match.c.dart';
 import 'package:ion/app/services/text_parser/model/text_matcher.dart';
+import 'package:ion/app/utils/url.dart';
 
 /// Constructs TextSpan from TextMatch objects with customizable styles and tap handling.
 class TextSpanBuilder {
@@ -92,7 +93,7 @@ class TextSpanBuilder {
     BuildContext context, {
     required TextMatch match,
   }) {
-    if (match.matcher is UrlMatcher) openUrlInAppBrowser(match.text);
+    if (match.matcher is UrlMatcher) openUrlInAppBrowser(normalizeUrl(match.text));
     if (match.matcher is HashtagMatcher || match.matcher is CashtagMatcher) {
       FeedAdvancedSearchRoute(query: match.text).go(context);
     }


### PR DESCRIPTION
## Description
This PR normalizes URLs before opening in the app browser when highlighted.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
