### PR TITLE
fix: fix ConfigRepository getConfig.refreshInterval=-1 recursion issue

### DIFF
--- a/lib/app/features/feed/providers/feed_config_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_config_provider.c.dart
@@ -19,7 +19,7 @@ Future<FeedConfig> feedConfig(Ref ref) async {
   final result = await repository.getConfig<FeedConfig>(
     'apps-runtime_ion-app',
     cacheStrategy: AppConfigCacheStrategy.file,
-    refreshInterval: cacheDuration.inMilliseconds,
+    refreshInterval: cacheDuration,
     parser: (data) => FeedConfig.fromJson(jsonDecode(data) as Map<String, dynamic>),
     checkVersion: true,
   );

--- a/lib/app/features/feed/providers/feed_user_interests_provider.c.dart
+++ b/lib/app/features/feed/providers/feed_user_interests_provider.c.dart
@@ -75,7 +75,7 @@ class FeedUserInterests extends _$FeedUserInterests {
     return repository.getConfig<FeedInterests>(
       'content-topics_${type}_$locale',
       cacheStrategy: AppConfigCacheStrategy.file,
-      refreshInterval: cacheDuration.inMilliseconds,
+      refreshInterval: cacheDuration,
       parser: (data) => FeedInterests.fromJson(jsonDecode(data) as Map<String, dynamic>),
       checkVersion: true,
     );

--- a/lib/app/features/force_update/providers/force_update_provider.c.dart
+++ b/lib/app/features/force_update/providers/force_update_provider.c.dart
@@ -39,8 +39,7 @@ class ForceUpdate extends _$ForceUpdate {
         cacheStrategy: AppConfigCacheStrategy.localStorage,
         refreshInterval: ref
             .read(envProvider.notifier)
-            .get<Duration>(EnvVariable.MIN_APP_VERSION_CONFIG_CACHE_DURATION)
-            .inMilliseconds,
+            .get<Duration>(EnvVariable.MIN_APP_VERSION_CONFIG_CACHE_DURATION),
         parser: (data) => data,
       );
 

--- a/lib/app/features/push_notifications/providers/app_translations_provider.c.dart
+++ b/lib/app/features/push_notifications/providers/app_translations_provider.c.dart
@@ -73,7 +73,7 @@ class Translator<T extends AppConfigWithVersion> {
         await _translationsRepository.getConfig<PushNotificationTranslations>(
       'ion-app_push-notifications_translations_${locale.languageCode}',
       cacheStrategy: AppConfigCacheStrategy.file,
-      refreshInterval: cacheDuration.inMilliseconds,
+      refreshInterval: cacheDuration,
       parser: (data) =>
           PushNotificationTranslations.fromJson(jsonDecode(data) as Map<String, dynamic>),
       checkVersion: true,

--- a/lib/app/features/user/providers/service_pubkeys_provider.c.dart
+++ b/lib/app/features/user/providers/service_pubkeys_provider.c.dart
@@ -18,7 +18,7 @@ Future<List<String>> servicePubkeys(Ref ref) async {
   final result = await repo.getConfig<List<String>>(
     'service_pubkeys',
     cacheStrategy: AppConfigCacheStrategy.localStorage,
-    refreshInterval: cacheDuration.inMilliseconds,
+    refreshInterval: cacheDuration,
     parser: (data) => (jsonDecode(data) as List<dynamic>).cast<String>(),
     checkVersion: true,
   );


### PR DESCRIPTION
## Description
Replaced recursive call in getConfig with a fallback cache check to prevent potential infinite recursion when network returns no data and cache is empty. Now throws AppConfigNotFoundException instead of re-calling itself with refreshInterval = -1.

The original implementation called getConfig() recursively with refreshInterval = -1 when both the cache and network returned no data. If the network kept returning null (e.g., 204 No Content), this led to repeated self-calls with no exit condition, eventually causing a StackOverflowError due to infinite recursion.

## Type of Change
- [x] Bug fix