### PR TITLE
fix: video edit button navigation

### DIFF
--- a/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
@@ -113,14 +113,14 @@ class MainActivity : FlutterFragmentActivity() {
                         checkSdkLicenseVideoEditor(
                             callback = { isValid ->
                                 if (isValid) {
+                                    // ✅ The license is active
                                     startVideoEditorModeTrimmer(trimmerVideoUri)
                                 } else {
+                                    // ❌ Use of SDK is restricted: the license is revoked or expired
                                     result.error(ERR_CODE_SDK_LICENSE_REVOKED, "", null)
                                 }
                             },
-                            onError = { 
-                                result.error(ERR_CODE_SDK_NOT_INITIALIZED, "", null) 
-                            }
+                            onError = { result.error(ERR_CODE_SDK_NOT_INITIALIZED, "", null) }
                         )
                     }
                 }
@@ -270,7 +270,6 @@ class MainActivity : FlutterFragmentActivity() {
                 return null
             }
             
-            // Use internal files directory for safe storage
             val editingFileName = "editing_${System.currentTimeMillis()}.mp4"
             val editingFile = File(filesDir, editingFileName)
             
@@ -278,10 +277,7 @@ class MainActivity : FlutterFragmentActivity() {
                 editingFile.delete()
             }
             
-            // Copy original to safe location
             originalFile.copyTo(editingFile, overwrite = true)
