### PR TITLE
fix: show cant find profile page when user is deleted

### DIFF
--- a/lib/app/features/user/pages/profile_page/profile_page.dart
+++ b/lib/app/features/user/pages/profile_page/profile_page.dart
@@ -51,7 +51,9 @@ class ProfilePage extends HookConsumerWidget {
     final isBlockedOrBlockedBy =
         isBlocked != null && isBlocked || isBlockedBy != null && isBlockedBy;
 
-    if (!userMetadata.hasValue || isBlockedOrBlockedBy) {
+    final isDeleted = ref.watch(isUserDeletedProvider(pubkey)).valueOrNull.falseOrValue;
+
+    if (isDeleted || isBlockedOrBlockedBy) {
       return const CantFindProfilePage();
     }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where `CantFindProfilePage` was not properly shown when metadata didn't load

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
