### PR TITLE
fix: change route for MoneyMessage-ViewTransaction button

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
@@ -228,7 +228,7 @@ class ViewTransactionButton extends ConsumerWidget {
         if (!context.mounted) {
           return;
         }
-        unawaited(CoinTransactionResultChatRoute().push<void>(context));
+        unawaited(CoinTransactionDetailsChatRoute().push<void>(context));
       },
     );
   }


### PR DESCRIPTION
## Description
The bug: When you press “View Transaction” on a money message, the app shows a “success” modal, and only from there you can press “details” to see the transaction details.
Fix: Changed the destination of “View Transaction” to go directly to the transaction details.

## Type of Change
- [x] Bug fix
