### PR TITLE
fix: static background for story viewer swipe dismiss

### DIFF
--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -87,7 +87,7 @@ class StoryViewerPage extends HookConsumerWidget {
                 .removeViewPadding(removeBottom: true, removeTop: true),
             child: Scaffold(
               resizeToAvoidBottomInset: false,
-              backgroundColor: context.theme.appColors.primaryText,
+              backgroundColor: Colors.black,
               body: Stack(
                 children: [
                   PositionedDirectional(

--- a/lib/app/router/base_route_data.dart
+++ b/lib/app/router/base_route_data.dart
@@ -27,12 +27,12 @@ abstract class BaseRouteData extends GoRouteData {
   BaseRouteData({
     required this.child,
     this.type = IceRouteType.single,
-    this.isFullscreenImage = false,
+    this.isFullscreenMedia = false,
     this.canPop,
   });
 
   final IceRouteType type;
-  final bool isFullscreenImage;
+  final bool isFullscreenMedia;
   final Widget child;
   final bool? canPop;
   @override
@@ -67,7 +67,7 @@ abstract class BaseRouteData extends GoRouteData {
       IceRouteType.swipeDismissible => SwipeDismissiblePageRoute(
           child: child,
           state: state,
-          isFullscreenImage: isFullscreenImage,
+          isFullscreenMedia: isFullscreenMedia,
         ),
     };
   }
@@ -186,7 +186,7 @@ class SwipeDismissiblePageRoute extends CustomTransitionPage<void> {
   SwipeDismissiblePageRoute({
     required Widget child,
     required GoRouterState state,
-    required bool isFullscreenImage,
+    required bool isFullscreenMedia,
   }) : super(
           key: state.pageKey,
           fullscreenDialog: true,
@@ -201,7 +201,7 @@ class SwipeDismissiblePageRoute extends CustomTransitionPage<void> {
             );
           },
           child: DismissibleContent(
-            isFullscreenImage: isFullscreenImage,
+            isFullscreenMedia: isFullscreenMedia,
             state: state,
             child: child,
           ),

--- a/lib/app/router/chat_routes.dart
+++ b/lib/app/router/chat_routes.dart
@@ -370,7 +370,7 @@ class ChatMediaRoute extends BaseRouteData {
             initialIndex: initialIndex,
           ),
           type: IceRouteType.swipeDismissible,
-          isFullscreenImage: true,
+          isFullscreenMedia: true,
         );
 
   final String eventReference;

--- a/lib/app/router/components/modal_wrapper/dismissible_content.dart
+++ b/lib/app/router/components/modal_wrapper/dismissible_content.dart
@@ -10,24 +10,24 @@ class DismissibleContent extends ConsumerWidget {
   const DismissibleContent({
     required this.child,
     required this.state,
-    required this.isFullscreenImage,
+    required this.isFullscreenMedia,
     super.key,
   });
 
   final Widget child;
   final GoRouterState state;
-  final bool isFullscreenImage;
+  final bool isFullscreenMedia;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isZoomed = ref.watch(imageZoomProvider);
 
-    // 1. If zoom is enabled, disable swipe.
-    // 2. If it's a fullscreen image, use only vertical direction.
-    // 3. Otherwise (e.g., "the trending video list"), allow swipe in all directions (multi).
+    // 1. If zoomed - disable swipe.
+    // 2. If fullscreen media (stories, chat media) - vertical only for natural dismiss gesture
+    // 3. Otherwise (video feeds) - multi-directional
     final dismissDirection = isZoomed
         ? SwipeDismissDirection.none
-        : (isFullscreenImage ? SwipeDismissDirection.vertical : SwipeDismissDirection.multi);
+        : (isFullscreenMedia ? SwipeDismissDirection.vertical : SwipeDismissDirection.multi);
 
     return DismissiblePage(
       onDismissed: () {
@@ -37,6 +37,9 @@ class DismissibleContent extends ConsumerWidget {
       },
       direction: dismissDirection,
       isZoomed: isZoomed,
+      // For fullscreen media, keep background static (don't animate opacity)
+      // where background stays fixed while content moves
+      staticBackground: isFullscreenMedia,
       child: child,
     );
   }

--- a/lib/app/router/feed_routes.dart
+++ b/lib/app/router/feed_routes.dart
@@ -434,6 +434,7 @@ class StoryViewerRoute extends BaseRouteData {
                 : null,
           ),
           type: IceRouteType.swipeDismissible,
+          isFullscreenMedia: true,
         );
 
   final String pubkey;
@@ -538,7 +539,7 @@ class FullscreenMediaRoute extends BaseRouteData {
                 : null,
           ),
           type: IceRouteType.swipeDismissible,
-          isFullscreenImage: true,
+          isFullscreenMedia: true,
         );
 
   final int initialMediaIndex;


### PR DESCRIPTION
 ## Description
  - Fixed an issue where the black background in the story viewer was moving along with the content when swiping down to dismiss. The background now remains static while only the content moves.

  ## Additional Notes
  - Added a new `staticBackground` parameter to `DismissiblePage` widget to control whether the background should animate its opacity during swipe
  - Renamed `isFullscreenImage` to `isFullscreenMedia` throughout the codebase for better semantic accuracy
  - The fix only affects fullscreen media views (stories, chat media) while preserving the existing behavior for other dismissible screens like video feeds

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
