### PR TITLE
feat: add canPop parameter to BaseRouteData for customizable pop behavior

### DIFF
--- a/lib/app/router/base_route_data.dart
+++ b/lib/app/router/base_route_data.dart
@@ -28,19 +28,20 @@ abstract class BaseRouteData extends GoRouteData {
     required this.child,
     this.type = IceRouteType.single,
     this.isFullscreenImage = false,
+    this.canPop,
   });
 
   final IceRouteType type;
   final bool isFullscreenImage;
   final Widget child;
-
+  final bool? canPop;
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) {
     return switch (type) {
       IceRouteType.single => CupertinoPage<void>(
           key: state.pageKey,
           child: PopScope(
-            canPop: Platform.isIOS,
+            canPop: canPop ?? Platform.isIOS,
             onPopInvokedWithResult: (didPop, result) async {
               if (!didPop) {
                 context.pop();

--- a/lib/app/router/chat_routes.dart
+++ b/lib/app/router/chat_routes.dart
@@ -54,6 +54,7 @@ class ConversationRoute extends BaseRouteData {
             conversationId: conversationId,
             receiverPubKey: receiverPubKey,
           ),
+          canPop: true,
         );
 
   final String? conversationId;


### PR DESCRIPTION
## Description
This PR introduces a `canPop` parameter to `BaseRouteData`, enabling customizable pop behavior. Users can now swipe left from message pages to access conversation pages on android

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
