### PR TITLE
revert: pull to refresh indicator size

### DIFF
--- a/lib/app/components/scroll_view/ion_pull_to_refresh_loading_indicator.dart
+++ b/lib/app/components/scroll_view/ion_pull_to_refresh_loading_indicator.dart
@@ -41,7 +41,7 @@ class IonPullToRefreshLoadingIndicator extends StatelessWidget {
             opacity: isRefreshing ? 1 : percentageComplete,
             child: IONLoadingIndicatorThemed(
               value: shouldAnimate ? null : percentageComplete,
-              size: Size.square(20.0.s),
+              size: Size.square(30.s),
             ),
           ),
         ),


### PR DESCRIPTION
## Description
This PR reverts [this PR](https://github.com/ice-blockchain/ion-app/pull/1350) related to pull to refresh indicator size.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
