### PR TITLE
feat: change time precision for event messages from seconds to microseconds

### DIFF
--- a/lib/app/features/core/model/paged.c.dart
+++ b/lib/app/features/core/model/paged.c.dart
@@ -13,8 +13,8 @@ class PaginationParams with _$PaginationParams {
 
   PaginationParams._();
 
-  // Adding 2 seconds because otherwise events might be unintentionally skipped
-  DateTime? get until => lastEventTime?.add(const Duration(seconds: 2));
+  // Adding 2 microseconds because otherwise events might be unintentionally skipped
+  DateTime? get until => lastEventTime?.add(const Duration(microseconds: 2));
 }
 
 @freezed

--- a/lib/app/features/feed/notifications/providers/notification_followers_subscription_provider.c.dart
+++ b/lib/app/features/feed/notifications/providers/notification_followers_subscription_provider.c.dart
@@ -37,7 +37,7 @@ Future<void> notificationFollowersSubscription(Ref ref) async {
         ),
       ],
     ).toString(),
-    since: DateTime.now().subtract(const Duration(seconds: 2)),
+    since: DateTime.now().subtract(const Duration(microseconds: 2)),
   );
 
   bool isCurrentUserLastAdded(IonConnectEntity entity) =>

--- a/lib/app/features/feed/notifications/providers/notification_likes_subscription_provider.c.dart
+++ b/lib/app/features/feed/notifications/providers/notification_likes_subscription_provider.c.dart
@@ -28,7 +28,7 @@ Future<void> notificationLikesSubscription(Ref ref) async {
     tags: {
       '#p': [currentPubkey],
     },
-    since: DateTime.now().subtract(const Duration(seconds: 2)),
+    since: DateTime.now().subtract(const Duration(microseconds: 2)),
   );
 
   await ref.watch(entitiesSyncerNotifierProvider('notifications-likes').notifier).syncEntities(

--- a/lib/app/features/feed/notifications/providers/notification_quotes_subscription_provider.c.dart
+++ b/lib/app/features/feed/notifications/providers/notification_quotes_subscription_provider.c.dart
@@ -29,7 +29,7 @@ Future<void> notificationQuotesSubscription(Ref ref) async {
         [null, null, currentPubkey],
       ],
     },
-    since: DateTime.now().subtract(const Duration(seconds: 2)),
+    since: DateTime.now().subtract(const Duration(microseconds: 2)),
   );
 
   await ref.watch(entitiesSyncerNotifierProvider('notifications-quotes').notifier).syncEntities(

--- a/lib/app/features/feed/notifications/providers/notification_replies_subscription_provider.c.dart
+++ b/lib/app/features/feed/notifications/providers/notification_replies_subscription_provider.c.dart
@@ -37,7 +37,7 @@ Future<void> notificationRepliesSubscription(Ref ref) async {
         marker: RelatedEventMarker.reply.toShortString(),
       ),
     ]).toString(),
-    since: DateTime.now().subtract(const Duration(seconds: 2)),
+    since: DateTime.now().subtract(const Duration(microseconds: 2)),
   );
 
   await ref.watch(entitiesSyncerNotifierProvider('notifications-replies').notifier).syncEntities(

--- a/lib/app/features/feed/notifications/providers/notification_reposts_subscription_provider.c.dart
+++ b/lib/app/features/feed/notifications/providers/notification_reposts_subscription_provider.c.dart
@@ -30,7 +30,7 @@ Future<void> notificationRepostsSubscription(Ref ref) async {
       '#p': [currentPubkey],
       '#k': [ModifiablePostEntity.kind.toString(), ArticleEntity.kind.toString()],
     },
-    since: DateTime.now().subtract(const Duration(seconds: 2)),
+    since: DateTime.now().subtract(const Duration(microseconds: 2)),
   );
 
   await ref.watch(entitiesSyncerNotifierProvider('notifications-reposts').notifier).syncEntities(

--- a/lib/app/features/ion_connect/providers/entities_syncer_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/entities_syncer_notifier.c.dart
@@ -26,7 +26,7 @@ class EntitiesSyncerNotifier extends _$EntitiesSyncerNotifier {
     required Future<DateTime?> Function(DateTime? since) minCreatedAtBuilder,
     ActionSource actionSource = const ActionSourceCurrentUser(),
     int limit = 100,
-    Duration overlap = const Duration(seconds: 2),
+    Duration overlap = const Duration(microseconds: 2),
   }) async {
     await _completePreviousSync(
       requestFilters: requestFilters,
@@ -73,7 +73,7 @@ class EntitiesSyncerNotifier extends _$EntitiesSyncerNotifier {
     required Future<DateTime?> Function(DateTime? since) minCreatedAtBuilder,
     ActionSource actionSource = const ActionSourceCurrentUser(),
     int limit = 100,
-    Duration overlap = const Duration(seconds: 2),
+    Duration overlap = const Duration(microseconds: 2),
   }) async {
     await _completePreviousSync(
       requestFilters: requestFilters,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,7 +109,7 @@ dependencies:
   nostr_dart:
     git:
       url: https://github.com/ice-blockchain/nostr-dart
-      ref: 0.0.34
+      ref: 0.0.35
   ogp_data_extract: ^0.1.4
   package_info_plus: ^8.3.0
   palette_generator: ^0.3.3+5


### PR DESCRIPTION

## Description
This PR changes the time overlap we use for some requests from 2 seconds to 2 microsends, because time precision inside nostr-dart library was changed from seconds to microseconds.

## Additional Notes
Related PR: [Link](https://github.com/ice-blockchain/nostr-dart/pull/12)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
