### PR TITLE
fix: send funds via chat to the correct person

### DIFF
--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -220,7 +221,7 @@ class E2eeRecentChatTile extends HookConsumerWidget {
     final currentUserPubkey = ref.watch(currentPubkeySelectorProvider);
 
     final receiverPubkey =
-        entity.relatedPubkeys?.firstWhere((p) => p.value != currentUserPubkey).value;
+        entity.relatedPubkeys?.firstWhereOrNull((p) => p.value != currentUserPubkey)?.value;
 
     if (receiverPubkey == null) {
       return const SizedBox.shrink();

--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -221,7 +220,7 @@ class E2eeRecentChatTile extends HookConsumerWidget {
     final currentUserPubkey = ref.watch(currentPubkeySelectorProvider);
 
     final receiverPubkey =
-        entity.relatedPubkeys?.firstWhereOrNull((p) => p.value != currentUserPubkey)?.value;
+        entity.relatedPubkeys?.firstWhere((p) => p.value != currentUserPubkey).value;
 
     if (receiverPubkey == null) {
       return const SizedBox.shrink();

--- a/lib/app/features/user/providers/request_coins_submit_notifier.c.dart
+++ b/lib/app/features/user/providers/request_coins_submit_notifier.c.dart
@@ -44,7 +44,7 @@ class RequestCoinsSubmitNotifier extends _$RequestCoinsSubmitNotifier {
         throw const CurrentUserNotFoundException();
       }
 
-      final request = await _buildFundsRequestData(formData);
+      final request = await _buildFundsRequestData(formData, currentUserPubkey);
       final pubkeys = await _collectPubkeys(formData.contactPubkey!, currentUserPubkey);
 
       final sendToRelayService = await ref.read(sendTransactionToRelayServiceProvider.future);
@@ -108,7 +108,10 @@ class RequestCoinsSubmitNotifier extends _$RequestCoinsSubmitNotifier {
     }
   }
 
-  Future<FundsRequestData> _buildFundsRequestData(RequestCoinsFormData formData) async {
+  Future<FundsRequestData> _buildFundsRequestData(
+    RequestCoinsFormData formData,
+    String currentUserPubkey,
+  ) async {
     final RequestCoinsFormData(:assetData, :network, :contactPubkey, :toWallet) = formData;
 
     final user = await ref.read(userMetadataProvider(contactPubkey!).future);
@@ -131,7 +134,7 @@ class RequestCoinsSubmitNotifier extends _$RequestCoinsSubmitNotifier {
       networkId: network.id,
       assetClass: isNative ? 'native' : 'token',
       assetAddress: contractAddress,
-      pubkey: contactPubkey,
+      pubkey: currentUserPubkey,
       walletAddress: toWalletAddress,
       content: content,
     );

--- a/lib/app/router/chat_routes.dart
+++ b/lib/app/router/chat_routes.dart
@@ -312,6 +312,7 @@ class SendCoinsConfirmationChatRoute extends BaseRouteData {
       : super(
           child: ConfirmationSheet(
             successRouteLocationBuilder: () => CoinTransactionResultChatRoute().location,
+            redirectType: RedirectType.push,
           ),
           type: IceRouteType.bottomSheet,
         );


### PR DESCRIPTION
## Description
1. Fix navigation issue, when sending coins from chat.
2. Send pubkey of the current user in the request, so the person, who sent request, will receive coins.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Demo

https://github.com/user-attachments/assets/e5ebff71-faf9-4244-81c0-069e254e5d6a

