### PR TITLE
fix: prevent scroll jump at end of message list

### DIFF
--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -223,7 +223,7 @@ class E2eeRecentChatTile extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final userMetadata = ref.watch(userMetadataProvider(receiverPubkey)).valueOrNull;
+    final userMetadata = ref.watch(cachedUserMetadataProvider(receiverPubkey));
 
     if (userMetadata == null) {
       return const RecentChatSkeletonItem();


### PR DESCRIPTION
## Description
This PR fixes the smooth scrolling issue when the user reaches the bottom of the page.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
