### PR TITLE
fix(chat): handle deleted accounts in chat timeline page

### DIFF
--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -110,20 +110,24 @@ class _Header extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final receiver = ref.watch(userMetadataProvider(receiverMasterPubkey)).valueOrNull;
+    final receiverUserMetadata = ref.watch(userMetadataProvider(receiverMasterPubkey));
 
-    if (receiver == null) {
+    if (receiverUserMetadata.isLoading) {
       return const SizedBox.shrink();
     }
 
     return OneToOneMessagingHeader(
       conversationId: conversationId,
-      imageUrl: receiver.data.picture,
-      name: receiver.data.displayName,
+      imageUrl: receiverUserMetadata.valueOrNull?.data.picture,
+      name:
+          receiverUserMetadata.valueOrNull?.data.displayName ?? context.i18n.common_deleted_account,
       receiverMasterPubkey: receiverMasterPubkey,
       onTap: () => ProfileRoute(pubkey: receiverMasterPubkey).push<void>(context),
       subtitle: Text(
-        prefixUsername(username: receiver.data.name, context: context),
+        prefixUsername(
+          username: receiverUserMetadata.valueOrNull?.data.name ?? '',
+          context: context,
+        ),
         style: context.theme.appTextThemes.caption.copyWith(
           color: context.theme.appColors.quaternaryText,
         ),

--- a/lib/app/features/user/providers/user_metadata_provider.c.dart
+++ b/lib/app/features/user/providers/user_metadata_provider.c.dart
@@ -59,3 +59,9 @@ Future<UserMetadataEntity?> currentUserMetadata(Ref ref) async {
     return null;
   }
 }
+
+@riverpod
+Future<bool> isUserDeleted(Ref ref, String pubkey) async {
+  final userMetadata = await ref.watch(userMetadataProvider(pubkey).future);
+  return userMetadata == null;
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -116,6 +116,7 @@
   "common_no_internet_connection": "No internet connection",
   "common_error": "Error",
   "common_chat": "Chat",
+  "common_deleted_account": "Deleted Account",
   "auth_secured_by": "Secured by",
   "auth_link_new_device_title": "Link new device",
   "auth_link_new_device_description": "You're accessing your account from a new device. To continue using the app, please link it to your account",


### PR DESCRIPTION
## Description
This PR fixes the issue where if a user is deleted, it should be shown as a deleted account.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
