### PR TITLE
fix: support legacy PostEntity in video full screen page

### DIFF
--- a/lib/app/features/video/views/components/video_post_info.dart
+++ b/lib/app/features/video/views/components/video_post_info.dart
@@ -6,6 +6,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/mute_provider.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
 import 'package:ion/app/features/feed/views/components/user_info/user_info.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/video/views/components/video_button.dart';
 import 'package:ion/app/features/video/views/components/video_post_text.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -16,10 +17,15 @@ class VideoPostInfo extends StatelessWidget {
     super.key,
   });
 
-  final ModifiablePostEntity videoPost;
+  final IonConnectEntity videoPost;
 
   @override
   Widget build(BuildContext context) {
+    final publishedAt = switch (videoPost) {
+      final ModifiablePostEntity post => post.data.publishedAt.value,
+      _ => videoPost.createdAt,
+    };
+
     return Column(
       children: [
         Container(
@@ -41,7 +47,7 @@ class VideoPostInfo extends StatelessWidget {
             children: [
               UserInfo(
                 pubkey: videoPost.masterPubkey,
-                createdAt: videoPost.data.publishedAt.value,
+                createdAt: publishedAt,
                 trailing: Consumer(
                   builder: (context, ref, child) {
                     final isMuted = ref.watch(globalMuteNotifierProvider);

--- a/lib/app/features/video/views/components/video_post_text.dart
+++ b/lib/app/features/video/views/components/video_post_text.dart
@@ -7,6 +7,9 @@ import 'package:ion/app/components/text_editor/text_editor_preview.dart';
 import 'package:ion/app/components/text_editor/utils/text_editor_styles.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
+import 'package:ion/app/features/feed/data/models/entities/post_data.c.dart';
+import 'package:ion/app/features/ion_connect/model/entity_data_with_media_content.dart';
+import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/ion_connect/views/hooks/use_parsed_media_content.dart';
 
 class VideoTextPost extends HookWidget {
@@ -15,11 +18,21 @@ class VideoTextPost extends HookWidget {
     super.key,
   });
 
-  final ModifiablePostEntity entity;
+  final IonConnectEntity entity;
 
   @override
   Widget build(BuildContext context) {
-    final (:content, :media) = useParsedMediaContent(data: entity.data);
+    final postData = switch (entity) {
+      final ModifiablePostEntity post => post.data,
+      final PostEntity post => post.data,
+      _ => null,
+    };
+
+    if (postData is! EntityDataWithMediaContent) {
+      return const SizedBox.shrink();
+    }
+
+    final (:content, :media) = useParsedMediaContent(data: postData);
     final isTextExpanded = useState(false);
     final style = context.theme.appTextThemes.body2.copyWith(
       color: context.theme.appColors.secondaryBackground,


### PR DESCRIPTION
## Description
This PR fixes an issue where videos from legacy PostEntities could not be launched in media full screen page. 

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
