### PR TITLE
fix: replace userMetadataProvider with cached version in chat user search list

### DIFF
--- a/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
+++ b/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
@@ -26,54 +26,47 @@ class ChatSearchResultListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userMetadata = ref.watch(userMetadataProvider(pubkeyAndContent.$1));
+    final userMetadata = ref.watch(cachedUserMetadataProvider(pubkeyAndContent.$1));
 
     return Padding(
       padding: EdgeInsets.symmetric(vertical: 8.0.s),
       child: ScreenSideOffset.small(
-        child: userMetadata.maybeWhen(
-          data: (userMetadata) {
-            if (userMetadata == null) {
-              return const SizedBox.shrink();
-            }
-
-            return GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () {
-                ref
-                    .read(chatSearchHistoryProvider.notifier)
-                    .addUserIdToTheHistory(userMetadata.masterPubkey);
-                context.pushReplacement(
-                  ConversationRoute(receiverPubKey: pubkeyAndContent.$1).location,
-                );
-              },
-              child: Row(
-                children: [
-                  Expanded(
-                    child: BadgesUserListItem(
-                      pubkey: userMetadata.masterPubkey,
-                      title: Text(userMetadata.data.displayName),
-                      subtitle: pubkeyAndContent.$2.isNotEmpty && showLastMessage
-                          ? Text(
-                              pubkeyAndContent.$2,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            )
-                          : Text(
-                              prefixUsername(username: userMetadata.data.name, context: context),
-                            ),
+        child: userMetadata == null
+            ? const Skeleton(child: ChatSearchListItemShape())
+            : GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  ref
+                      .read(chatSearchHistoryProvider.notifier)
+                      .addUserIdToTheHistory(userMetadata.masterPubkey);
+                  context.pushReplacement(
+                    ConversationRoute(receiverPubKey: pubkeyAndContent.$1).location,
+                  );
+                },
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: BadgesUserListItem(
+                        pubkey: userMetadata.masterPubkey,
+                        title: Text(userMetadata.data.displayName),
+                        subtitle: pubkeyAndContent.$2.isNotEmpty && showLastMessage
+                            ? Text(
+                                pubkeyAndContent.$2,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              )
+                            : Text(
+                                prefixUsername(username: userMetadata.data.name, context: context),
+                              ),
+                      ),
                     ),
-                  ),
-                  Assets.svg.iconArrowRight.icon(
-                    size: 24.0.s,
-                    color: context.theme.appColors.tertararyText,
-                  ),
-                ],
+                    Assets.svg.iconArrowRight.icon(
+                      size: 24.0.s,
+                      color: context.theme.appColors.tertararyText,
+                    ),
+                  ],
+                ),
               ),
-            );
-          },
-          orElse: () => const Skeleton(child: ChatSearchListItemShape()),
-        ),
       ),
     );
   }


### PR DESCRIPTION
## Description
This PR replaces userMetadataProvider with the cached version in the chat search list.

## Additional Notes
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
