### PR TITLE
feat: user metadata from database

### DIFF
--- a/lib/app/features/chat/components/messaging_header/one_to_one_messaging_header.dart
+++ b/lib/app/features/chat/components/messaging_header/one_to_one_messaging_header.dart
@@ -4,33 +4,26 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/avatar/avatar.dart';
 import 'package:ion/app/components/avatar/story_colored_profile_avatar.dart';
+import 'package:ion/app/components/skeleton/container_skeleton.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/providers/muted_conversations_provider.c.dart';
 import 'package:ion/app/features/chat/views/components/message_items/messages_context_menu/one_to_one_messages_context_menu.dart';
 import 'package:ion/app/features/user/providers/badges_notifier.c.dart';
+import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:ion/app/features/user_block/providers/block_list_notifier.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart';
+import 'package:ion/app/router/app_routes.c.dart';
+import 'package:ion/app/utils/username.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class OneToOneMessagingHeader extends ConsumerWidget {
   const OneToOneMessagingHeader({
-    required this.name,
-    required this.subtitle,
     required this.conversationId,
     required this.receiverMasterPubkey,
-    this.imageUrl,
-    this.imageWidget,
-    this.onTap,
-    this.onToggleMute,
     super.key,
   });
 
-  final String name;
-
-  final Widget subtitle;
-  final String? imageUrl;
-  final Widget? imageWidget;
   final String conversationId;
-  final GestureTapCallback? onTap;
-  final VoidCallback? onToggleMute;
   final String receiverMasterPubkey;
 
   @override
