### PR TITLE
fix: replace ICE with ION in the CoinsComparator

### DIFF
--- a/lib/app/features/wallets/domain/coins/coins_comparator.dart
+++ b/lib/app/features/wallets/domain/coins/coins_comparator.dart
@@ -87,7 +87,6 @@ class CoinsComparator {
 class CoinPriority {
   final _priorityList = const [
     'ION', // Ice Open Network
-    'ICE', // Ice Open Network
     'BNB', // Binance Coin
     'BTC', // Bitcoin
     'ETH', // Ethereum

--- a/lib/app/features/wallets/domain/coins/coins_comparator.dart
+++ b/lib/app/features/wallets/domain/coins/coins_comparator.dart
@@ -86,6 +86,7 @@ class CoinsComparator {
 
 class CoinPriority {
   final _priorityList = const [
+    'ION', // Ice Open Network
     'ICE', // Ice Open Network
     'BNB', // Binance Coin
     'BTC', // Bitcoin


### PR DESCRIPTION
## Description
Replaced deprecated abbreviation to sort coins correctly.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
