### PR TITLE
fix: close the Manage coins page after token import

### DIFF
--- a/lib/app/features/wallets/views/pages/import_token_page/import_token_page.dart
+++ b/lib/app/features/wallets/views/pages/import_token_page/import_token_page.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/components/progress_bar/ion_loading_indicator.dart';
@@ -12,6 +13,7 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/views/pages/import_token_page/components/import_token_form.dart';
 import 'package:ion/app/features/wallets/views/pages/import_token_page/components/security_risks.dart';
 import 'package:ion/app/features/wallets/views/pages/import_token_page/providers/import_token_notifier_provider.c.dart';
+import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -77,7 +79,7 @@ class ImportTokenPage extends HookConsumerWidget {
 
   void _onTokenImported(BuildContext context) {
     if (context.mounted) {
-      Navigator.of(context).pop();
+      context.go(WalletRoute().location);
     }
   }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Demo
https://github.com/user-attachments/assets/1c613389-0c62-476f-a858-70a6580a186f

