### PR TITLE
feat: add support for unclassified topic in posts and articles

### DIFF
--- a/lib/app/features/feed/create_article/providers/create_article_provider.c.dart
+++ b/lib/app/features/feed/create_article/providers/create_article_provider.c.dart
@@ -12,6 +12,7 @@ import 'package:ion/app/extensions/delta.dart';
 import 'package:ion/app/features/core/providers/env_provider.c.dart';
 import 'package:ion/app/features/feed/create_article/providers/draft_article_provider.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/article_data.c.dart';
+import 'package:ion/app/features/feed/data/models/feed_interests.c.dart';
 import 'package:ion/app/features/feed/data/models/who_can_reply_settings_option.c.dart';
 import 'package:ion/app/features/gallery/providers/gallery_provider.c.dart';
 import 'package:ion/app/features/ion_connect/model/action_source.c.dart';
@@ -89,6 +90,9 @@ class CreateArticle extends _$CreateArticle {
         content: jsonEncode(updatedContent.toJson()),
       );
 
+      if (topics.isEmpty) {
+        topics.add(FeedInterests.unclassified);
+      }
       final relatedHashtags = [
         ...topics.map((topic) => RelatedHashtag(value: topic)),
         ...extractTags(updatedContent).map((tag) => RelatedHashtag(value: tag)),
@@ -213,6 +217,11 @@ class CreateArticle extends _$CreateArticle {
         content: contentString,
       );
 
+      if (topics.contains(FeedInterests.unclassified) && topics.length > 1) {
+        topics.remove(FeedInterests.unclassified);
+      } else if (topics.isEmpty) {
+        topics.add(FeedInterests.unclassified);
+      }
       final relatedHashtags = [
         ...topics.map((topic) => RelatedHashtag(value: topic)),
         ...extractTags(updatedContent).map((tag) => RelatedHashtag(value: tag)),

--- a/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.c.dart
@@ -17,6 +17,7 @@ import 'package:ion/app/features/feed/create_post/model/create_post_option.dart'
 import 'package:ion/app/features/feed/data/models/entities/article_data.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.c.dart';
 import 'package:ion/app/features/feed/data/models/entities/post_data.c.dart';
+import 'package:ion/app/features/feed/data/models/feed_interests.c.dart';
 import 'package:ion/app/features/feed/data/models/who_can_reply_settings_option.c.dart';
 import 'package:ion/app/features/feed/polls/models/poll_data.c.dart';
 import 'package:ion/app/features/feed/providers/counters/replies_count_provider.c.dart';
@@ -87,6 +88,9 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       final mentions = _buildMentions(postContent);
 
       final parentQuotedTopics = _getTopicsFromParentAndQuoted(parentEntity, quotedEntity);
+      if (topics.isEmpty && parentQuotedTopics.isEmpty) {
+        topics.add(FeedInterests.unclassified);
+      }
       final relatedHashtags = {
         ...topics.map((topic) => RelatedHashtag(value: topic)),
         ...parentQuotedTopics.map((topic) => RelatedHashtag(value: topic)),
@@ -162,6 +166,11 @@ class CreatePostNotifier extends _$CreatePostNotifier {
       final (:files, :media) = await _uploadMediaFiles(mediaFiles: mediaFiles);
       final modifiedMedia = Map<String, MediaAttachment>.from(mediaAttachments)..addAll(media);
 
+      if (topics.contains(FeedInterests.unclassified) && topics.length > 1) {
+        topics.remove(FeedInterests.unclassified);
+      } else if (topics.isEmpty) {
+        topics.add(FeedInterests.unclassified);
+      }
       final relatedHashtags = [
         ...topics.map((topic) => RelatedHashtag(value: topic)),
         ...extractTags(postContent).map((tag) => RelatedHashtag(value: tag)),


### PR DESCRIPTION
## Description
This PR adds a support for `unclassified` topics, which is automatically added to posts/article when no other topics are selected.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
