### PR TITLE
fix: cache file storage URL to prevent multiple NIP96 requests

### DIFF
--- a/lib/app/extensions/riverpod.dart
+++ b/lib/app/extensions/riverpod.dart
@@ -99,3 +99,11 @@ extension ListenResultExtension on WidgetRef {
     }
   }
 }
+
+extension CacheForExtension on Ref {
+  void cacheFor(Duration duration) {
+    final link = keepAlive();
+    final timer = Timer(duration, link.close);
+    onDispose(timer.cancel);
+  }
+}

--- a/lib/app/features/ion_connect/providers/file_storage_url_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/file_storage_url_provider.c.dart
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/ion_connect/utils/file_storage_utils.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'file_storage_url_provider.c.g.dart';
+
+@riverpod
+Future<String> fileStorageUrl(Ref ref) async {
+  final cancelToken = CancelToken();
+
+  ref
+    ..onDispose(cancelToken.cancel)
+    ..cacheFor(const Duration(minutes: 5));
+
+  final url = await getFileStorageApiUrl(ref, cancelToken: cancelToken);
+  return url;
+}

--- a/lib/app/features/ion_connect/providers/ion_connect_delete_file_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_delete_file_notifier.c.dart
@@ -7,6 +7,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/core/providers/dio_provider.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/ion_connect/providers/file_storage_url_provider.c.dart';
 import 'package:ion/app/features/ion_connect/utils/file_storage_utils.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -33,7 +34,7 @@ class IonConnectDeleteFileNotifier extends _$IonConnectDeleteFileNotifier {
       return;
     }
 
-    final storageUrl = await getFileStorageApiUrl(ref);
+    final storageUrl = await ref.read(fileStorageUrlProvider.future);
 
     await Future.wait(
       fileHashes.map(

--- a/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_upload_notifier.c.dart
@@ -13,6 +13,7 @@ import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/file_alt.dart';
 import 'package:ion/app/features/ion_connect/model/file_metadata.c.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
+import 'package:ion/app/features/ion_connect/providers/file_storage_url_provider.c.dart';
 import 'package:ion/app/features/ion_connect/utils/file_storage_utils.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -38,7 +39,7 @@ class IonConnectUploadNotifier extends _$IonConnectUploadNotifier {
 
     final dimension = '${file.width}x${file.height}';
 
-    final url = await getFileStorageApiUrl(ref);
+    final url = await ref.read(fileStorageUrlProvider.future);
 
     final fileBytes = await File(file.path).readAsBytes();
 

--- a/lib/app/features/ion_connect/utils/file_storage_utils.dart
+++ b/lib/app/features/ion_connect/utils/file_storage_utils.dart
@@ -2,6 +2,7 @@
 
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
@@ -33,7 +34,10 @@ Future<String> generateAuthorizationToken({
 }
 
 // TODO: handle delegatedToUrl when migrating to common relays
-Future<String> getFileStorageApiUrl(Ref ref) async {
+Future<String> getFileStorageApiUrl(
+  Ref ref, {
+  CancelToken? cancelToken,
+}) async {
   final userRelays = await ref.read(currentUserRelaysProvider.future);
   if (userRelays == null) {
     throw UserRelaysNotFoundException();
@@ -49,7 +53,10 @@ Future<String> getFileStorageApiUrl(Ref ref) async {
       path: FileStorageMetadata.path,
     );
 
-    final response = await ref.read(dioProvider).getUri<dynamic>(metadataUri);
+    final response = await ref.read(dioProvider).getUri<dynamic>(
+          metadataUri,
+          cancelToken: cancelToken,
+        );
     final path = FileStorageMetadata.fromJson(
       json.decode(response.data as String) as Map<String, dynamic>,
     ).apiUrl;


### PR DESCRIPTION
 ## Description
 This PR fixes a performance issue where multiple requests were made to the NIP96 endpoint when uploading multiple media files. Previously, each file upload triggered a separate request to fetch the storage URL, causing unnecessary network overhead.

The fix introduces a cached provider (`fileStorageUrlProvider`) that fetches the URL once and reuses it for all subsequent uploads within a 5-minute window.

 ## Additional Notes
  - The provider includes proper cleanup with `CancelToken` to cancel in-flight requests when disposed


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
