### PR TITLE
fix: show posts inside profile for muted users

### DIFF
--- a/lib/app/features/components/entities_list/entities_list.dart
+++ b/lib/app/features/components/entities_list/entities_list.dart
@@ -29,6 +29,7 @@ class EntitiesList extends HookWidget {
     this.separatorHeight,
     this.onVideoTap,
     this.readFromDB = false,
+    this.showMuted = false,
     super.key,
   });
 
@@ -37,6 +38,7 @@ class EntitiesList extends HookWidget {
   final bool displayParent;
   final OnVideoTapCallback? onVideoTap;
   final bool readFromDB;
+  final bool showMuted;
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +53,7 @@ class EntitiesList extends HookWidget {
           separatorHeight: separatorHeight,
           onVideoTap: onVideoTap,
           readFromDB: readFromDB,
+          showMuted: showMuted,
         );
       },
     );
@@ -62,6 +65,7 @@ class _EntityListItem extends ConsumerWidget {
     required this.eventReference,
     required this.displayParent,
     required this.readFromDB,
+    required this.showMuted,
     this.onVideoTap,
     double? separatorHeight,
     super.key,
@@ -72,6 +76,7 @@ class _EntityListItem extends ConsumerWidget {
   final bool displayParent;
   final bool readFromDB;
   final OnVideoTapCallback? onVideoTap;
+  final bool showMuted;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -81,7 +86,7 @@ class _EntityListItem extends ConsumerWidget {
         ref.watch(ionConnectSyncEntityProvider(eventReference: eventReference, db: readFromDB));
 
     if (entity == null ||
-        _isBlockedOrMutedOrBlocking(ref, entity) ||
+        _isBlockedOrMutedOrBlocking(ref, entity, showMuted) ||
         _isDeleted(ref, entity) ||
         _isRepostedEntityDeleted(ref, entity) ||
         !_hasMetadata(ref, entity)) {
@@ -119,8 +124,8 @@ class _EntityListItem extends ConsumerWidget {
     return false;
   }
 
-  bool _isBlockedOrMutedOrBlocking(WidgetRef ref, IonConnectEntity entity) {
-    final isMuted = ref.watch(isUserMutedProvider(entity.masterPubkey));
+  bool _isBlockedOrMutedOrBlocking(WidgetRef ref, IonConnectEntity entity, bool showMuted) {
+    final isMuted = !showMuted && ref.watch(isUserMutedProvider(entity.masterPubkey));
     final isBlockedOrBlockedBy =
         ref.watch(isEntityBlockedOrBlockedByNotifierProvider(entity)).valueOrNull ?? false;
     return isMuted || isBlockedOrBlockedBy;

--- a/lib/app/features/user/pages/profile_page/components/tabs/tab_entities_list.dart
+++ b/lib/app/features/user/pages/profile_page/components/tabs/tab_entities_list.dart
@@ -11,7 +11,6 @@ import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/ion_connect/providers/entities_paged_data_provider.c.dart';
 import 'package:ion/app/features/user/model/tab_entity_type.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/tabs/empty_state.dart';
-import 'package:ion/app/features/user/providers/muted_users_notifier.c.dart';
 import 'package:ion/app/features/user/providers/tab_data_source_provider.c.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:ion/app/features/user_block/providers/block_list_notifier.c.dart';
@@ -59,7 +58,6 @@ class TabEntitiesList extends ConsumerWidget {
     final entitiesPagedData = ref.watch(entitiesPagedDataProvider(dataSource));
     final isBlockedOrBlockedBy =
         ref.watch(isBlockedOrBlockedByNotifierProvider(pubkey)).valueOrNull ?? false;
-    final isMuted = ref.watch(isUserMutedProvider(pubkey));
     final entities = entitiesPagedData?.data.items;
 
     return LoadMoreBuilder(
@@ -68,7 +66,7 @@ class TabEntitiesList extends ConsumerWidget {
       slivers: [
         if (entities == null)
           const EntitiesListSkeleton()
-        else if (entities.isEmpty || isBlockedOrBlockedBy || isMuted)
+        else if (entities.isEmpty || isBlockedOrBlockedBy)
           EmptyState(
             type: type,
             isCurrentUserProfile: pubkey == ref.watch(currentPubkeySelectorProvider),
@@ -79,6 +77,7 @@ class TabEntitiesList extends ConsumerWidget {
               ? builder!(entities.toList())
               : EntitiesList(
                   refs: entities.map((entity) => entity.toEventReference()).toList(),
+                  showMuted: true,
                   onVideoTap: ({
                     required String eventReference,
                     required int initialMediaIndex,


### PR DESCRIPTION
## Description
This PR fixes an issue where after clicking `not interested` on a user, it wasn't possible to see any of their posts on their profile. Such behavior should only apply to blocking. For non interested/muting, only content on feed should be hidden.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
