### PR TITLE
fix(stories): allow viewing stories from non-followed users

### DIFF
--- a/lib/app/features/feed/stories/providers/story_viewing_provider.c.dart
+++ b/lib/app/features/feed/stories/providers/story_viewing_provider.c.dart
@@ -2,9 +2,11 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
 import 'package:ion/app/features/feed/stories/data/models/models.dart';
 import 'package:ion/app/features/feed/stories/providers/feed_stories_provider.c.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
+import 'package:ion/app/features/ion_connect/providers/ion_connect_entity_provider.c.dart';
 import 'package:ion/app/features/optimistic_ui/features/likes/post_like_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -14,7 +16,7 @@ part 'story_viewing_provider.c.g.dart';
 ///
 /// This controller maintains the state of currently viewed stories and provides methods
 /// to navigate between stories and users.
-@riverpod
+@Riverpod(keepAlive: true)
 class StoryViewingController extends _$StoryViewingController {
   @override
   StoryViewerState build(String pubkey) {
@@ -22,6 +24,27 @@ class StoryViewingController extends _$StoryViewingController {
 
     return StoryViewerState(
       userStories: stories,
+      currentUserIndex: 0,
+      currentStoryIndex: 0,
+    );
+  }
+
+  Future<void> setUserStoryByReference(EventReference eventReference) async {
+    final storyEntity = await ref.read(
+      ionConnectEntityProvider(eventReference: eventReference).future,
+    );
+
+    if (storyEntity == null) {
+      return;
+    }
+
+    state = state.copyWith(
+      userStories: [
+        UserStories(
+          pubkey: pubkey,
+          stories: [storyEntity as ModifiablePostEntity],
+        ),
+      ],
       currentUserIndex: 0,
       currentStoryIndex: 0,
     );

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -36,7 +36,9 @@ class StoryViewerPage extends HookConsumerWidget {
     useEffect(
       () {
         return () {
-          ref.invalidate(storyViewingControllerProvider(pubkey));
+          if (context.mounted) {
+            ref.invalidate(storyViewingControllerProvider(pubkey));
+          }
         };
       },
       [],

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -31,6 +32,15 @@ class StoryViewerPage extends HookConsumerWidget {
     useStatusBarColor();
 
     final storyViewerState = ref.watch(storyViewingControllerProvider(pubkey));
+
+    useEffect(
+      () {
+        return () {
+          ref.invalidate(storyViewingControllerProvider(pubkey));
+        };
+      },
+      [],
+    );
 
     useOnInit(
       () {


### PR DESCRIPTION
## Description
With this PR, user can view a story from a non-followed user in the chat if it's shared in conversation.

## Additional Notes
N/A

## Task ID
ION-2943

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
