### PR TITLE
feat(chat,wallet): add max amount validation for MoneyMessage request

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
@@ -21,6 +21,7 @@ import 'package:ion/app/features/wallets/providers/networks_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/send_asset_form_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/transaction_provider.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_view_data_provider.c.dart';
+import 'package:ion/app/features/wallets/views/utils/amount_parser.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 
 class RequestedMoneyMessageButton extends StatelessWidget {
@@ -164,6 +165,8 @@ class _SendMoneyButton extends ConsumerWidget {
 
       await sendAssetFormController.setCoin(coinGroup, walletView);
 
+      final maxAmount = coinGroup.totalAmount;
+
       sendAssetFormController
         ..setRequest(request!)
         ..setContact(receiverPubkey, isContactPreselected: true)
@@ -171,7 +174,9 @@ class _SendMoneyButton extends ConsumerWidget {
 
       await sendAssetFormController.setNetwork(network);
 
-      sendAssetFormController.setCoinsAmount(amount ?? '');
+      sendAssetFormController
+        ..setCoinsAmount(amount ?? '')
+        ..exceedsMaxAmount = (parseAmount(amount) ?? 0) > maxAmount;
 
       if (!context.mounted) return;
 

--- a/lib/app/features/wallets/model/send_asset_form_data.c.dart
+++ b/lib/app/features/wallets/model/send_asset_form_data.c.dart
@@ -26,5 +26,6 @@ class SendAssetFormData with _$SendAssetFormData {
     @Default(true) bool canCoverNetworkFee,
     @Default([]) List<NetworkFeeOption> networkFeeOptions,
     @Default(false) bool isContactPreselected,
+    @Default(false) bool exceedsMaxAmount,
   }) = _SendAssetFormData;
 }

--- a/lib/app/features/wallets/providers/send_asset_form_provider.c.dart
+++ b/lib/app/features/wallets/providers/send_asset_form_provider.c.dart
@@ -176,4 +176,8 @@ class SendAssetFormController extends _$SendAssetFormController {
   void setRequest(FundsRequestEntity request) {
     state = state.copyWith(request: request);
   }
+
+  set exceedsMaxAmount(bool value) {
+    state = state.copyWith(exceedsMaxAmount: value);
+  }
 }

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/buttons/coin_amount_input.dart
@@ -16,6 +16,7 @@ class CoinAmountInput extends HookWidget {
     this.maxValue,
     this.coinAbbreviation,
     this.enabled = true,
+    this.errorText,
     super.key,
   });
 
@@ -24,6 +25,7 @@ class CoinAmountInput extends HookWidget {
   final double? maxValue;
   final String? coinAbbreviation;
   final bool enabled;
+  final String? errorText;
 
   @override
   Widget build(BuildContext context) {
@@ -61,6 +63,7 @@ class CoinAmountInput extends HookWidget {
             return null;
           },
           labelText: label,
+          errorText: errorText,
           suffixIcon: maxValue != null && enabled
               ? Padding(
                   padding: EdgeInsetsDirectional.only(end: 16.0.s),

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -59,6 +59,7 @@ class SendCoinsForm extends HookConsumerWidget {
     final selectedContactPubkey = formController.contactPubkey;
     final coin = formController.assetData.as<CoinAssetToSendData>();
     final maxAmount = coin?.selectedOption?.amount ?? 0;
+    final exceedsMaxAmount = formController.exceedsMaxAmount;
 
     final amount = coin?.amount ?? 0.0;
     final amountController = useTextEditingController();
@@ -93,7 +94,8 @@ class SendCoinsForm extends HookConsumerWidget {
     final isContinueButtonEnabled = formController.canCoverNetworkFee &&
         validAmount &&
         formController.senderWallet?.address != null &&
-        validator.value.validate(formController.receiverAddress);
+        validator.value.validate(formController.receiverAddress) &&
+        !exceedsMaxAmount;
 
     final feeSectionSpacing = SizedBox(height: 20.0.s);
 
@@ -175,6 +177,8 @@ class SendCoinsForm extends HookConsumerWidget {
                         maxValue: coin?.selectedOption?.amount ?? 0,
                         coinAbbreviation: coin?.coinsGroup.abbreviation ?? '',
                         enabled: formController.request == null,
+                        errorText:
+                            exceedsMaxAmount ? locale.wallet_coin_amount_insufficient_funds : null,
                       ),
                       CoinsNetworkFeeSelector(
                         padding: EdgeInsetsDirectional.only(top: 17.0.s),


### PR DESCRIPTION
## Description
The bug: When someone requests 1000 ION, but you have only 10, the Send form doesn’t validate your balance against the requested amount.
This PR fixes the issue by adding validation to ensure you cannot send more than your available balance.

## Type of Change
- [x] Bug fix

## Screenshots
<img width="180" alt="image" src="https://github.com/user-attachments/assets/66b72823-6fcc-4d16-b6c4-d79575e19ca2">
