### PR TITLE
feat: add tap-to-see tooltip for stories with quoted posts

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/features/components/ion_connect_network_image/ion_connect_network_image.dart';
 import 'package:ion/app/features/feed/stories/providers/story_image_loading_provider.c.dart';
+import 'package:ion/app/features/feed/stories/providers/story_pause_provider.c.dart';
+import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart';
 import 'package:ion/app/features/ion_connect/model/quoted_event.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 
-class ImageStoryViewer extends ConsumerWidget {
+class ImageStoryViewer extends HookConsumerWidget {
   const ImageStoryViewer({
     required this.imageUrl,
     required this.authorPubkey,
@@ -26,6 +29,7 @@ class ImageStoryViewer extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final cacheManager = ref.watch(storyImageCacheManagerProvider);
     final hasQuotedPost = quotedEvent != null;
+    final showTooltip = useState(false);
 
     final imageWidget = IonConnectNetworkImage(
       imageUrl: imageUrl,
@@ -54,12 +58,28 @@ class ImageStoryViewer extends ConsumerWidget {
     if (hasQuotedPost) {
       return GestureDetector(
         onTap: () {
-          final eventReference = quotedEvent!.eventReference;
-          PostDetailsRoute(
-            eventReference: eventReference.encode(),
-          ).push<void>(context);
+          if (!showTooltip.value) {
+            showTooltip.value = true;
+            ref.read(storyPauseControllerProvider.notifier).paused = true;
+          }
         },
-        child: imageWidget,
+        child: TapToSeeHint(
+          showTooltip: showTooltip.value,
+          onTooltipTap: () {
+            showTooltip.value = false;
+            ref.read(storyPauseControllerProvider.notifier).paused = false;
+
+            final eventReference = quotedEvent!.eventReference;
+            PostDetailsRoute(
+              eventReference: eventReference.encode(),
+            ).push<void>(context);
+          },
+          onHideTooltip: () {
+            showTooltip.value = false;
+            ref.read(storyPauseControllerProvider.notifier).paused = false;
+          },
+          child: imageWidget,
+        ),
       );
     }
 

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart
@@ -7,83 +7,94 @@ import 'package:ion/generated/assets.gen.dart';
 
 class TapToSeeHint extends HookWidget {
   const TapToSeeHint({
-    required this.showTooltip,
     required this.child,
-    this.onTooltipTap,
-    this.onHideTooltip,
+    required this.onTap,
+    this.onVisibilityChanged,
     super.key,
   });
 
-  final bool showTooltip;
   final Widget child;
-  final VoidCallback? onTooltipTap;
-  final VoidCallback? onHideTooltip;
+  final VoidCallback onTap;
+  final ValueChanged<bool>? onVisibilityChanged;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.appColors;
     final textStyles = context.theme.appTextThemes;
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        child,
-        if (showTooltip)
-          GestureDetector(
-            onTap: onHideTooltip,
-            behavior: HitTestBehavior.opaque,
-            child: SizedBox.expand(
-              child: Center(
-                child: GestureDetector(
-                  onTap: onTooltipTap,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Container(
-                        padding: EdgeInsetsDirectional.only(
-                          start: 16.0.s,
-                          end: 12.0.s,
-                          top: 9.0.s,
-                          bottom: 9.0.s,
-                        ),
-                        decoration: BoxDecoration(
-                          color: colors.onPrimaryAccent,
-                          borderRadius: BorderRadius.circular(8.0.s),
-                          boxShadow: [
-                            BoxShadow(
-                              color: colors.primaryText.withValues(alpha: 0.2),
-                              blurRadius: 8.0.s,
-                              offset: Offset(0, 2.0.s),
-                            ),
-                          ],
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              context.i18n.story_see_post,
-                              style: textStyles.subtitle3.copyWith(
+    final showTooltip = useState(false);
+
+    void toggleTooltip() {
+      showTooltip.value = !showTooltip.value;
+      onVisibilityChanged?.call(showTooltip.value);
+    }
+
+    return GestureDetector(
+      onTap: showTooltip.value ? null : toggleTooltip,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          child,
+          if (showTooltip.value)
+            GestureDetector(
+              onTap: toggleTooltip,
+              behavior: HitTestBehavior.opaque,
+              child: SizedBox.expand(
+                child: Center(
+                  child: GestureDetector(
+                    onTap: () {
+                      toggleTooltip();
+                      onTap();
+                    },
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          padding: EdgeInsetsDirectional.only(
+                            start: 16.0.s,
+                            end: 12.0.s,
+                            top: 9.0.s,
+                            bottom: 9.0.s,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colors.onPrimaryAccent,
+                            borderRadius: BorderRadius.circular(8.0.s),
+                            boxShadow: [
+                              BoxShadow(
+                                color: colors.primaryText.withValues(alpha: 0.2),
+                                blurRadius: 8.0.s,
+                                offset: Offset(0, 2.0.s),
+                              ),
+                            ],
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                context.i18n.story_see_post,
+                                style: textStyles.subtitle3.copyWith(
+                                  color: colors.primaryText,
+                                ),
+                              ),
+                              SizedBox(width: 4.0.s),
+                              Assets.svg.iconArrowRight.icon(
+                                size: 16.0.s,
                                 color: colors.primaryText,
                               ),
-                            ),
-                            SizedBox(width: 4.0.s),
-                            Assets.svg.iconArrowRight.icon(
-                              size: 16.0.s,
-                              color: colors.primaryText,
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
-                      ),
-                      CustomPaint(
-                        painter: _NotchPainter(color: colors.onPrimaryAccent),
-                        size: Size(19.0.s, 7.0.s),
-                      ),
-                    ],
+                        CustomPaint(
+                          painter: _NotchPainter(color: colors.onPrimaryAccent),
+                          size: Size(19.0.s, 7.0.s),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),
             ),
-          ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart
@@ -74,7 +74,7 @@ class TapToSeeHint extends HookWidget {
                         ),
                       ),
                       CustomPaint(
-                        painter: NotchPainter(color: colors.onPrimaryAccent),
+                        painter: _NotchPainter(color: colors.onPrimaryAccent),
                         size: Size(19.0.s, 7.0.s),
                       ),
                     ],
@@ -88,8 +88,8 @@ class TapToSeeHint extends HookWidget {
   }
 }
 
-class NotchPainter extends CustomPainter {
-  const NotchPainter({required this.color});
+class _NotchPainter extends CustomPainter {
+  const _NotchPainter({required this.color});
 
   final Color color;
 

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/tap_to_see_hint.dart
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/generated/assets.gen.dart';
+
+class TapToSeeHint extends HookWidget {
+  const TapToSeeHint({
+    required this.showTooltip,
+    required this.child,
+    this.onTooltipTap,
+    this.onHideTooltip,
+    super.key,
+  });
+
+  final bool showTooltip;
+  final Widget child;
+  final VoidCallback? onTooltipTap;
+  final VoidCallback? onHideTooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.appColors;
+    final textStyles = context.theme.appTextThemes;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        child,
+        if (showTooltip)
+          GestureDetector(
+            onTap: onHideTooltip,
+            behavior: HitTestBehavior.opaque,
+            child: SizedBox.expand(
+              child: Center(
+                child: GestureDetector(
+                  onTap: onTooltipTap,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        padding: EdgeInsetsDirectional.only(
+                          start: 16.0.s,
+                          end: 12.0.s,
+                          top: 9.0.s,
+                          bottom: 9.0.s,
+                        ),
+                        decoration: BoxDecoration(
+                          color: colors.onPrimaryAccent,
+                          borderRadius: BorderRadius.circular(8.0.s),
+                          boxShadow: [
+                            BoxShadow(
+                              color: colors.primaryText.withValues(alpha: 0.2),
+                              blurRadius: 8.0.s,
+                              offset: Offset(0, 2.0.s),
+                            ),
+                          ],
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              context.i18n.story_see_post,
+                              style: textStyles.subtitle3.copyWith(
+                                color: colors.primaryText,
+                              ),
+                            ),
+                            SizedBox(width: 4.0.s),
+                            Assets.svg.iconArrowRight.icon(
+                              size: 16.0.s,
+                              color: colors.primaryText,
+                            ),
+                          ],
+                        ),
+                      ),
+                      CustomPaint(
+                        painter: NotchPainter(color: colors.onPrimaryAccent),
+                        size: Size(19.0.s, 7.0.s),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class NotchPainter extends CustomPainter {
+  const NotchPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    final path = Path()
+      // Start from top-left
+      ..moveTo(0, 0)
+      // Draw curve to the notch
+      ..cubicTo(
+        size.width * 0.11,
+        0,
+        size.width * 0.28,
+        size.height * 0.44,
+        size.width * 0.395,
+        size.height * 0.76,
+      )
+      // Draw the central dip
+      ..cubicTo(
+        size.width * 0.43,
+        size.height * 0.87,
+        size.width * 0.46,
+        size.height * 0.93,
+        size.width * 0.5,
+        size.height * 0.93,
+      )
+      ..cubicTo(
+        size.width * 0.54,
+        size.height * 0.93,
+        size.width * 0.57,
+        size.height * 0.87,
+        size.width * 0.605,
+        size.height * 0.76,
+      )
+      // Draw curve from notch to top-right
+      ..cubicTo(
+        size.width * 0.72,
+        size.height * 0.44,
+        size.width * 0.89,
+        0,
+        size.width,
+        0,
+      )
+      ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
+}

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/viewers.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/viewers.dart
@@ -2,4 +2,5 @@
 
 export 'image_story_viewer.dart';
 export 'story_viewer_content.dart';
+export 'tap_to_see_hint.dart';
 export 'video_story_viewer.dart';

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -630,6 +630,7 @@
   "push_notifications_no_access_title": "الإذن غير متاح",
   "push_notifications_no_access_description": "لقد رفضت إذن الإشعارات سابقاً. يرجى الذهاب إلى الإعدادات لتمكين الإشعارات.",
   "story_preview_title": "معاينة القصة",
+  "story_see_post": "عرض المنشور",
   "delete_story_title": "حذف القصة؟",
   "delete_video_title": "حذف الفيديو؟",
   "delete_post_title": "حذف المنشور؟",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -668,6 +668,7 @@
   "story_reply_receiver": "Replied you",
   "story_reply_not_available_sender": "Content unavailable",
   "story_reply_not_available_receiver": "Unavailable story",
+  "story_see_post": "See post",
   "delete_video_title": "Delete video?",
   "delete_post_title": "Delete post?",
   "delete_article_title": "Delete article?",


### PR DESCRIPTION
  ## Description
Implement a tap-to-see tooltip for stories with quoted posts. When users tap on a story that contains a quoted post, a tooltip appears, allowing them to navigate to the full post details.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->

<img width="200" alt="image" src="https://github.com/user-attachments/assets/95ff0533-cbac-4ebc-8229-6be7d4d290ca" />

