### PR TITLE
fix: correct mute/unmute icon logic in chat media page

### DIFF
--- a/lib/app/features/chat/views/pages/chat_media_page/chat_media_page.dart
+++ b/lib/app/features/chat/views/pages/chat_media_page/chat_media_page.dart
@@ -215,11 +215,11 @@ class _MediaBottomOverlay extends ConsumerWidget {
                     await ref.read(globalMuteNotifierProvider.notifier).toggle();
                   },
                   child: isMuted
-                      ? Assets.svg.iconChannelUnmute.icon(
+                      ? Assets.svg.iconChannelMute.icon(
                           size: 24.0.s,
                           color: context.theme.appColors.onPrimaryAccent,
                         )
-                      : Assets.svg.iconChannelMute.icon(
+                      : Assets.svg.iconChannelUnmute.icon(
                           size: 24.0.s,
                           color: context.theme.appColors.onPrimaryAccent,
                         ),


### PR DESCRIPTION
## Description
This PR addresses the logic for the mute/unmute icons on the chat media page.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
