### PR TITLE
fix: update cache timestamp in case 204 response in ConfigRepository

### DIFF
--- a/lib/app/features/components/ion_connect_avatar/ion_connect_avatar.dart
+++ b/lib/app/features/components/ion_connect_avatar/ion_connect_avatar.dart
@@ -28,7 +28,12 @@ class IonConnectAvatar extends ConsumerWidget {
 
     return Avatar(
       imageWidget: imageUrl != null
-          ? IonConnectNetworkImage(imageUrl: imageUrl, authorPubkey: pubkey, height: size, width: size)
+          ? IonConnectNetworkImage(
+              imageUrl: imageUrl,
+              authorPubkey: pubkey,
+              height: size,
+              width: size,
+            )
           : DefaultAvatar(size: size),
       size: size,
       borderRadius: borderRadius,


### PR DESCRIPTION
## Description

Problem:
When server returns 204 No Content (indicating cached data is up-to-date), the cache timestamp wasn't being updated. This caused infinite repeated network requests every time getConfig was called, as the cache was always considered stale.


Root cause:
- `_getFromNetwork` returns null on 204 No Content
- Cache timestamp was only updated when `networkData != null`
- Without timestamp update, subsequent calls treated cache as expired

### Solution:
- Always update cache timestamp when server returns 204 No Content

## Type of Change
- [x] Bug fix
