### PR TITLE
fix(chat): update MoneySent recent message title

### DIFF
--- a/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
+++ b/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
@@ -280,7 +280,7 @@ class ChatPreview extends HookConsumerWidget {
       MessageType.visualMedia => context.i18n.common_media,
       MessageType.document => lastMessageContent,
       MessageType.requestFunds => context.i18n.chat_money_request_title,
-      MessageType.moneySent => context.i18n.chat_money_sent_title,
+      MessageType.moneySent => _getMoneySentTitle(ref, lastMessageContent),
       MessageType.profile => ref
               .watch(
                 userMetadataProvider(
@@ -316,6 +316,14 @@ class ChatPreview extends HookConsumerWidget {
         ),
       ],
     );
+  }
+
+  String _getMoneySentTitle(WidgetRef ref, String messageContent) {
+    final messagePubkey = EventReference.fromEncoded(lastMessageContent).pubkey;
+    final isMyPubkey = ref.watch(currentPubkeySelectorProvider) == messagePubkey;
+    return isMyPubkey
+        ? ref.context.i18n.chat_money_sent_title
+        : ref.context.i18n.chat_money_received_title;
   }
 }
 


### PR DESCRIPTION
## Description
Previously the message was "Money sent" even for a user who received money. Now it's displayed "Money sent" for the sender and "Money received" for the receiver.

## Type of Change
- [x] Bug fix

## Screenshots
<img width="250" alt="image" src="https://github.com/user-attachments/assets/fe7ba6e5-8d0d-48bc-860d-5330ba05e9be">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/942f8f20-20e1-4e70-9519-42178ea3038a">
