### PR TITLE
fix(wallet): disable TON explorer for not Confirmed transactions

### DIFF
--- a/lib/app/features/wallets/providers/network_fee_provider.c.dart
+++ b/lib/app/features/wallets/providers/network_fee_provider.c.dart
@@ -56,7 +56,11 @@ Future<NetworkFeeInformation?> networkFee(
 
   if (nativeCoin == null) {
     Logger.error('Cannot load fees info. nativeCoin is null.');
-    return null;
+    return NetworkFeeInformation(
+      networkNativeToken: networkNativeToken,
+      sendableAsset: sendableAsset,
+      networkFeeOptions: [],
+    );
   }
 
   final networkFeeOptions = _buildNetworkFeeOptions(

--- a/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
+++ b/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
@@ -28,6 +28,8 @@ import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/app/services/share/share.dart';
 import 'package:ion/generated/assets.gen.dart';
 
+const _abbreviationsToExclude = {'TON', 'ION', 'ICE'};
+
 class TransactionDetailsPage extends ConsumerWidget {
   const TransactionDetailsPage({
     required this.exploreRouteLocationBuilder,
@@ -52,6 +54,12 @@ class TransactionDetailsPage extends ConsumerWidget {
     final currentUserAddress = transactionData.type.isSend
         ? transactionData.senderAddress
         : transactionData.receiverAddress;
+
+    final assetAbbreviation =
+        transactionData.assetData.mapOrNull(coin: (value) => value.coinsGroup)?.abbreviation;
+
+    final disableExplorer = _abbreviationsToExclude.contains(assetAbbreviation) &&
+        transactionData.status != TransactionStatus.confirmed;
 
     return SheetContent(
       body: Column(
@@ -177,6 +185,7 @@ class TransactionDetailsPage extends ConsumerWidget {
                             SizedBox(height: 15.0.s),
                           ],
                           TransactionDetailsActions(
+                            disableExplorer: disableExplorer,
                             onViewOnExplorer: () {
                               final url = transactionData.transactionExplorerUrl;
                               final location = exploreRouteLocationBuilder(url);

--- a/lib/app/features/wallets/views/pages/transaction_details/transaction_details_actions.dart
+++ b/lib/app/features/wallets/views/pages/transaction_details/transaction_details_actions.dart
@@ -9,11 +9,13 @@ class TransactionDetailsActions extends StatelessWidget {
   const TransactionDetailsActions({
     required this.onViewOnExplorer,
     required this.onShare,
+    this.disableExplorer = false,
     super.key,
   });
 
   final VoidCallback onViewOnExplorer;
   final VoidCallback onShare;
+  final bool disableExplorer;
 
   @override
   Widget build(BuildContext context) {
@@ -21,15 +23,18 @@ class TransactionDetailsActions extends StatelessWidget {
       children: [
         Expanded(
           child: Button(
-            type: ButtonType.outlined,
+            type: disableExplorer ? ButtonType.disabled : ButtonType.outlined,
+            disabled: disableExplorer,
             label: Text(
               context.i18n.transaction_details_view_on_explorer,
             ),
             mainAxisSize: MainAxisSize.max,
-            leadingIcon: Assets.svg.iconButtonInternet.icon(),
+            leadingIcon: Assets.svg.iconButtonInternet.icon(
+              color: disableExplorer ? context.theme.appColors.onPrimaryAccent : null,
+            ),
             onPressed: onViewOnExplorer,
-            backgroundColor: context.theme.appColors.tertararyBackground,
-            borderColor: context.theme.appColors.onTerararyFill,
+            backgroundColor: disableExplorer ? null : context.theme.appColors.tertararyBackground,
+            borderColor: disableExplorer ? null : context.theme.appColors.onTerararyFill,
           ),
         ),
         SizedBox(


### PR DESCRIPTION
## Description
This PR disables "View on explorer" button in Transaction Details dialog for non-confirmed TON transactions.
Also it fixes a situation when we stuck in the "in progress" state during sending coins.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots
<img width="180" alt="image" src="https://github.com/user-attachments/assets/82820e32-eb4f-4a37-b4c4-d852ece00846">