@@ -42,6 +35,28 @@ class OneToOneMessagingHeader extends ConsumerWidget {
     final isVerified = ref.watch(isUserVerifiedProvider(receiverMasterPubkey)).valueOrNull ?? false;
     final isNicknameProven =
         ref.watch(isNicknameProvenProvider(receiverMasterPubkey)).valueOrNull ?? true;
+    final isDeleted = ref.watch(isUserDeletedProvider(receiverMasterPubkey)).valueOrNull ?? false;
+
+    final userMetadata = ref.watch(userMetadataFromDbNotifierProvider(receiverMasterPubkey))?.data;
+
+    // Show skeleton while loading user data (unless deleted)
+    if ((userMetadata == null) && !isDeleted) {
+      return const _HeaderSkeleton();
+    }
+
+    final receiverPicture = isDeleted ? null : userMetadata?.picture;
+    final receiverName = userMetadata?.name;
+    final receiverDisplayName = userMetadata?.displayName;
+
+    final subtitle = Text(
+      prefixUsername(
+        context: context,
+        username: receiverName,
+      ),
+      style: context.theme.appTextThemes.caption.copyWith(
+        color: context.theme.appColors.quaternaryText,
+      ),
+    );
 
     return Padding(
       padding: EdgeInsetsDirectional.fromSTEB(16.0.s, 8.0.s, 16.0.s, 12.0.s),
@@ -57,7 +72,7 @@ class OneToOneMessagingHeader extends ConsumerWidget {
           SizedBox(width: 12.0.s),
           Expanded(
             child: GestureDetector(
-              onTap: onTap,
+              onTap: () => ProfileRoute(pubkey: receiverMasterPubkey).push<void>(context),
               child: Row(
                 children: [
                   if (isBlockedBy)
@@ -66,9 +81,8 @@ class OneToOneMessagingHeader extends ConsumerWidget {
                     StoryColoredProfileAvatar(
                       pubkey: receiverMasterPubkey,
                       size: 36.0.s,
-                      imageUrl: imageUrl,
-                      imageWidget: imageWidget,
                       useRandomGradient: true,
+                      imageUrl: (!isBlockedBy && !isDeleted) ? receiverPicture : null,
                     ),
                   SizedBox(width: 10.0.s),
                   Expanded(
@@ -79,10 +93,12 @@ class OneToOneMessagingHeader extends ConsumerWidget {
                           children: [
                             Flexible(
                               child: Text(
-                                name,
-                                style: context.theme.appTextThemes.subtitle3,
-                                overflow: TextOverflow.ellipsis,
+                                isDeleted
+                                    ? context.i18n.common_deleted_account
+                                    : receiverDisplayName ?? '',
                                 maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: context.theme.appTextThemes.subtitle3,
                               ),
                             ),
                             if (isVerified) ...[
@@ -112,9 +128,59 @@ class OneToOneMessagingHeader extends ConsumerWidget {
           ),
           OneToOneMessagingContextMenu(
             isBlocked: isBlocked,
-            onToggleMute: onToggleMute,
+            onToggleMute: () {
+              ref
+                  .read(mutedConversationsProvider.notifier)
+                  .toggleMutedMasterPubkey(receiverMasterPubkey);
+            },
             conversationId: conversationId,
             receiverMasterPubkey: receiverMasterPubkey,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeaderSkeleton extends StatelessWidget {
+  const _HeaderSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsetsDirectional.fromSTEB(16.0.s, 8.0.s, 16.0.s, 12.0.s),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: Assets.svg.iconChatBack.icon(
+              size: 24.0.s,
+              flipForRtl: true,
+            ),
+          ),
+          SizedBox(width: 12.0.s),
+          ContainerSkeleton(
+            height: 36.0.s,
+            width: 36.0.s,
+          ),
+          SizedBox(width: 10.0.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ContainerSkeleton(
+                  height: context.theme.appTextThemes.subtitle3.fontSize!.s,
+                  width: 120.0.s,
+                  skeletonBaseColor: context.theme.appColors.onTerararyFill,
+                ),
+                SizedBox(height: 4.0.s),
+                ContainerSkeleton(
+                  height: context.theme.appTextThemes.subtitle3.fontSize!.s,
+                  width: 150.0.s,
+                  skeletonBaseColor: context.theme.appColors.onTerararyFill,
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/app/features/chat/e2ee/providers/encrypted_deletion_request_handler.c.dart
+++ b/lib/app/features/chat/e2ee/providers/encrypted_deletion_request_handler.c.dart
@@ -15,6 +15,7 @@ import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
 import 'package:ion/app/features/ion_connect/model/global_subscription_encrypted_event_message_handler.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.c.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_event_signer_provider.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'encrypted_deletion_request_handler.c.g.dart';
@@ -28,12 +29,15 @@ class EncryptedDeletionRequestHandler extends GlobalSubscriptionEncryptedEventMe
     this.env,
     this.masterPubkey,
     this.eventSigner,
+    this.userMetadataSyncProvider,
   );
 
   final ConversationMessageDao conversationMessageDao;
   final ConversationMessageReactionDao conversationMessageReactionDao;
   final ConversationDao conversationDao;
   final EventMessageDao eventMessageDao;
+  final UserMetadataSync userMetadataSyncProvider;
+
   final Env env;
   final String masterPubkey;
   final EventSigner eventSigner;
@@ -49,6 +53,7 @@ class EncryptedDeletionRequestHandler extends GlobalSubscriptionEncryptedEventMe
   Future<void> handle(EventMessage rumor) async {
     unawaited(_deleteConversation(rumor));
     unawaited(_deleteConversationMessages(rumor));
+    unawaited(userMetadataSyncProvider.syncUserMetadata(masterPubkeys: {rumor.masterPubkey}));
   }
 
   Future<void> _deleteConversation(EventMessage rumor) async {
@@ -114,5 +119,6 @@ Future<EncryptedDeletionRequestHandler?> encryptedDeletionRequestHandler(Ref ref
     ref.watch(envProvider.notifier),
     masterPubkey,
     eventSigner,
+    ref.watch(userMetadataSyncProvider.notifier),
   );
 }

--- a/lib/app/features/chat/e2ee/providers/encrypted_direct_message_handler.c.dart
+++ b/lib/app/features/chat/e2ee/providers/encrypted_direct_message_handler.c.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/global_subscription_encrypted_event_message_handler.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart';
 import 'package:ion/app/services/media_service/media_encryption_service.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -25,6 +26,7 @@ class EncryptedDirectMessageHandler extends GlobalSubscriptionEncryptedEventMess
     this.messageMediaDao,
     this.sendE2eeMessageStatusService,
     this.mediaEncryptionService,
+    this.userMetadataSyncProvider,
   );
 
   final String masterPubkey;
@@ -34,6 +36,7 @@ class EncryptedDirectMessageHandler extends GlobalSubscriptionEncryptedEventMess
   final MessageMediaDao messageMediaDao;
   final SendE2eeMessageStatusService sendE2eeMessageStatusService;
   final MediaEncryptionService mediaEncryptionService;
+  final UserMetadataSync userMetadataSyncProvider;
 
   @override
   bool canHandle({
@@ -46,6 +49,7 @@ class EncryptedDirectMessageHandler extends GlobalSubscriptionEncryptedEventMess
   Future<void> handle(EventMessage rumor) async {
     await _addDirectMessageToDatabase(rumor);
     unawaited(_sendReceivedStatus(rumor));
+    unawaited(userMetadataSyncProvider.syncUserMetadata(masterPubkeys: {rumor.masterPubkey}));
   }
 
   Future<void> _addDirectMessageToDatabase(
@@ -130,5 +134,6 @@ Future<EncryptedDirectMessageHandler?> encryptedDirectMessageHandler(Ref ref) as
     ref.watch(messageMediaDaoProvider),
     await ref.watch(sendE2eeMessageStatusServiceProvider.future),
     ref.watch(mediaEncryptionServiceProvider),
+    ref.watch(userMetadataSyncProvider.notifier),
   );
 }

--- a/lib/app/features/chat/e2ee/providers/encrypted_direct_message_reaction_handler.c.dart
+++ b/lib/app/features/chat/e2ee/providers/encrypted_direct_message_reaction_handler.c.dart
@@ -9,18 +9,18 @@ import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/global_subscription_encrypted_event_message_handler.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_gift_wrap.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'encrypted_direct_message_reaction_handler.c.g.dart';
 
 class EncryptedDirectMessageReactionHandler extends GlobalSubscriptionEncryptedEventMessageHandler {
   EncryptedDirectMessageReactionHandler(
-    this.conversationMessageReactionDao,
-    this.eventMessageDao,
-  );
+      this.conversationMessageReactionDao, this.eventMessageDao, this.userMetadataSyncProvider);
 
   final ConversationMessageReactionDao conversationMessageReactionDao;
   final EventMessageDao eventMessageDao;
+  final UserMetadataSync userMetadataSyncProvider;
 
   @override
   bool canHandle({
@@ -34,6 +34,7 @@ class EncryptedDirectMessageReactionHandler extends GlobalSubscriptionEncryptedE
 
   @override
   Future<void> handle(EventMessage rumor) async {
+    unawaited(userMetadataSyncProvider.syncUserMetadata(masterPubkeys: {rumor.masterPubkey}));
     await conversationMessageReactionDao.add(
       reactionEvent: rumor,
       eventMessageDao: eventMessageDao,
@@ -43,7 +44,5 @@ class EncryptedDirectMessageReactionHandler extends GlobalSubscriptionEncryptedE
 
 @riverpod
 EncryptedDirectMessageReactionHandler encryptedDirectMessageReactionHandler(Ref ref) =>
-    EncryptedDirectMessageReactionHandler(
-      ref.watch(conversationMessageReactionDaoProvider),
-      ref.watch(eventMessageDaoProvider),
-    );
+    EncryptedDirectMessageReactionHandler(ref.watch(conversationMessageReactionDaoProvider),
+        ref.watch(eventMessageDaoProvider), ref.watch(userMetadataSyncProvider.notifier));

--- a/lib/app/features/chat/e2ee/providers/encrypted_direct_message_reaction_handler.c.dart
+++ b/lib/app/features/chat/e2ee/providers/encrypted_direct_message_reaction_handler.c.dart
@@ -16,7 +16,10 @@ part 'encrypted_direct_message_reaction_handler.c.g.dart';
 
 class EncryptedDirectMessageReactionHandler extends GlobalSubscriptionEncryptedEventMessageHandler {
   EncryptedDirectMessageReactionHandler(
-      this.conversationMessageReactionDao, this.eventMessageDao, this.userMetadataSyncProvider);
+    this.conversationMessageReactionDao,
+    this.eventMessageDao,
+    this.userMetadataSyncProvider,
+  );
 
   final ConversationMessageReactionDao conversationMessageReactionDao;
   final EventMessageDao eventMessageDao;
@@ -44,5 +47,8 @@ class EncryptedDirectMessageReactionHandler extends GlobalSubscriptionEncryptedE
 
 @riverpod
 EncryptedDirectMessageReactionHandler encryptedDirectMessageReactionHandler(Ref ref) =>
-    EncryptedDirectMessageReactionHandler(ref.watch(conversationMessageReactionDaoProvider),
-        ref.watch(eventMessageDaoProvider), ref.watch(userMetadataSyncProvider.notifier));
+    EncryptedDirectMessageReactionHandler(
+      ref.watch(conversationMessageReactionDaoProvider),
+      ref.watch(eventMessageDaoProvider),
+      ref.watch(userMetadataSyncProvider.notifier),
+    );

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -19,7 +19,7 @@ import 'package:ion/app/features/chat/recent_chats/providers/selected_reply_mess
 import 'package:ion/app/features/chat/views/components/message_items/edit_message_info/edit_message_info.dart';
 import 'package:ion/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar.dart';
 import 'package:ion/app/features/chat/views/components/message_items/replied_message_info/replied_message_info.dart';
-import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:ion/app/utils/username.dart';
@@ -110,22 +110,23 @@ class _Header extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final receiverUserMetadata = ref.watch(userMetadataProvider(receiverMasterPubkey));
+    final receiverUserMetadata =
+        ref.watch(userMetadataFromDbNotifierProvider(receiverMasterPubkey));
 
-    if (receiverUserMetadata.isLoading) {
+    if (receiverUserMetadata == null) {
       return const SizedBox.shrink();
     }
 
     return OneToOneMessagingHeader(
       conversationId: conversationId,
-      imageUrl: receiverUserMetadata.valueOrNull?.data.picture,
+      imageUrl: receiverUserMetadata.data.picture,
       name:
-          receiverUserMetadata.valueOrNull?.data.displayName ?? context.i18n.common_deleted_account,
+          receiverUserMetadata.data.displayName,
       receiverMasterPubkey: receiverMasterPubkey,
       onTap: () => ProfileRoute(pubkey: receiverMasterPubkey).push<void>(context),
       subtitle: Text(
         prefixUsername(
-          username: receiverUserMetadata.valueOrNull?.data.name ?? '',
+          username: receiverUserMetadata.data.name,
           context: context,
         ),
         style: context.theme.appTextThemes.caption.copyWith(

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/components/skeleton/container_skeleton.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
@@ -27,6 +28,7 @@ import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:ion/app/utils/username.dart';
+import 'package:ion/generated/assets.gen.dart';
 
 class OneToOneMessagesPage extends HookConsumerWidget {
   const OneToOneMessagesPage({
@@ -122,23 +124,33 @@ class _Header extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final receiverUserMetadata =
-        ref.watch(userMetadataFromDbNotifierProvider(receiverMasterPubkey));
+    final receiverPicture = ref.watch(
+      userMetadataFromDbNotifierProvider(receiverMasterPubkey).select((data) => data?.data.picture),
+    );
 
-    if (receiverUserMetadata == null) {
-      return const SizedBox.shrink();
+    final receiverName = ref.watch(
+      userMetadataFromDbNotifierProvider(receiverMasterPubkey).select((data) => data?.data.name),
+    );
+
+    final receiverDisplayName = ref.watch(
+      userMetadataFromDbNotifierProvider(receiverMasterPubkey)
+          .select((data) => data?.data.displayName),
+    );
+
+    if (receiverName == null || receiverDisplayName == null) {
+      return const _HeaderSkeleton();
     }
 
     return OneToOneMessagingHeader(
       conversationId: conversationId,
-      imageUrl: receiverUserMetadata.data.picture,
-      name: receiverUserMetadata.data.displayName,
+      imageUrl: receiverPicture,
+      name: receiverDisplayName,
       receiverMasterPubkey: receiverMasterPubkey,
       onTap: () => ProfileRoute(pubkey: receiverMasterPubkey).push<void>(context),
       subtitle: Text(
         prefixUsername(
-          username: receiverUserMetadata.data.name,
           context: context,
+          username: receiverName,
         ),
         style: context.theme.appTextThemes.caption.copyWith(
           color: context.theme.appColors.quaternaryText,
@@ -147,6 +159,53 @@ class _Header extends HookConsumerWidget {
       onToggleMute: () {
         ref.read(mutedConversationsProvider.notifier).toggleMutedMasterPubkey(receiverMasterPubkey);
       },
+    );
+  }
+}
+
+class _HeaderSkeleton extends StatelessWidget {
+  const _HeaderSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsetsDirectional.fromSTEB(16.0.s, 8.0.s, 16.0.s, 12.0.s),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: Assets.svg.iconChatBack.icon(
+              size: 24.0.s,
+              flipForRtl: true,
+            ),
+          ),
+          SizedBox(width: 12.0.s),
+          ContainerSkeleton(
+            height: 36.0.s,
+            width: 36.0.s,
+            skeletonBaseColor: context.theme.appColors.onTerararyFill,
+          ),
+          SizedBox(width: 10.0.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ContainerSkeleton(
+                  height: context.theme.appTextThemes.subtitle3.fontSize!.s,
+                  width: 120.0.s,
+                  skeletonBaseColor: context.theme.appColors.onTerararyFill,
+                ),
+                SizedBox(height: 4.0.s),
+                ContainerSkeleton(
+                  height: context.theme.appTextThemes.subtitle3.fontSize!.s,
+                  width: 150.0.s,
+                  skeletonBaseColor: context.theme.appColors.onTerararyFill,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -120,8 +120,7 @@ class _Header extends HookConsumerWidget {
     return OneToOneMessagingHeader(
       conversationId: conversationId,
       imageUrl: receiverUserMetadata.data.picture,
-      name:
-          receiverUserMetadata.data.displayName,
+      name: receiverUserMetadata.data.displayName,
       receiverMasterPubkey: receiverMasterPubkey,
       onTap: () => ProfileRoute(pubkey: receiverMasterPubkey).push<void>(context),
       subtitle: Text(

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/components/skeleton/container_skeleton.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
@@ -16,19 +15,14 @@ import 'package:ion/app/features/chat/e2ee/views/components/one_to_one_messages_
 import 'package:ion/app/features/chat/model/database/chat_database.c.dart';
 import 'package:ion/app/features/chat/providers/conversation_messages_provider.c.dart';
 import 'package:ion/app/features/chat/providers/exist_chat_conversation_id_provider.c.dart';
-import 'package:ion/app/features/chat/providers/muted_conversations_provider.c.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/selected_edit_message_provider.c.dart';
 import 'package:ion/app/features/chat/recent_chats/providers/selected_reply_message_provider.c.dart';
 import 'package:ion/app/features/chat/views/components/message_items/edit_message_info/edit_message_info.dart';
 import 'package:ion/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar.dart';
 import 'package:ion/app/features/chat/views/components/message_items/replied_message_info/replied_message_info.dart';
-import 'package:ion/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart';
 import 'package:ion/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
-import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
-import 'package:ion/app/utils/username.dart';
-import 'package:ion/generated/assets.gen.dart';
 
 class OneToOneMessagesPage extends HookConsumerWidget {
   const OneToOneMessagesPage({
@@ -124,88 +118,9 @@ class _Header extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final receiverPicture = ref.watch(
-      userMetadataFromDbNotifierProvider(receiverMasterPubkey).select((data) => data?.data.picture),
-    );
-
-    final receiverName = ref.watch(
-      userMetadataFromDbNotifierProvider(receiverMasterPubkey).select((data) => data?.data.name),
-    );
-
-    final receiverDisplayName = ref.watch(
-      userMetadataFromDbNotifierProvider(receiverMasterPubkey)
-          .select((data) => data?.data.displayName),
-    );
-
-    if (receiverName == null || receiverDisplayName == null) {
-      return const _HeaderSkeleton();
-    }
-
     return OneToOneMessagingHeader(
       conversationId: conversationId,
-      imageUrl: receiverPicture,
-      name: receiverDisplayName,
       receiverMasterPubkey: receiverMasterPubkey,
-      onTap: () => ProfileRoute(pubkey: receiverMasterPubkey).push<void>(context),
-      subtitle: Text(
-        prefixUsername(
-          context: context,
-          username: receiverName,
-        ),
-        style: context.theme.appTextThemes.caption.copyWith(
-          color: context.theme.appColors.quaternaryText,
-        ),
-      ),
-      onToggleMute: () {
-        ref.read(mutedConversationsProvider.notifier).toggleMutedMasterPubkey(receiverMasterPubkey);
-      },
-    );
-  }
-}
-
-class _HeaderSkeleton extends StatelessWidget {
-  const _HeaderSkeleton();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsetsDirectional.fromSTEB(16.0.s, 8.0.s, 16.0.s, 12.0.s),
-      child: Row(
-        children: [
-          GestureDetector(
-            onTap: () => Navigator.pop(context),
-            child: Assets.svg.iconChatBack.icon(
-              size: 24.0.s,
-              flipForRtl: true,
-            ),
-          ),
-          SizedBox(width: 12.0.s),
-          ContainerSkeleton(
-            height: 36.0.s,
-            width: 36.0.s,
-            skeletonBaseColor: context.theme.appColors.onTerararyFill,
-          ),
-          SizedBox(width: 10.0.s),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ContainerSkeleton(
-                  height: context.theme.appTextThemes.subtitle3.fontSize!.s,
-                  width: 120.0.s,
-                  skeletonBaseColor: context.theme.appColors.onTerararyFill,
-                ),
-                SizedBox(height: 4.0.s),
-                ContainerSkeleton(
-                  height: context.theme.appTextThemes.subtitle3.fontSize!.s,
-                  width: 150.0.s,
-                  skeletonBaseColor: context.theme.appColors.onTerararyFill,
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -20,6 +22,8 @@ import 'package:ion/app/features/chat/views/components/message_items/edit_messag
 import 'package:ion/app/features/chat/views/components/message_items/messaging_bottom_bar/messaging_bottom_bar.dart';
 import 'package:ion/app/features/chat/views/components/message_items/replied_message_info/replied_message_info.dart';
 import 'package:ion/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/app/services/media_service/media_service.c.dart';
 import 'package:ion/app/utils/username.dart';
@@ -35,6 +39,14 @@ class OneToOneMessagesPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final conversationId = useState<String?>(null);
+
+    useOnInit(() {
+      unawaited(
+        ref
+            .read(userMetadataSyncProvider.notifier)
+            .syncUserMetadata(masterPubkeys: {receiverMasterPubkey}),
+      );
+    });
 
     useEffect(
       () {

--- a/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
+++ b/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
@@ -20,6 +20,7 @@ import 'package:ion/app/features/chat/views/components/message_items/message_typ
 import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:ion/app/features/user_block/providers/block_list_notifier.c.dart';
+import 'package:ion/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart';
 import 'package:ion/app/utils/date.dart';
 import 'package:ion/generated/assets.gen.dart';
 
@@ -247,9 +248,9 @@ class SenderSummary extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(userMetadataProvider(pubkey)).valueOrNull?.data;
+    final userMetadata = ref.watch(userMetadataFromDbNotifierProvider(pubkey));
 
-    if (user == null) {
+    if (userMetadata == null) {
       return const SizedBox.shrink();
     }
 
@@ -272,7 +273,7 @@ class SenderSummary extends ConsumerWidget {
             ),
           ),
         Text(
-          isEdit ? context.i18n.button_edit : user.name,
+          isEdit ? context.i18n.button_edit : userMetadata.data.name,
           style: context.theme.appTextThemes.subtitle3.copyWith(
             color: textColor ?? context.theme.appColors.primaryText,
           ),

--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -252,7 +252,7 @@ class E2eeRecentChatTile extends HookConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final cachedUserMetadata = ref.watch(userMetadataFromDbNotifierProvider(receiverMasterPubkey));
+    final userMetadata = ref.watch(userMetadataFromDbNotifierProvider(receiverMasterPubkey));
 
     final unreadMessagesCount =
         ref.watch(getUnreadMessagesCountProvider(conversation.conversationId));
@@ -264,10 +264,11 @@ class E2eeRecentChatTile extends HookConsumerWidget {
     final isUserVerified =
         ref.watch(isUserVerifiedProvider(receiverMasterPubkey)).valueOrNull.falseOrValue;
 
+
     final isDeleted =
         ref.watch(isUserDeletedProvider(receiverMasterPubkey)).valueOrNull.falseOrValue;
 
-    if (cachedUserMetadata == null && !isDeleted) {
+    if (userMetadata == null && !isDeleted) {
       return const RecentChatSkeletonItem();
     }
 
@@ -275,10 +276,8 @@ class E2eeRecentChatTile extends HookConsumerWidget {
       defaultAvatar: null,
       conversation: conversation,
       messageType: entity.messageType,
-      name: isDeleted
-          ? context.i18n.common_deleted_account
-          : cachedUserMetadata?.data.displayName ?? '',
-      avatarUrl: isDeleted ? null : cachedUserMetadata?.data.picture,
+      name: isDeleted ? context.i18n.common_deleted_account : userMetadata?.data.displayName ?? '',
+      avatarUrl: isDeleted ? null : userMetadata?.data.picture,
       eventReference: eventReference,
       unreadMessagesCount: unreadMessagesCount.valueOrNull ?? 0,
       lastMessageContent: conversation.latestMessage?.content ?? '',

--- a/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
+++ b/lib/app/features/chat/recent_chats/views/pages/recent_chats_timeline_page/recent_chats_timeline_page.dart
@@ -264,7 +264,6 @@ class E2eeRecentChatTile extends HookConsumerWidget {
     final isUserVerified =
         ref.watch(isUserVerifiedProvider(receiverMasterPubkey)).valueOrNull.falseOrValue;
 
-
     final isDeleted =
         ref.watch(isUserDeletedProvider(receiverMasterPubkey)).valueOrNull.falseOrValue;
 

--- a/lib/app/features/chat/views/pages/conversation_page/conversation_page.dart
+++ b/lib/app/features/chat/views/pages/conversation_page/conversation_page.dart
@@ -13,17 +13,18 @@ class ConversationPage extends HookConsumerWidget {
   const ConversationPage({
     super.key,
     this.conversationId,
-    this.receiverPubKey,
+    this.receiverMasterPubkey,
   });
 
   final String? conversationId;
-  final String? receiverPubKey;
+  final String? receiverMasterPubkey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final conversationType = ref.watch(conversationTypeProvider(conversationId, receiverPubKey));
+    final conversationType =
+        ref.watch(conversationTypeProvider(conversationId, receiverMasterPubkey));
 
-    ref.displayErrors(conversationTypeProvider(conversationId, receiverPubKey));
+    ref.displayErrors(conversationTypeProvider(conversationId, receiverMasterPubkey));
 
     return conversationType.maybeWhen(
       data: (conversationType) {
@@ -34,7 +35,7 @@ class ConversationPage extends HookConsumerWidget {
             return ChannelMessagingPage(communityId: conversationId!);
           case ConversationType.oneToOne:
             return OneToOneMessagesPage(
-              receiverMasterPubkey: receiverPubKey!,
+              receiverMasterPubkey: receiverMasterPubkey!,
             );
         }
       },

--- a/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
+++ b/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
@@ -25,7 +25,7 @@ class NewChatModal extends HookConsumerWidget {
       (UserMetadataEntity user) async {
         if (context.mounted) {
           context.replace(
-            ConversationRoute(receiverPubKey: user.masterPubkey).location,
+            ConversationRoute(receiverMasterPubkey: user.masterPubkey).location,
           );
         }
       },

--- a/lib/app/features/core/providers/env_provider.c.dart
+++ b/lib/app/features/core/providers/env_provider.c.dart
@@ -15,6 +15,7 @@ enum EnvVariable {
   BANUBA_TOKEN,
   STORY_EXPIRATION_HOURS,
   EDIT_POST_ALLOWED_MINUTES,
+  USER_METADATA_SYNC_MINUTES,
   EDIT_MESSAGE_ALLOWED_MINUTES,
   COMMUNITY_CREATION_CACHE_MINUTES,
   COMMUNITY_MEMBERS_COUNT_CACHE_MINUTES,
@@ -52,6 +53,8 @@ class Env extends _$Env {
       EnvVariable.USER_SEARCH_RELAY => const String.fromEnvironment('USER_SEARCH_RELAY') as T,
       EnvVariable.STORY_EXPIRATION_HOURS =>
         const int.fromEnvironment('STORY_EXPIRATION_HOURS') as T,
+      EnvVariable.USER_METADATA_SYNC_MINUTES =>
+        const int.fromEnvironment('USER_METADATA_SYNC_MINUTES') as T,
       EnvVariable.EDIT_POST_ALLOWED_MINUTES =>
         const int.fromEnvironment('EDIT_POST_ALLOWED_MINUTES') as T,
       EnvVariable.EDIT_MESSAGE_ALLOWED_MINUTES =>

--- a/lib/app/features/feed/providers/feed_user_interest_picker_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_user_interest_picker_provider.c.dart
@@ -146,6 +146,7 @@ typedef InterestedItems<T extends CategoryWithWeight> = ({
 
 @riverpod
 Future<FeedUserInterestPicker> feedUserInterestPicker(Ref ref, FeedType feedType) async {
+  await Future.delayed(const Duration(hours: 3));
   final interests = await ref.watch(feedUserInterestsProvider(feedType).future);
   final config = await ref.watch(feedConfigProvider.future);
   final random = Random();

--- a/lib/app/features/feed/providers/feed_user_interest_picker_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_user_interest_picker_provider.c.dart
@@ -146,7 +146,6 @@ typedef InterestedItems<T extends CategoryWithWeight> = ({
 
 @riverpod
 Future<FeedUserInterestPicker> feedUserInterestPicker(Ref ref, FeedType feedType) async {
-  await Future.delayed(const Duration(hours: 3));
   final interests = await ref.watch(feedUserInterestsProvider(feedType).future);
   final config = await ref.watch(feedConfigProvider.future);
   final random = Random();

--- a/lib/app/features/ion_connect/providers/ion_connect_entity_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_entity_provider.c.dart
@@ -90,7 +90,7 @@ Future<IonConnectEntity?> ionConnectEntity(
   if (currentUser == null) {
     throw const CurrentUserNotFoundException();
   }
-  if (cache) { 
+  if (cache) {
     final entity = ref.watch(ionConnectCachedEntityProvider(eventReference: eventReference));
     if (entity != null) {
       return entity;

--- a/lib/app/features/ion_connect/providers/ion_connect_entity_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_entity_provider.c.dart
@@ -90,7 +90,7 @@ Future<IonConnectEntity?> ionConnectEntity(
   if (currentUser == null) {
     throw const CurrentUserNotFoundException();
   }
-  if (cache) {
+  if (cache) { 
     final entity = ref.watch(ionConnectCachedEntityProvider(eventReference: eventReference));
     if (entity != null) {
       return entity;

--- a/lib/app/features/push_notifications/providers/notification_response_handler.c.dart
+++ b/lib/app/features/push_notifications/providers/notification_response_handler.c.dart
@@ -113,6 +113,7 @@ class NotificationResponseHandler extends _$NotificationResponseHandler {
   }
 
   Future<void> _openChat(String pubkey) async {
-    await ConversationRoute(receiverPubKey: pubkey).push<void>(rootNavigatorKey.currentContext!);
+    await ConversationRoute(receiverMasterPubkey: pubkey)
+        .push<void>(rootNavigatorKey.currentContext!);
   }
 }

--- a/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
+++ b/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
@@ -40,7 +40,7 @@ class ChatSearchResultListItem extends ConsumerWidget {
                       .read(chatSearchHistoryProvider.notifier)
                       .addUserIdToTheHistory(userMetadata.masterPubkey);
                   context.pushReplacement(
-                    ConversationRoute(receiverPubKey: pubkeyAndContent.$1).location,
+                    ConversationRoute(receiverMasterPubkey: pubkeyAndContent.$1).location,
                   );
                 },
                 child: Row(

--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -54,7 +54,7 @@ class ProfileActions extends ConsumerWidget {
         SizedBox(width: 8.0.s),
         ProfileAction(
           onPressed: () {
-            ConversationRoute(receiverPubKey: pubkey).push<void>(context);
+            ConversationRoute(receiverMasterPubkey: pubkey).push<void>(context);
           },
           assetName: Assets.svg.iconChatOff,
         ),

--- a/lib/app/features/user/pages/profile_page/pages/request_coins_form_modal/request_coins_form_modal.dart
+++ b/lib/app/features/user/pages/profile_page/pages/request_coins_form_modal/request_coins_form_modal.dart
@@ -54,7 +54,7 @@ class RequestCoinsFormModal extends HookConsumerWidget {
       ..displayErrors(requestCoinsSubmitNotifierProvider)
       ..listenSuccess(
         requestCoinsSubmitNotifierProvider,
-        (_) => ConversationRoute(receiverPubKey: form.contactPubkey).go(context),
+        (_) => ConversationRoute(receiverMasterPubkey: form.contactPubkey).go(context),
       );
 
     final isLoading = ref.watch(requestCoinsSubmitNotifierProvider).isLoading;

--- a/lib/app/features/user_metadata/database/dao/user_metadata_dao.c.dart
+++ b/lib/app/features/user_metadata/database/dao/user_metadata_dao.c.dart
@@ -57,4 +57,11 @@ class UserMetadataDao extends DatabaseAccessor<UserMetadataDatabase> with _$User
     final userMetadataModels = await query.get();
     return userMetadataModels.map((model) => model.masterPubkey).toSet();
   }
+
+  Future<int> deleteMetadata(List<String> masterPubkeys) async {
+    final query = delete(db.userMetadataTable)
+      ..where((user) => user.masterPubkey.isIn(masterPubkeys));
+
+    return query.go();
+  }
 }

--- a/lib/app/features/user_metadata/database/dao/user_metadata_dao.c.dart
+++ b/lib/app/features/user_metadata/database/dao/user_metadata_dao.c.dart
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:drift/drift.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
+import 'package:ion/app/features/user/model/user_metadata.c.dart';
+import 'package:ion/app/features/user_metadata/database/tables/user_metadata_table.c.dart';
+import 'package:ion/app/features/user_metadata/database/user_metadata_database.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_metadata_dao.c.g.dart';
+
+@riverpod
+UserMetadataDao userMetadataDao(Ref ref) {
+  keepAliveWhenAuthenticated(ref);
+  return UserMetadataDao(db: ref.watch(userMetadataDatabaseProvider));
+}
+
+@DriftAccessor(tables: [UserMetadataTable])
+class UserMetadataDao extends DatabaseAccessor<UserMetadataDatabase> with _$UserMetadataDaoMixin {
+  UserMetadataDao({required UserMetadataDatabase db}) : super(db);
+
+  Future<void> insertAll(List<UserMetadataEntity> usersMetadata) async {
+    final databaseModels = await Future.wait<EventMessageDbModel>(
+      usersMetadata.map((userMetadata) => userMetadata.toEventMessageDbModel()),
+    );
+
+    return batch((batch) {
+      batch.insertAll(db.userMetadataTable, databaseModels, mode: InsertMode.insertOrReplace);
+    });
+  }
+
+  Future<UserMetadataEntity?> get(String masterPubkey) async {
+    final query = select(db.userMetadataTable)
+      ..where((user) => user.masterPubkey.equals(masterPubkey))
+      ..limit(1);
+
+    final model = await query.getSingleOrNull();
+
+    return model == null ? null : UserMetadataEntityExtension.fromEventMessageDbModel(model);
+  }
+
+  Stream<UserMetadataEntity?> watch(String masterPubkey) {
+    final query = select(db.userMetadataTable)
+      ..where((user) => user.masterPubkey.equals(masterPubkey))
+      ..limit(1);
+
+    return query.watchSingleOrNull().map(
+          (model) =>
+              model == null ? null : UserMetadataEntityExtension.fromEventMessageDbModel(model),
+        );
+  }
+
+  Future<Set<String>> getExistingMasterPubkeys() async {
+    final query = select(db.userMetadataTable);
+
+    final userMetadataModels = await query.get();
+    return userMetadataModels.map((model) => model.masterPubkey).toSet();
+  }
+}

--- a/lib/app/features/user_metadata/database/tables/user_metadata_table.c.dart
+++ b/lib/app/features/user_metadata/database/tables/user_metadata_table.c.dart
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:drift/drift.dart';
+import 'package:ion/app/extensions/event_message.dart';
+import 'package:ion/app/features/ion_connect/database/converters/event_reference_converter.c.dart';
+import 'package:ion/app/features/ion_connect/database/converters/event_tags_converter.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/user/model/user_metadata.c.dart';
+import 'package:ion/app/features/user_metadata/database/user_metadata_database.c.dart';
+
+@DataClassName('EventMessageDbModel')
+class UserMetadataTable extends Table {
+  TextColumn get id => text()();
+  IntColumn get kind => integer()();
+  TextColumn get pubkey => text()();
+  TextColumn get masterPubkey => text()();
+  IntColumn get createdAt => integer()();
+  TextColumn get sig => text().nullable()();
+  TextColumn get content => text()();
+  TextColumn get tags => text().map(const EventTagsConverter())();
+  TextColumn get eventReference => text().map(const EventReferenceConverter())();
+
+  @override
+  Set<Column> get primaryKey => {masterPubkey};
+}
+
+extension UserMetadataEntityExtension on UserMetadataEntity {
+  Future<EventMessageDbModel> toEventMessageDbModel() async {
+    final eventMessage = await toEventMessage(data);
+    return EventMessageDbModel(
+      id: eventMessage.id,
+      sig: eventMessage.sig,
+      kind: eventMessage.kind,
+      tags: eventMessage.tags,
+      pubkey: eventMessage.pubkey,
+      content: eventMessage.content,
+      createdAt: eventMessage.createdAt,
+      masterPubkey: eventMessage.masterPubkey,
+      eventReference: toEventReference(),
+    );
+  }
+
+  static UserMetadataEntity fromEventMessageDbModel(EventMessageDbModel model) {
+    final eventMessage = EventMessage(
+      id: model.id,
+      sig: model.sig,
+      kind: model.kind,
+      tags: model.tags,
+      pubkey: model.pubkey,
+      content: model.content,
+      createdAt: model.createdAt,
+    );
+    return UserMetadataEntity.fromEventMessage(eventMessage);
+  }
+}

--- a/lib/app/features/user_metadata/database/user_metadata_database.c.dart
+++ b/lib/app/features/user_metadata/database/user_metadata_database.c.dart
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:drift/drift.dart';
+import 'package:drift_flutter/drift_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/exceptions/exceptions.dart';
+import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
+import 'package:ion/app/features/ion_connect/database/converters/event_reference_converter.c.dart';
+import 'package:ion/app/features/ion_connect/database/converters/event_tags_converter.dart';
+import 'package:ion/app/features/ion_connect/model/event_reference.c.dart';
+import 'package:ion/app/features/user_metadata/database/tables/user_metadata_table.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_metadata_database.c.g.dart';
+
+@riverpod
+UserMetadataDatabase userMetadataDatabase(Ref ref) {
+  keepAliveWhenAuthenticated(ref);
+  final masterPubkey = ref.watch(currentPubkeySelectorProvider);
+
+  if (masterPubkey == null) {
+    throw UserMasterPubkeyNotFoundException();
+  }
+
+  final database = UserMetadataDatabase(masterPubkey);
+
+  onLogout(ref, database.close);
+
+  return database;
+}
+
+@DriftDatabase(tables: [UserMetadataTable])
+class UserMetadataDatabase extends _$UserMetadataDatabase {
+  UserMetadataDatabase(this.masterPubkey) : super(_openConnection(masterPubkey));
+
+  final String masterPubkey;
+
+  @override
+  int get schemaVersion => 1;
+
+  static QueryExecutor _openConnection(String pubkey) {
+    return driftDatabase(name: 'user_metadata_database_$pubkey');
+  }
+}

--- a/lib/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart
+++ b/lib/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-
 import 'package:ion/app/features/user/model/user_metadata.c.dart';
 import 'package:ion/app/features/user_metadata/database/dao/user_metadata_dao.c.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/lib/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart
+++ b/lib/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart
@@ -15,9 +15,7 @@ class UserMetadataFromDbNotifier extends _$UserMetadataFromDbNotifier {
     });
 
     final subscription = ref.watch(userMetadataDaoProvider).watch(masterPubkey).listen((metadata) {
-      if (metadata != null) {
-        state = metadata;
-      }
+      state = metadata;
     });
 
     ref.onDispose(subscription.cancel);

--- a/lib/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart
+++ b/lib/app/features/user_metadata/providers/user_metadata_from_db_provider.c.dart
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: ice License 1.0
+
+
+import 'package:ion/app/features/user/model/user_metadata.c.dart';
+import 'package:ion/app/features/user_metadata/database/dao/user_metadata_dao.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_metadata_from_db_provider.c.g.dart';
+
+@riverpod
+class UserMetadataFromDbNotifier extends _$UserMetadataFromDbNotifier {
+  @override
+  UserMetadataEntity? build(String masterPubkey) {
+    ref.watch(userMetadataDaoProvider).get(masterPubkey).then((metadata) {
+      state = metadata;
+    });
+
+    final subscription = ref.watch(userMetadataDaoProvider).watch(masterPubkey).listen((metadata) {
+      if (metadata != null) {
+        state = metadata;
+      }
+    });
+
+    ref.onDispose(subscription.cancel);
+
+    return null;
+  }
+}

--- a/lib/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart
+++ b/lib/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart
@@ -43,7 +43,7 @@ class UserMetadataSync extends _$UserMetadataSync {
 
     final existingMasterPubkeys = await userMetadataDao.getExistingMasterPubkeys();
 
-    final masterPubkeysDifference = existingMasterPubkeys.difference(masterPubkeys);
+    final masterPubkeysDifference = masterPubkeys.difference(existingMasterPubkeys);
 
     final masterPubkeysToSync = Set<String>.from(existingMasterPubkeys)..addAll(masterPubkeys);
 
@@ -76,7 +76,7 @@ class UserMetadataSync extends _$UserMetadataSync {
 
     final usersMetadata = await Future.wait(
       masterPubkeys
-          .map((pubkey) => ref.watch(userMetadataProvider(pubkey, cache: false).future))
+          .map((pubkey) => ref.read(userMetadataProvider(pubkey, cache: false).future))
           .toList(),
     );
 

--- a/lib/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart
+++ b/lib/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'dart:async';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/exceptions/exceptions.dart';
+import 'package:ion/app/features/auth/providers/auth_provider.c.dart';
+import 'package:ion/app/features/auth/providers/delegation_complete_provider.c.dart';
+import 'package:ion/app/features/core/providers/env_provider.c.dart';
+import 'package:ion/app/features/user/model/user_metadata.c.dart';
+import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
+import 'package:ion/app/features/user_metadata/database/dao/user_metadata_dao.c.dart';
+import 'package:ion/app/services/storage/local_storage.c.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_metadata_sync_provider.c.g.dart';
+
+@riverpod
+class UserMetadataSync extends _$UserMetadataSync {
+  static const String localStorageKey = 'user_metadata_last_sync';
+
+  @override
+  Future<void> build() async {
+    final keepAlive = ref.keepAlive();
+    onLogout(ref, keepAlive.close);
+
+    final authState = await ref.watch(authProvider.future);
+    if (!authState.isAuthenticated) return;
+
+    final delegationComplete = await ref.watch(delegationCompleteProvider.future);
+    if (!delegationComplete) return;
+  }
+
+  Future<void> syncUserMetadata({
+    bool forceSync = false,
+    Set<String> masterPubkeys = const {},
+  }) async {
+    final masterPubkey = ref.watch(currentPubkeySelectorProvider);
+
+    if (masterPubkey == null) throw UserMasterPubkeyNotFoundException();
+
+    final userMetadataDao = ref.watch(userMetadataDaoProvider);
+
+    final existingMasterPubkeys = await userMetadataDao.getExistingMasterPubkeys();
+
+    final masterPubkeysDifference = existingMasterPubkeys.difference(masterPubkeys);
+
+    final masterPubkeysToSync = Set<String>.from(existingMasterPubkeys)..addAll(masterPubkeys);
+
+    final syncWindow =
+        ref.read(envProvider.notifier).get<int>(EnvVariable.USER_METADATA_SYNC_MINUTES);
+
+    final localStorage = await ref.watch(localStorageAsyncProvider.future);
+
+    final lastSyncTime = DateTime.tryParse(localStorage.getString(localStorageKey) ?? '');
+
+    if (forceSync ||
+        lastSyncTime == null ||
+        masterPubkeysDifference.isNotEmpty ||
+        lastSyncTime.isBefore(DateTime.now().subtract(Duration(minutes: syncWindow)))) {
+      final usersMetadata = await _fetchUsersMetadata(ref: ref, masterPubkeys: masterPubkeysToSync);
+
+      if (usersMetadata.isEmpty) return;
+
+      await userMetadataDao.insertAll(usersMetadata);
+
+      await localStorage.setString(localStorageKey, DateTime.now().toIso8601String());
+    }
+  }
+
+  Future<List<UserMetadataEntity>> _fetchUsersMetadata({
+    required Ref ref,
+    required Set<String> masterPubkeys,
+  }) async {
+    if (masterPubkeys.isEmpty) return [];
+
+    final usersMetadata = await Future.wait(
+      masterPubkeys
+          .map((pubkey) => ref.watch(userMetadataProvider(pubkey, cache: false).future))
+          .toList(),
+    );
+
+    return usersMetadata.nonNulls.toList();
+  }
+}

--- a/lib/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart
+++ b/lib/app/features/user_metadata/providers/user_metadata_sync_provider.c.dart
@@ -62,7 +62,12 @@ class UserMetadataSync extends _$UserMetadataSync {
 
       if (usersMetadata.isEmpty) return;
 
+      // If relay returned null for a master pubkey, we should remove existing metadata
+      final deletedUsers =
+          masterPubkeysToSync.difference(usersMetadata.map((e) => e.masterPubkey).toSet());
+
       await userMetadataDao.insertAll(usersMetadata);
+      await userMetadataDao.deleteMetadata(deletedUsers.toList());
 
       await localStorage.setString(localStorageKey, DateTime.now().toIso8601String());
     }

--- a/lib/app/router/chat_routes.dart
+++ b/lib/app/router/chat_routes.dart
@@ -49,17 +49,17 @@ class ChatRoutes {
 class ConversationRoute extends BaseRouteData {
   ConversationRoute({
     this.conversationId,
-    this.receiverPubKey,
+    this.receiverMasterPubkey,
   }) : super(
           child: ConversationPage(
             conversationId: conversationId,
-            receiverPubKey: receiverPubKey,
+            receiverMasterPubkey: receiverMasterPubkey,
           ),
           canPop: true,
         );
 
   final String? conversationId;
-  final String? receiverPubKey;
+  final String? receiverMasterPubkey;
 }
 
 class ChannelDetailRoute extends BaseRouteData {


### PR DESCRIPTION
## Description
- Syncs E2EE conversations user metadata to the local database
- Pull to refresh (always forces sync of existing conversation profiles)
- New event (30014, 5, 7) triggers check of the users metadata (sync window controller by env variable)
- User opened one-to-one conversation triggers check of users metadata
- Any new master pubkey passed to the flows which doesn't exist in the db causes force update

## Type of Change
- [x] New feature
- [x] Refactoring
