### PR TITLE
fix: correctly change available topics based on post/video type

### DIFF
--- a/lib/app/features/feed/create_post/views/components/topics/topics_button.dart
+++ b/lib/app/features/feed/create_post/views/components/topics/topics_button.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -46,6 +47,27 @@ class TopicsButton extends HookConsumerWidget {
         });
       },
       [topicsTooltipVisible],
+    );
+
+    useEffect(
+      () {
+        if (availableSubcategories.isEmpty || selectedSubcategories.isEmpty) return null;
+        final selectedSubcategoriesKeysSet = selectedSubcategoriesKeys.toSet();
+        final selectedAvailableSubcategoriesKeys =
+            selectedSubcategoriesKeysSet.intersection({...availableSubcategories.keys});
+        final setsAreEqual = const SetEquality<String>().equals(
+          selectedAvailableSubcategoriesKeys,
+          selectedSubcategoriesKeysSet,
+        );
+        if (!setsAreEqual) {
+          WidgetsBinding.instance.addPostFrameCallback(
+            (_) => ref.read(selectedInterestsNotifierProvider.notifier).selectInterests =
+                selectedAvailableSubcategoriesKeys.toList(),
+          );
+        }
+        return null;
+      },
+      [availableSubcategories],
     );
 
     return ShowcaseWrapper(

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_content.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/create_post_content.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/components/text_editor/text_editor.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/feed/create_post/model/create_post_option.dart';
 import 'package:ion/app/features/feed/create_post/views/components/reply_input_field/attached_media_preview.dart';
 import 'package:ion/app/features/feed/create_post/views/components/topics/topics_button.dart';
@@ -58,7 +59,9 @@ class CreatePostContent extends StatelessWidget {
           children: [
             _VideoPreviewSection(attachedVideoNotifier: attachedVideoNotifier),
             _TopicsSection(
+              attachedMediaNotifier: attachedMediaNotifier,
               attachedVideoNotifier: attachedVideoNotifier,
+              attachedMediaLinksNotifier: attachedMediaLinksNotifier,
               parentEvent: parentEvent,
               quotedEvent: quotedEvent,
             ),
@@ -239,12 +242,16 @@ class _QuotedEntitySection extends StatelessWidget {
 
 class _TopicsSection extends HookConsumerWidget {
   const _TopicsSection({
+    required this.attachedMediaNotifier,
     required this.attachedVideoNotifier,
+    required this.attachedMediaLinksNotifier,
     required this.parentEvent,
     required this.quotedEvent,
   });
 
+  final AttachedMediaNotifier attachedMediaNotifier;
   final ValueNotifier<MediaFile?> attachedVideoNotifier;
+  final AttachedMediaLinksNotifier attachedMediaLinksNotifier;
   final EventReference? parentEvent;
   final EventReference? quotedEvent;
 
@@ -255,7 +262,18 @@ class _TopicsSection extends HookConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final isVideo = attachedVideoNotifier.value != null;
+    final isAnyMediaVideo = attachedMediaNotifier.value.any(
+      (media) {
+        final mediaType = MediaType.fromMimeType(media.mimeType.emptyOrValue);
+        return mediaType == MediaType.video;
+      },
+    );
+    final isAnyMediaLinkVideo = attachedMediaLinksNotifier.value.values.any(
+      (mediaLink) {
+        return mediaLink.mediaType == MediaType.video;
+      },
+    );
+    final isVideo = attachedVideoNotifier.value != null || isAnyMediaVideo || isAnyMediaLinkVideo;
 
     return ScreenSideOffset.small(
       child: Padding(


### PR DESCRIPTION
## Description
This PR improves a logic to detect wether or not post is a video post or not and update topics list based on that.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
