### PR TITLE
feat: Use restored keypair on new devices instead of generating a new one

### DIFF
--- a/lib/app/features/auth/views/pages/link_new_device/link_new_device_dialog.dart
+++ b/lib/app/features/auth/views/pages/link_new_device/link_new_device_dialog.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/ion_connect/providers/restore_device_keypair_no
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/app/services/ui_event_queue/ui_event_queue_notifier.c.dart';
 import 'package:ion/generated/assets.gen.dart';
 import 'package:ion_identity_client/ion_identity.dart';
@@ -103,6 +104,11 @@ class LinkNewDeviceDialog extends HookConsumerWidget {
           DeviceKeypairUtils.extractDeviceKeypairAttachmentFromMetadata(currentUserMetadata);
       return keypairAttachment != null;
     } catch (e) {
+      Logger.error(
+        e,
+        stackTrace: StackTrace.current,
+        message: 'Failed to check metadata for uploaded keypair',
+      );
       return false;
     }
   }

--- a/lib/app/features/ion_connect/providers/device_keypair_utils.dart
+++ b/lib/app/features/ion_connect/providers/device_keypair_utils.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/ion_connect/model/file_alt.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/features/ion_connect/providers/device_keypair_constants.dart';
 import 'package:ion/app/features/ion_connect/providers/file_storage_url_provider.c.dart';
+import 'package:ion/app/features/user/model/user_metadata.c.dart';
 import 'package:ion/app/features/user/providers/current_user_identity_provider.c.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:ion/app/services/ion_identity/ion_identity_client_provider.c.dart';
@@ -51,19 +52,23 @@ class DeviceKeypairUtils {
   }
 
   /// Finds the device keypair MediaAttachment from current user's metadata
+  static MediaAttachment? extractDeviceKeypairAttachmentFromMetadata(UserMetadataEntity? metadata) {
+    if (metadata == null) {
+      return null;
+    }
+
+    // Find device keypair attachment by alt field
+    return metadata.data.media.values
+        .where((attachment) => attachment.alt == FileAlt.attestationKey)
+        .firstOrNull;
+  }
+
   static Future<MediaAttachment?> findDeviceKeypairAttachment({
     required Ref ref,
   }) async {
     try {
       final currentUserMetadata = await ref.read(currentUserMetadataProvider.future);
-      if (currentUserMetadata == null) {
-        return null;
-      }
-
-      // Find device keypair attachment by alt field
-      return currentUserMetadata.data.media.values
-          .where((attachment) => attachment.alt == FileAlt.attestationKey)
-          .firstOrNull;
+      return extractDeviceKeypairAttachmentFromMetadata(currentUserMetadata);
     } catch (e) {
       return null;
     }

--- a/lib/app/features/ion_connect/providers/ion_connect_event_signer_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_event_signer_provider.c.dart
@@ -3,6 +3,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/ion_connect/providers/device_keypair_utils.dart';
 import 'package:ion/app/services/ion_connect/ed25519_key_store.dart';
 import 'package:ion/app/services/storage/secure_storage.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -26,11 +27,16 @@ class IonConnectEventSigner extends _$IonConnectEventSigner {
   }
 
   Future<EventSigner?> initEventSigner() async {
-    final currentUserIonConnectEventSigner =
-        await ref.read(ionConnectEventSignerProvider(identityKeyName).future);
+    final currentUserIonConnectEventSigner = await future;
     if (currentUserIonConnectEventSigner != null) {
       // Event signer already exists, reuse it
       return currentUserIonConnectEventSigner;
+    }
+
+    final deviceKeypairAttachment = await DeviceKeypairUtils.findDeviceKeypairAttachment(ref: ref);
+    if (deviceKeypairAttachment != null) {
+      // There's an uploaded keypair - return null and restore it later (LinkNewDevice)
+      return null;
     }
 
     // Generate a new event signer

--- a/lib/app/features/user/pages/switch_account_modal/components/accounts_list/account_tile.dart
+++ b/lib/app/features/user/pages/switch_account_modal/components/accounts_list/account_tile.dart
@@ -23,7 +23,7 @@ class AccountsTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentIdentityKeyName = ref.watch(currentIdentityKeyNameSelectorProvider);
-    final eventSigner = ref.watch(ionConnectEventSignerProvider(identityKeyName)).valueOrNull;
+    final eventSigner = ref.watch(currentUserIonConnectEventSignerProvider).valueOrNull;
 
     if (eventSigner == null) {
       return Skeleton(child: ListItem());


### PR DESCRIPTION
## Description
This PR updates the keypair handling flow during login on new devices.

What’s changed:
- When a user logs in on a new device, we now check if an uploaded keypair exists:
    • If yes -> we restore/download the existing keypair
    • If not -> we generate a new keypair and follow the existing attestation flow

## Task ID
ION-2933

## Type of Change
- [x] New feature
