### PR TITLE
fix: video player controller not disposing

### DIFF
--- a/lib/app/features/core/providers/video_player_provider.c.dart
+++ b/lib/app/features/core/providers/video_player_provider.c.dart
@@ -57,6 +57,18 @@ class VideoController extends _$VideoController {
         .watch(videoPlayerControllerFactoryProvider(sourcePath))
         .createController(VideoPlayerOptions(mixWithOthers: true));
 
+    ref.onCancel(() async {
+      await Future.wait([
+        controller.dispose(),
+        () async {
+          if (_activeController != controller) {
+            await _activeController?.dispose();
+            _activeController = null;
+          }
+        }(),
+      ]);
+    });
+
     try {
       await controller.initialize();
       if (!controller.value.hasError) {
@@ -112,10 +124,6 @@ class VideoController extends _$VideoController {
         stackTrace: stackTrace,
       );
     }
-
-    ref.onCancel(() async {
-      return controller.dispose();
-    });
 
     return controller;
   }


### PR DESCRIPTION
## Description
This PR fixes an issue where video player controller sometimes didn't get disposed, causing a memory leak.

## Additional Notes
This happened mostly during fast scrolling in vertical videos page. The root cause of this issue was that dispose logic was set up after the video player controller got created and initialized. If the provider got destroyed before video player controller finished initializing, it was never disposed. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
