### PR TITLE
fix: use ellipsis for overflowing display name in messaging header

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -348,13 +348,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -369,13 +365,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/app/features/chat/components/messaging_header/messaging_header.dart
+++ b/lib/app/features/chat/components/messaging_header/messaging_header.dart
@@ -41,39 +41,46 @@ class MessagingHeader extends StatelessWidget {
             ),
           ),
           SizedBox(width: 12.0.s),
-          GestureDetector(
-            onTap: onTap,
-            child: Row(
-              children: [
-                Avatar(
-                  size: 36.0.s,
-                  imageUrl: imageWidget != null ? null : imageUrl,
-                  imageWidget: imageWidget,
-                ),
-                SizedBox(width: 10.0.s),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
+          Expanded(
+            child: GestureDetector(
+              onTap: onTap,
+              child: Row(
+                children: [
+                  Avatar(
+                    size: 36.0.s,
+                    imageUrl: imageWidget != null ? null : imageUrl,
+                    imageWidget: imageWidget,
+                  ),
+                  SizedBox(width: 10.0.s),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          name,
-                          style: context.theme.appTextThemes.subtitle3,
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                name,
+                                style: context.theme.appTextThemes.subtitle3,
+                                overflow: TextOverflow.ellipsis,
+                                maxLines: 1,
+                              ),
+                            ),
+                            if (isVerified) ...[
+                              SizedBox(width: 3.0.s),
+                              Assets.svg.iconBadgeVerify.icon(size: 16.0.s),
+                            ],
+                          ],
                         ),
-                        if (isVerified) ...[
-                          SizedBox(width: 3.0.s),
-                          Assets.svg.iconBadgeVerify.icon(size: 16.0.s),
-                        ],
+                        SizedBox(height: 1.0.s),
+                        subtitle,
                       ],
                     ),
-                    SizedBox(height: 1.0.s),
-                    subtitle,
-                  ],
-                ),
-              ],
+                  ),
+                ],
+              ),
             ),
           ),
-          const Spacer(),
           MessagingContextMenu(
             conversationId: conversationId,
             onToggleMute: onToggleMute,


### PR DESCRIPTION
## Description
This PR addresses the use of ellipsis for shortened display names in the messaging header.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="180" alt="image" src="https://github.com/user-attachments/assets/bb84c454-8eaa-4c7d-b3e4-a684dc0102b1"> 
