### PR TITLE
fix: use the correct pubkey on send funds by request

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/components/money_message_button.dart
@@ -138,7 +138,7 @@ class _SendMoneyButton extends ConsumerWidget {
       final amount = request?.data.content.amount;
       final networkId = request?.data.networkId ?? '';
       final assetId = request?.data.content.assetId ?? '';
-      final receiverPubkey = request?.pubkey;
+      final receiverPubkey = request?.data.pubkey;
 
       // Get required data from providers
       final network = await ref.read(networkByIdProvider(networkId).future);


### PR DESCRIPTION
## Description
Issue: `User relays not found for ***`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Demo 
Before and after the fix
<img src="https://github.com/user-attachments/assets/3085008e-bbb9-4b5c-be22-477369c3280e" width=200> <img src="https://github.com/user-attachments/assets/9887879e-a853-4297-9ed4-187adf574c20" width=200>

