### PR TITLE
fix: video pause conditions

### DIFF
--- a/lib/app/features/video/views/pages/video_page.dart
+++ b/lib/app/features/video/views/pages/video_page.dart
@@ -100,9 +100,7 @@ class VideoPage extends HookConsumerWidget {
 
       if (current == AppLifecycleState.resumed) {
         playerController.play();
-      } else if (current == AppLifecycleState.inactive ||
-          current == AppLifecycleState.paused ||
-          current == AppLifecycleState.hidden) {
+      } else if (current == AppLifecycleState.paused || current == AppLifecycleState.hidden) {
         playerController.pause();
       }
     });


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of this PR and what it accomplishes. -->
- video should not pause when you take a screenshot till it saves before the video continues to play

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
