### PR TITLE
fix: correct the borderRadius for the coin icons.

### DIFF
--- a/lib/app/components/coins/coin_icon.dart
+++ b/lib/app/components/coins/coin_icon.dart
@@ -7,20 +7,61 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/utils/image_path.dart';
 import 'package:ion/generated/assets.gen.dart';
 
+enum CoinIconType {
+  small,
+  medium,
+  big,
+  huge,
+}
+
 class CoinIconWidget extends StatelessWidget {
-  const CoinIconWidget({
+  const CoinIconWidget._({
     required this.imageUrl,
-    super.key,
-    this.size,
+    required this.type,
   });
 
+  factory CoinIconWidget.withType(String imageUrl, CoinIconType type) {
+    return CoinIconWidget._(
+      imageUrl: imageUrl,
+      type: type,
+    );
+  }
+
+  factory CoinIconWidget.small(String imageUrl) {
+    return CoinIconWidget._(
+      imageUrl: imageUrl,
+      type: CoinIconType.small,
+    );
+  }
+
+  factory CoinIconWidget.medium(String imageUrl) {
+    return CoinIconWidget._(
+      imageUrl: imageUrl,
+      type: CoinIconType.medium,
+    );
+  }
+
+  factory CoinIconWidget.big(String imageUrl) {
+    return CoinIconWidget._(
+      imageUrl: imageUrl,
+      type: CoinIconType.big,
+    );
+  }
+
+  factory CoinIconWidget.huge(String imageUrl) {
+    return CoinIconWidget._(
+      imageUrl: imageUrl,
+      type: CoinIconType.huge,
+    );
+  }
+
   final String imageUrl;
-  final double? size;
+  final CoinIconType type;
 
   @override
   Widget build(BuildContext context) {
-    final iconSize = size ?? 24.s;
-    final borderRadius = BorderRadius.circular(4.s);
+    final iconSize = _size(type);
+    final borderRadius = _borderRadius(type);
 
     return imageUrl.isSvg
         ? ClipRRect(
@@ -48,5 +89,23 @@ class CoinIconWidget extends StatelessWidget {
               ),
             ),
           );
+  }
+
+  double _size(CoinIconType type) {
+    return switch (type) {
+      CoinIconType.small => 16.s,
+      CoinIconType.medium => 24.s,
+      CoinIconType.big => 36.s,
+      CoinIconType.huge => 46.s,
+    };
+  }
+
+  BorderRadius _borderRadius(CoinIconType type) {
+    return switch (type) {
+      CoinIconType.small => BorderRadius.circular(5.s),
+      CoinIconType.medium => BorderRadius.circular(7.s),
+      CoinIconType.big => BorderRadius.circular(10.s),
+      CoinIconType.huge => BorderRadius.circular(14.s),
+    };
   }
 }

--- a/lib/app/components/select/select_coin_button.dart
+++ b/lib/app/components/select/select_coin_button.dart
@@ -94,10 +94,7 @@ class _HasCoinSelected extends StatelessWidget {
           style: textTheme.caption3,
         ),
         backgroundColor: Colors.transparent,
-        leading: CoinIconWidget(
-          imageUrl: selectedCoin.coin.iconUrl,
-          size: 36.0.s,
-        ),
+        leading: CoinIconWidget.big(selectedCoin.coin.iconUrl),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/app/features/wallets/views/components/coin_icon_with_network.dart
+++ b/lib/app/features/wallets/views/components/coin_icon_with_network.dart
@@ -10,7 +10,7 @@ class CoinIconWithNetwork extends StatelessWidget {
   const CoinIconWithNetwork._({
     required this.iconUrl,
     required this.network,
-    required this.coinSize,
+    required this.coinIconType,
     required this.networkSize,
     required this.containerSize,
   });
@@ -22,9 +22,9 @@ class CoinIconWithNetwork extends StatelessWidget {
       CoinIconWithNetwork._(
         iconUrl: iconUrl,
         network: network,
-        coinSize: 36.0.s,
         networkSize: 16.0.s,
         containerSize: 40.0.s,
+        coinIconType: CoinIconType.big,
       );
 
   factory CoinIconWithNetwork.medium(
@@ -34,17 +34,17 @@ class CoinIconWithNetwork extends StatelessWidget {
       CoinIconWithNetwork._(
         iconUrl: iconUrl,
         network: network,
-        coinSize: 46.0.s,
         networkSize: 21.0.s,
         containerSize: 51.0.s,
+        coinIconType: CoinIconType.huge,
       );
 
   final String iconUrl;
   final NetworkData network;
 
-  final double coinSize;
   final double networkSize;
   final double containerSize;
+  final CoinIconType coinIconType;
 
   @override
   Widget build(BuildContext context) {
@@ -58,10 +58,7 @@ class CoinIconWithNetwork extends StatelessWidget {
           PositionedDirectional(
             top: 0,
             start: 0,
-            child: CoinIconWidget(
-              imageUrl: iconUrl,
-              size: coinSize,
-            ),
+            child: CoinIconWidget.withType(iconUrl, coinIconType),
           ),
           PositionedDirectional(
             bottom: 0,

--- a/lib/app/features/wallets/views/components/coin_networks_list/coin_network_item.dart
+++ b/lib/app/features/wallets/views/components/coin_networks_list/coin_network_item.dart
@@ -47,10 +47,7 @@ class _CoinNetworkItem extends ConsumerWidget {
       leading: Stack(
         clipBehavior: Clip.none,
         children: [
-          CoinIconWidget(
-            imageUrl: coinData.iconUrl,
-            size: 36.0.s,
-          ),
+          CoinIconWidget.big(coinData.iconUrl),
           PositionedDirectional(
             bottom: -3.0.s,
             end: -3.0.s,

--- a/lib/app/features/wallets/views/components/coins_list/coin_item.dart
+++ b/lib/app/features/wallets/views/components/coins_list/coin_item.dart
@@ -5,7 +5,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/coins/coin_icon.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/extensions/build_context.dart';
-import 'package:ion/app/extensions/num.dart';
 import 'package:ion/app/extensions/theme_data.dart';
 import 'package:ion/app/features/wallets/model/coins_group.c.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/user_preferences_selectors.c.dart';
@@ -29,10 +28,7 @@ class CoinsGroupItem extends ConsumerWidget {
       title: Text(coinsGroup.name),
       subtitle: Text(coinsGroup.abbreviation),
       backgroundColor: context.theme.appColors.tertararyBackground,
-      leading: CoinIconWidget(
-        imageUrl: coinsGroup.iconUrl,
-        size: 36.0.s,
-      ),
+      leading: CoinIconWidget.big(coinsGroup.iconUrl),
       onTap: onTap,
       trailing: Column(
         crossAxisAlignment: CrossAxisAlignment.end,

--- a/lib/app/features/wallets/views/pages/coins_flow/coin_details/coin_details_page.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_details/coin_details_page.dart
@@ -70,7 +70,7 @@ class CoinDetailsPage extends HookConsumerWidget {
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            CoinIconWidget(imageUrl: coinsGroup.iconUrl),
+            CoinIconWidget.medium(coinsGroup.iconUrl),
             SizedBox(width: 6.0.s),
             Text(coinsGroup.name),
           ],

--- a/lib/app/features/wallets/views/pages/coins_flow/coin_receive_modal/components/coin_address_tile/coin_address_tile.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/coin_receive_modal/components/coin_address_tile/coin_address_tile.dart
@@ -49,10 +49,7 @@ class CoinAddressTile extends HookConsumerWidget {
               children: [
                 Row(
                   children: [
-                    CoinIconWidget(
-                      imageUrl: coinsGroup.iconUrl,
-                      size: 16.0.s,
-                    ),
+                    CoinIconWidget.small(coinsGroup.iconUrl),
                     SizedBox(width: 6.0.s),
                     Expanded(
                       child: Text(

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/confirmation_sheet.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/confirmation_sheet.dart
@@ -93,10 +93,7 @@ class ConfirmationSheet extends ConsumerWidget {
                       amount: coin.amount,
                       currency: coin.coinsGroup.abbreviation,
                       usdAmount: coin.amountUSD,
-                      icon: CoinIconWidget(
-                        imageUrl: coin.coinsGroup.iconUrl,
-                        size: 36.0.s,
-                      ),
+                      icon: CoinIconWidget.big(coin.coinsGroup.iconUrl),
                       transactionType: TransactionType.send,
                     ),
                   SizedBox(height: 16.0.s),
@@ -109,10 +106,7 @@ class ConfirmationSheet extends ConsumerWidget {
                     ListItem.textWithIcon(
                       title: Text(locale.wallet_asset),
                       value: coin.coinsGroup.abbreviation,
-                      icon: CoinIconWidget(
-                        imageUrl: coin.coinsGroup.iconUrl,
-                        size: ScreenSideOffset.defaultSmallMargin,
-                      ),
+                      icon: CoinIconWidget.small(coin.coinsGroup.iconUrl),
                     ),
                   SizedBox(height: 16.0.s),
                   if (formData.senderWallet?.address case final String address)

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_result_sheet.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/confirmation/transaction_result_sheet.dart
@@ -66,9 +66,7 @@ class TransactionResultSheet extends ConsumerWidget {
                         amount: coin.amount,
                         currency: coin.coinsGroup.abbreviation,
                         usdAmount: coin.amountUSD,
-                        icon: CoinIconWidget(
-                          imageUrl: coin.coinsGroup.iconUrl,
-                        ),
+                        icon: CoinIconWidget.medium(coin.coinsGroup.iconUrl),
                         transactionType: TransactionType.send,
                       ),
                       // TODO: Recheck the nft part during implementation

--- a/lib/app/features/wallets/views/pages/manage_coins/components/manage_coin_item_widget.dart
+++ b/lib/app/features/wallets/views/pages/manage_coins/components/manage_coin_item_widget.dart
@@ -6,7 +6,6 @@ import 'package:ion/app/components/coins/coin_icon.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/extensions/asset_gen_image.dart';
 import 'package:ion/app/extensions/build_context.dart';
-import 'package:ion/app/extensions/num.dart';
 import 'package:ion/app/extensions/theme_data.dart';
 import 'package:ion/app/features/wallets/model/coins_group.c.dart';
 import 'package:ion/app/features/wallets/views/pages/manage_coins/providers/manage_coins_provider.c.dart';
@@ -30,10 +29,7 @@ class ManageCoinItemWidget extends ConsumerWidget {
       title: Text(coinsGroup.name),
       subtitle: Text(coinsGroup.abbreviation),
       backgroundColor: context.theme.appColors.tertararyBackground,
-      leading: CoinIconWidget(
-        imageUrl: coinsGroup.iconUrl,
-        size: 36.0.s,
-      ),
+      leading: CoinIconWidget.big(coinsGroup.iconUrl),
       trailing: isSelected
           ? Assets.svg.iconBlockCheckboxOn.icon()
           : Assets.svg.iconBlockCheckboxOff.icon(),

--- a/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
+++ b/lib/app/features/wallets/views/pages/transaction_details/transaction_details.dart
@@ -84,9 +84,7 @@ class TransactionDetailsPage extends ConsumerWidget {
                                   amount: coin.amount,
                                   currency: coin.coinsGroup.abbreviation,
                                   usdAmount: coin.amountUSD,
-                                  icon: CoinIconWidget(
-                                    imageUrl: coin.coinsGroup.iconUrl,
-                                  ),
+                                  icon: CoinIconWidget.medium(coin.coinsGroup.iconUrl),
                                   transactionType: transactionData.type,
                                 ),
                                 nft: (nft) => Padding(
@@ -149,10 +147,7 @@ class TransactionDetailsPage extends ConsumerWidget {
                                   ListItem.textWithIcon(
                                     title: Text(locale.wallet_asset),
                                     value: coin.coinsGroup.abbreviation,
-                                    icon: CoinIconWidget(
-                                      imageUrl: coin.coinsGroup.iconUrl,
-                                      size: ScreenSideOffset.defaultSmallMargin,
-                                    ),
+                                    icon: CoinIconWidget.small(coin.coinsGroup.iconUrl),
                                   ),
                                 ],
                                 orElse: () => const [SizedBox.shrink()],


### PR DESCRIPTION
## Description
1. Refactored `CoinIconWidget` to strict radius/size.
2. Set the correct values for different types.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="200" src="https://github.com/user-attachments/assets/49117e23-fbe0-44c9-be55-3a3c01562a47"> <img width="200" src="https://github.com/user-attachments/assets/e75beacb-f034-4cd6-98cd-d9795a745795"> <img width="200" src="https://github.com/user-attachments/assets/b5560d03-b106-4def-b4d5-04e7526b55cc">

