### PR TITLE
fix(chat): invalidate ActiveRelays on EventSigner change

### DIFF
--- a/lib/app/features/ion_connect/providers/active_relays_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/active_relays_provider.c.dart
@@ -38,7 +38,12 @@ class ActiveRelays extends _$ActiveRelays {
     ref.listen(
       currentUserIonConnectEventSignerProvider,
       (prev, next) {
-        if (prev != next) {
+        // Only invalidate when switching between two different valid signers
+        // This avoids false positives when logging in/out (null transitions)
+        final bothNotNull = prev?.value != null && next.value != null;
+        final valuesNotEqual = prev?.value != next.value;
+
+        if (bothNotNull && valuesNotEqual) {
           invalidateAll();
         }
       },

--- a/lib/app/features/ion_connect/providers/active_relays_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/active_relays_provider.c.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
+import 'package:ion/app/features/ion_connect/providers/ion_connect_event_signer_provider.c.dart';
 import 'package:ion/app/features/ion_connect/providers/relay_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,12 +11,8 @@ part 'active_relays_provider.c.g.dart';
 class ActiveRelays extends _$ActiveRelays {
   @override
   Set<String> build() {
-    onLogout(ref, () {
-      for (final url in state) {
-        ref.invalidate(relayProvider(url));
-      }
-    });
-
+    _invalidateOnLogout();
+    _invalidateOnSignerChange();
     return {};
   }
 
@@ -25,5 +22,26 @@ class ActiveRelays extends _$ActiveRelays {
 
   void removeRelay(String url) {
     state = {...state}..remove(url);
+  }
+
+  void invalidateAll() {
+    for (final url in state) {
+      ref.invalidate(relayProvider(url));
+    }
+  }
+
+  void _invalidateOnLogout() {
+    onLogout(ref, invalidateAll);
+  }
+
+  void _invalidateOnSignerChange() {
+    ref.listen(
+      currentUserIonConnectEventSignerProvider,
+      (prev, next) {
+        if (prev != next) {
+          invalidateAll();
+        }
+      },
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1842,11 +1842,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0.0.38"
-      resolved-ref: "4ba5318d95ab2460eb461623e0d88e002e0b2c52"
+      ref: "0.0.39"
+      resolved-ref: "78a95a90d2c72e232f12b37e68b67f8de946f1e8"
       url: "https://github.com/ice-blockchain/nostr-dart"
     source: git
-    version: "0.0.38"
+    version: "0.0.39"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,7 +111,7 @@ dependencies:
   nostr_dart:
     git:
       url: https://github.com/ice-blockchain/nostr-dart
-      ref: 0.0.38
+      ref: 0.0.39
   ogp_data_extract: ^0.1.4
   package_info_plus: ^8.3.0
   palette_generator: ^0.3.3+5


### PR DESCRIPTION
## Description
Currently, when we restore the device keypair, the app loads old messages only after restart. This PR makes the app restore conversations in the same session.

The issue was that relay were already connected with the old data, and need to be invalidated.

## Task ID
2891

## Type of Change
- [x] Bug fix