-            
-            // Track this file for cleanup
             currentEditingFile = editingFile
             return Uri.fromFile(editingFile)
         } catch (e: Exception) {

--- a/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : FlutterFragmentActivity() {
 
     private var exportResult: MethodChannel.Result? = null
     
-    // Track current editing file for cleanup (Android: Manual cleanup required)
+    // Track current editing file for cleanup
     private var currentEditingFile: File? = null
 
     private var videoEditorSDK: BanubaVideoEditor? = null
@@ -198,12 +198,9 @@ class MainActivity : FlutterFragmentActivity() {
                     this.exportResult?.success(data)
                 }
                 
-                // Clean up temporary editing file
                 cleanupCurrentEditingFile()
             } else if (result == RESULT_CANCELED) {
-                // Clean up temporary editing file
                 cleanupCurrentEditingFile()
-                
                 // User cancelled video editing - return null to indicate cancellation
                 this.exportResult?.success(null)
             }
@@ -254,7 +251,7 @@ class MainActivity : FlutterFragmentActivity() {
                 additionalExportData = null,
                 // set TrackData object if you open VideoCreationActivity with preselected music track
                 audioTrackData = null,
-                // set Trimmer video configuration with safe copy
+                // set Trimmer video configuration
                 predefinedVideos = arrayOf(finalUri),
                 extras = extras
             ), VIDEO_EDITOR_REQUEST_CODE
@@ -277,7 +274,6 @@ class MainActivity : FlutterFragmentActivity() {
             val editingFileName = "editing_${System.currentTimeMillis()}.mp4"
             val editingFile = File(filesDir, editingFileName)
             
-            // Remove existing file if it exists
             if (editingFile.exists()) {
                 editingFile.delete()
             }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -200,7 +200,6 @@ class AudioFocusHandler: NSObject {
                                     )
                 case AppDelegate.methodStartVideoEditorTrimmer:
                                     let trimmerVideoFilePath = methodCall.arguments as? String
-
                                     if let videoFilePath = trimmerVideoFilePath {
                                         videoEditor.openVideoEditorTrimmer(
                                             fromViewController: controller,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -163,7 +163,6 @@ class AudioFocusHandler: NSObject {
 
             channel.setMethodCallHandler { methodCall, result in
                 let call = methodCall.method
-                print("[EDIT_VIDEO] 🔍 iOS AppDelegate received method call: \(call)")
                 switch call {
                 case AppDelegate.methodInitPhotoEditor:
                     guard let token = methodCall.arguments as? String else {
@@ -200,23 +199,20 @@ class AudioFocusHandler: NSObject {
                                         flutterResult: result
                                     )
                 case AppDelegate.methodStartVideoEditorTrimmer:
-                                    print("[EDIT_VIDEO] 📱 iOS received methodStartVideoEditorTrimmer call")
                                     let trimmerVideoFilePath = methodCall.arguments as? String
-                                    print("[EDIT_VIDEO] 📱 Trimmer video file path: \(String(describing: trimmerVideoFilePath))")
-                                    
+
                                     if let videoFilePath = trimmerVideoFilePath {
-                                        print("[EDIT_VIDEO] 📱 About to call openVideoEditorTrimmer with path: \(videoFilePath)")
                                         videoEditor.openVideoEditorTrimmer(
                                             fromViewController: controller,
                                             videoURL: URL(fileURLWithPath: videoFilePath),
                                             flutterResult: result
                                         )
                                     } else {
-                                        print("[EDIT_VIDEO] ❌ Cannot start video editor in trimmer mode: missing or invalid video!")
+                                        print("Cannot start video editor in trimmer mode: missing or invalid video!")
                                         result(FlutterError(code: "ERR_START_TRIMMER_MISSING_VIDEO", message: "", details: nil))
                                     }
                 default:
-                    print("[EDIT_VIDEO] ❌ Unknown Flutter method called: \(methodCall.method)")
+                    print("Flutter method is not implemented on platform.")
                     result(FlutterMethodNotImplemented)
                 }
             }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -163,6 +163,7 @@ class AudioFocusHandler: NSObject {
 
             channel.setMethodCallHandler { methodCall, result in
                 let call = methodCall.method
+                print("[EDIT_VIDEO] 🔍 iOS AppDelegate received method call: \(call)")
                 switch call {
                 case AppDelegate.methodInitPhotoEditor:
                     guard let token = methodCall.arguments as? String else {
@@ -199,20 +200,23 @@ class AudioFocusHandler: NSObject {
                                         flutterResult: result
                                     )
                 case AppDelegate.methodStartVideoEditorTrimmer:
+                                    print("[EDIT_VIDEO] 📱 iOS received methodStartVideoEditorTrimmer call")
                                     let trimmerVideoFilePath = methodCall.arguments as? String
+                                    print("[EDIT_VIDEO] 📱 Trimmer video file path: \(String(describing: trimmerVideoFilePath))")
                                     
                                     if let videoFilePath = trimmerVideoFilePath {
+                                        print("[EDIT_VIDEO] 📱 About to call openVideoEditorTrimmer with path: \(videoFilePath)")
                                         videoEditor.openVideoEditorTrimmer(
                                             fromViewController: controller,
                                             videoURL: URL(fileURLWithPath: videoFilePath),
                                             flutterResult: result
                                         )
                                     } else {
-                                        print("Cannot start video editor in trimmer mode: missing or invalid video!")
+                                        print("[EDIT_VIDEO] ❌ Cannot start video editor in trimmer mode: missing or invalid video!")
                                         result(FlutterError(code: "ERR_START_TRIMMER_MISSING_VIDEO", message: "", details: nil))
                                     }
                 default:
-                    print("Flutter method is not implemented on platform.")
+                    print("[EDIT_VIDEO] ❌ Unknown Flutter method called: \(methodCall.method)")
                     result(FlutterMethodNotImplemented)
                 }
             }

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_content.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_content.dart
@@ -78,7 +78,9 @@ class _VideoPreviewSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ScreenSideOffset.small(
-      child: VideoPreviewCover(attachedVideoNotifier: attachedVideoNotifier),
+      child: VideoPreviewCover(
+        attachedVideoNotifier: attachedVideoNotifier,
+      ),
     );
   }
 }

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_content.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_content.dart
@@ -78,9 +78,7 @@ class _VideoPreviewSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ScreenSideOffset.small(
-      child: VideoPreviewCover(
-        attachedVideoNotifier: attachedVideoNotifier,
-      ),
+      child: VideoPreviewCover(attachedVideoNotifier: attachedVideoNotifier),
     );
   }
 }

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
@@ -44,7 +44,12 @@ class VideoPreviewCover extends HookConsumerWidget {
         .watch(
           videoControllerProvider(
             // local video - no need to pass authorPubkey for ion connect fallback
-            VideoControllerParams(sourcePath: filePath, looping: true),
+            VideoControllerParams(
+              sourcePath: filePath,
+              looping: true,
+              // Use name field which contains timestamp to force controller recreation
+              uniqueId: attachedVideo.name ?? '',
+            ),
           ),
         )
         .value;
@@ -108,7 +113,9 @@ class VideoPreviewCover extends HookConsumerWidget {
                   PositionedDirectional(
                     end: 12.0.s,
                     bottom: 12.0.s,
-                    child: VideoPreviewEditCover(attachedVideoNotifier: attachedVideoNotifier),
+                    child: VideoPreviewEditCover(
+                      attachedVideoNotifier: attachedVideoNotifier,
+                    ),
                   ),
                   PositionedDirectional(
                     start: 12.0.s,

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_cover.dart
@@ -47,7 +47,6 @@ class VideoPreviewCover extends HookConsumerWidget {
             VideoControllerParams(
               sourcePath: filePath,
               looping: true,
-              // Use name field which contains timestamp to force controller recreation
               uniqueId: attachedVideo.name ?? '',
             ),
           ),
@@ -113,9 +112,7 @@ class VideoPreviewCover extends HookConsumerWidget {
                   PositionedDirectional(
                     end: 12.0.s,
                     bottom: 12.0.s,
-                    child: VideoPreviewEditCover(
-                      attachedVideoNotifier: attachedVideoNotifier,
-                    ),
+                    child: VideoPreviewEditCover(attachedVideoNotifier: attachedVideoNotifier),
                   ),
                   PositionedDirectional(
                     start: 12.0.s,

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
@@ -39,7 +39,7 @@ class VideoPreviewEditCover extends ConsumerWidget {
             // User cancelled editing - do nothing
           } else {
             Logger.log(
-              '[EDIT_VIDEO] Failed to edit video',
+              'Failed to edit video',
               error: e,
               stackTrace: stackTrace,
             );

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
@@ -24,11 +24,14 @@ class VideoPreviewEditCover extends ConsumerWidget {
 
         try {
           final editedPath = await ref.read(editMediaProvider(attachedVideo).future);
-          final timestamp = DateTime.now().millisecondsSinceEpoch;
-          attachedVideoNotifier.value = attachedVideo.copyWith(
-            path: editedPath,
-            name: 'edited_$timestamp',
-          );
+
+          if (editedPath != attachedVideo.path) {
+            final timestamp = DateTime.now().millisecondsSinceEpoch;
+            attachedVideoNotifier.value = attachedVideo.copyWith(
+              path: editedPath,
+              name: 'edited_$timestamp',
+            );
+          }
         } catch (e, stackTrace) {
           Logger.log(
             'Video editing failed or cancelled',

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/services/logger/logger.dart';
@@ -26,7 +25,7 @@ class VideoPreviewEditCover extends ConsumerWidget {
         try {
           // Launch video editor for the attached video
           final editedPath = await ref.read(editMediaProvider(attachedVideo).future);
-          
+
           // If we reached here, Banuba returned successfully
           // Always update the video to ensure the controller reloads
           final timestamp = DateTime.now().millisecondsSinceEpoch;
@@ -35,15 +34,11 @@ class VideoPreviewEditCover extends ConsumerWidget {
             name: 'edited_$timestamp',
           );
         } catch (e, stackTrace) {
-          if (e is PlatformException && e.code == 'USER_CANCELLED') {
-            // User cancelled editing - do nothing
-          } else {
-            Logger.log(
-              'Failed to edit video',
-              error: e,
-              stackTrace: stackTrace,
-            );
-          }
+          Logger.log(
+            'Video editing failed or cancelled',
+            error: e,
+            stackTrace: stackTrace,
+          );
         }
       },
       child: DecoratedBox(

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
@@ -23,11 +23,7 @@ class VideoPreviewEditCover extends ConsumerWidget {
         if (attachedVideo == null) return;
 
         try {
-          // Launch video editor for the attached video
           final editedPath = await ref.read(editMediaProvider(attachedVideo).future);
-
-          // If we reached here, Banuba returned successfully
-          // Always update the video to ensure the controller reloads
           final timestamp = DateTime.now().millisecondsSinceEpoch;
           attachedVideoNotifier.value = attachedVideo.copyWith(
             path: editedPath,

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -40,21 +40,15 @@ class BanubaService {
   }
 
   Future<String> editPhoto(String filePath) async {
-    Logger.log('[EDIT_PHOTO] editPhoto called with filePath: $filePath');
-    
     try {
       await _initPhotoEditor();
 
-      Logger.log('[EDIT_PHOTO] Calling methodStartPhotoEditor...');
       final dynamic result = await platformChannel.invokeMethod(
         methodStartPhotoEditor,
         {'imagePath': filePath},
       );
 
-      Logger.log('[EDIT_PHOTO] Result from methodStartPhotoEditor: $result');
-
       if (result == null) {
-        Logger.log('[EDIT_PHOTO] User cancelled editing');
         throw PlatformException(
           code: 'USER_CANCELLED',
           message: 'User cancelled photo editing',
@@ -65,24 +59,19 @@ class BanubaService {
         final exportedPhotoFilePath = result[argExportedPhotoFile];
 
         if (exportedPhotoFilePath == null) {
-          Logger.log('[EDIT_PHOTO] No exported file, returning original path');
           return filePath;
         }
 
         if (Platform.isAndroid) {
           final file = await toFile(exportedPhotoFilePath as String);
-          Logger.log('[EDIT_PHOTO] Exported photo file path (Android): ${file.path}');
           return file.path;
         }
 
-        Logger.log('[EDIT_PHOTO] Exported photo file path: $exportedPhotoFilePath');
         return exportedPhotoFilePath as String;
       }
       
-      Logger.log('[EDIT_PHOTO] Unexpected result type, returning original path');
       return filePath;
     } on PlatformException catch (e) {
-      Logger.log('[EDIT_PHOTO] Platform exception during photo editing', error: e);
       rethrow;
     }
   }
@@ -94,16 +83,12 @@ class BanubaService {
         env.get<String>(EnvVariable.BANUBA_TOKEN),
       );
 
-      Logger.log('[EDIT_VIDEO] Calling methodStartVideoEditorTrimmer...');
       final result = await platformChannel.invokeMethod(
         methodStartVideoEditorTrimmer,
         filePath,
       );
-
-      Logger.log('[EDIT_VIDEO] Result from methodStartVideoEditorTrimmer: $result');
       
       if (result == null) {
-        Logger.log('[EDIT_VIDEO] User cancelled editing');
         throw PlatformException(
           code: 'USER_CANCELLED',
           message: 'User cancelled video editing',
@@ -113,18 +98,14 @@ class BanubaService {
       if (result is Map) {
         final exportedVideoFilePath = result[argExportedVideoFile];
         if (exportedVideoFilePath != null) {
-          Logger.log('[EDIT_VIDEO] Exported video file path: $exportedVideoFilePath');
           return exportedVideoFilePath as String;
         }
       }
       
-      Logger.log('[EDIT_VIDEO] No exported file, returning original path');
       return filePath;
     } on PlatformException catch (e) {
-      Logger.log('[EDIT_VIDEO] Platform exception during video editing', error: e);
       rethrow;
     } catch (e) {
-      Logger.log('[EDIT_VIDEO] Unexpected error during video editing', error: e);
       return filePath;
     }
   }
@@ -137,9 +118,6 @@ BanubaService banubaService(Ref ref) {
 
 @riverpod
 Future<String> editMedia(Ref ref, MediaFile mediaFile) async {
-  Logger.log('[EDIT_VIDEO] editMedia called with mediaFile.path: ${mediaFile.path}');
-  Logger.log('[EDIT_VIDEO] mediaFile.mimeType: ${mediaFile.mimeType}');
-  
   // Check if the path is already a file path or an asset ID
   String? filePath;
   
@@ -148,18 +126,15 @@ Future<String> editMedia(Ref ref, MediaFile mediaFile) async {
   final isAbsolutePath = mediaFile.path.startsWith('/') || File(mediaFile.path).existsSync();
   
   if (isAbsolutePath) {
-    Logger.log('[EDIT_VIDEO] Path is already a file path, using directly: ${mediaFile.path}');
     filePath = mediaFile.path;
   } else {
     // Otherwise, treat it as an asset ID and get the file path
-    Logger.log('[EDIT_VIDEO] Path appears to be an asset ID, fetching file path...');
     filePath = await ref.read(assetFilePathProvider(mediaFile.path).future);
-    Logger.log('[EDIT_VIDEO] Fetched file path from asset ID: $filePath');
   }
 
   if (filePath == null) {
     Logger.log(
-      '[EDIT_VIDEO] File path or mime type is null',
+      'File path or mime type is null',
       error: mediaFile,
       stackTrace: StackTrace.current,
     );

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -10,6 +10,7 @@ import 'package:ion/app/features/core/providers/env_provider.c.dart';
 import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
 import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
+import 'package:path/path.dart' as path;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uri_to_file/uri_to_file.dart';
 
@@ -100,9 +101,8 @@ BanubaService banubaService(Ref ref) {
 @riverpod
 Future<String> editMedia(Ref ref, MediaFile mediaFile) async {
   String? filePath;
-  final isAbsolutePath = mediaFile.path.startsWith('/') || File(mediaFile.path).existsSync();
 
-  if (isAbsolutePath) {
+  if (path.isAbsolute(mediaFile.path)) {
     filePath = mediaFile.path;
   } else {
     filePath = await ref.read(assetFilePathProvider(mediaFile.path).future);

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -49,10 +49,7 @@ class BanubaService {
       );
 
       if (result == null) {
-        throw PlatformException(
-          code: 'USER_CANCELLED',
-          message: 'User cancelled photo editing',
-        );
+        return filePath;
       }
 
       if (result is Map) {
@@ -69,9 +66,9 @@ class BanubaService {
 
         return exportedPhotoFilePath as String;
       }
-      
+
       return filePath;
-    } on PlatformException catch (e) {
+    } on PlatformException {
       rethrow;
     }
   }
@@ -87,24 +84,19 @@ class BanubaService {
         methodStartVideoEditorTrimmer,
         filePath,
       );
-      
+
       if (result == null) {
-        throw PlatformException(
-          code: 'USER_CANCELLED',
-          message: 'User cancelled video editing',
-        );
+        return filePath;
       }
-      
+
       if (result is Map) {
         final exportedVideoFilePath = result[argExportedVideoFile];
         if (exportedVideoFilePath != null) {
           return exportedVideoFilePath as String;
         }
       }
-      
+
       return filePath;
-    } on PlatformException catch (e) {
-      rethrow;
     } catch (e) {
       return filePath;
     }
@@ -120,11 +112,11 @@ BanubaService banubaService(Ref ref) {
 Future<String> editMedia(Ref ref, MediaFile mediaFile) async {
   // Check if the path is already a file path or an asset ID
   String? filePath;
-  
+
   // Check if it's an absolute file path (starts with '/' for both iOS and Android)
   // or if the file exists at the given path
   final isAbsolutePath = mediaFile.path.startsWith('/') || File(mediaFile.path).existsSync();
-  
+
   if (isAbsolutePath) {
     filePath = mediaFile.path;
   } else {

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -48,10 +48,6 @@ class BanubaService {
         {'imagePath': filePath},
       );
 
-      if (result == null) {
-        return filePath;
-      }
-
       if (result is Map) {
         final exportedPhotoFilePath = result[argExportedPhotoFile];
 
@@ -78,32 +74,21 @@ class BanubaService {
   }
 
   Future<String> editVideo(String filePath) async {
-    try {
-      await platformChannel.invokeMethod(
-        methodInitVideoEditor,
-        env.get<String>(EnvVariable.BANUBA_TOKEN),
-      );
+    await platformChannel.invokeMethod(
+      methodInitVideoEditor,
+      env.get<String>(EnvVariable.BANUBA_TOKEN),
+    );
 
-      final result = await platformChannel.invokeMethod(
-        methodStartVideoEditorTrimmer,
-        filePath,
-      );
+    final result = await platformChannel.invokeMethod(
+      methodStartVideoEditorTrimmer,
+      filePath,
+    );
 
-      if (result == null) {
-        return filePath;
-      }
-
-      if (result is Map) {
-        final exportedVideoFilePath = result[argExportedVideoFile];
-        if (exportedVideoFilePath != null) {
-          return exportedVideoFilePath as String;
-        }
-      }
-
-      return filePath;
-    } catch (e) {
-      return filePath;
+    if (result is Map) {
+      final exportedVideoFilePath = result[argExportedVideoFile];
+      return exportedVideoFilePath as String;
     }
+    return filePath;
   }
 }
 
@@ -114,17 +99,12 @@ BanubaService banubaService(Ref ref) {
 
 @riverpod
 Future<String> editMedia(Ref ref, MediaFile mediaFile) async {
-  // Check if the path is already a file path or an asset ID
   String? filePath;
-
-  // Check if it's an absolute file path (starts with '/' for both iOS and Android)
-  // or if the file exists at the given path
   final isAbsolutePath = mediaFile.path.startsWith('/') || File(mediaFile.path).existsSync();
 
   if (isAbsolutePath) {
     filePath = mediaFile.path;
   } else {
-    // Otherwise, treat it as an asset ID and get the file path
     filePath = await ref.read(assetFilePathProvider(mediaFile.path).future);
   }
 

--- a/lib/app/services/media_service/banuba_service.c.dart
+++ b/lib/app/services/media_service/banuba_service.c.dart
@@ -66,9 +66,13 @@ class BanubaService {
 
         return exportedPhotoFilePath as String;
       }
-
       return filePath;
-    } on PlatformException {
+    } on PlatformException catch (e) {
+      Logger.log(
+        'Start Photo Editor error',
+        error: e,
+        stackTrace: StackTrace.current,
+      );
       rethrow;
     }
   }


### PR DESCRIPTION
## Description
This PR fixes a bug where clicking the "edit" button on a video preview would redirect back to FeedMainModalPage instead of opening the video editor. The issue was caused by improper file handling on both iOS and Android, where temporary video files were being deleted during the editing process.

  Root Cause:

  - iOS: Banuba SDK was automatically cleaning up files from /tmp/ directory during the editing workflow
  - Android: Banuba SDK was deleting original video files during the editing workflow
  - Both platforms attempted to re-edit non-existent files, causing UI failures

  Solution:

 - Created copies of video files in persistent storage (Documents directory on iOS, internal files directory on Android)
 - Replaced context.pop() with proper editMediaProvider call to launch the Banuba video editor
 - iOS: Added automatic cleanup handling by Banuba
 - Android: Added manual cleanup with `cleanupCurrentEditingFile()` method 

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
