### PR TITLE
fix(chat): enable dismiss gesture for fullscreen preview image

### DIFF
--- a/lib/app/router/chat_routes.dart
+++ b/lib/app/router/chat_routes.dart
@@ -369,6 +369,7 @@ class ChatMediaRoute extends BaseRouteData {
             initialIndex: initialIndex,
           ),
           type: IceRouteType.swipeDismissible,
+          isFullscreenImage: true,
         );
 
   final String eventReference;


### PR DESCRIPTION
## Description
This PR addresses the chat feature by enabling a dismiss gesture for full-screen preview images.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

