### PR TITLE
fix: decrease login input field bottom scroll padding

### DIFF
--- a/lib/app/features/auth/views/pages/get_started/components/login_form.dart
+++ b/lib/app/features/auth/views/pages/get_started/components/login_form.dart
@@ -38,7 +38,7 @@ class LoginForm extends HookConsumerWidget {
               _ => loginActionState.error?.toString()
             },
             controller: identityKeyNameController,
-            scrollPadding: EdgeInsetsDirectional.only(bottom: 190.0.s),
+            scrollPadding: EdgeInsetsDirectional.only(bottom: 88.0.s),
             onFocused: (focused) {
               final isIdentityKeyNameEmpty = identityKeyNameController.text.isEmpty;
               if (!focused || !isIdentityKeyNameEmpty) {


### PR DESCRIPTION
## Description
This PR fixes the amount of space login modal scrolls up when keyboard is shown, to ensure that only identity key name and continue button are visible.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
