### PR TITLE
fix: disable manage coins provider when opening token import page

### DIFF
--- a/lib/app/features/wallets/views/pages/manage_coins/components/import_token_action_button.dart
+++ b/lib/app/features/wallets/views/pages/manage_coins/components/import_token_action_button.dart
@@ -1,19 +1,25 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/wallets/views/pages/manage_coins/providers/manage_coins_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 import 'package:ion/generated/assets.gen.dart';
 
-class ImportTokenActionButton extends StatelessWidget {
+class ImportTokenActionButton extends ConsumerWidget {
   const ImportTokenActionButton({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.theme.appColors;
 
     return GestureDetector(
-      onTap: () => ImportTokenRoute().push<void>(context),
+      onTap: () async {
+        final notifier = ref.read(manageCoinsNotifierProvider.notifier)..disableSave();
+        await ImportTokenRoute().push<void>(context);
+        notifier.enableSave();
+      },
       child: Assets.svg.iconPlusCreatechannel.icon(
         color: colors.primaryAccent,
         size: 33.0.s,

--- a/lib/app/features/wallets/views/pages/manage_coins/components/import_token_action_button.dart
+++ b/lib/app/features/wallets/views/pages/manage_coins/components/import_token_action_button.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/views/pages/manage_coins/providers/manage_coins_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
+import 'package:ion/app/services/logger/logger.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class ImportTokenActionButton extends ConsumerWidget {
@@ -16,9 +17,15 @@ class ImportTokenActionButton extends ConsumerWidget {
 
     return GestureDetector(
       onTap: () async {
-        final notifier = ref.read(manageCoinsNotifierProvider.notifier)..disableSave();
-        await ImportTokenRoute().push<void>(context);
-        notifier.enableSave();
+        final notifier = ref.read(manageCoinsNotifierProvider.notifier);
+        try {
+          notifier.disableSave();
+          await ImportTokenRoute().push<void>(context);
+        } catch (e) {
+          Logger.error('Caught error after ImportTokenRoute pop: $e');
+        } finally {
+          notifier.enableSave();
+        }
       },
       child: Assets.svg.iconPlusCreatechannel.icon(
         color: colors.primaryAccent,

--- a/lib/app/features/wallets/views/pages/manage_coins/manage_coins_page.dart
+++ b/lib/app/features/wallets/views/pages/manage_coins/manage_coins_page.dart
@@ -28,7 +28,13 @@ class ManageCoinsPage extends HookConsumerWidget {
     final searchResult = ref.watch(searchCoinsNotifierProvider);
     final manageCoins = ref.watch(manageCoinsNotifierProvider);
 
-    useEffect(() => ref.read(manageCoinsNotifierProvider.notifier).save, []);
+    useEffect(
+      () {
+        final notifier = ref.read(manageCoinsNotifierProvider.notifier)..enableSave();
+        return notifier.save;
+      },
+      [],
+    );
     useOnInit(
       () => searchCoinsNotifier.search(query: searchText.value),
       [searchText.value],

--- a/lib/app/features/wallets/views/pages/manage_coins/providers/manage_coins_provider.c.dart
+++ b/lib/app/features/wallets/views/pages/manage_coins/providers/manage_coins_provider.c.dart
@@ -19,6 +19,7 @@ part 'required_coin_groups_list.dart';
 @riverpod
 class ManageCoinsNotifier extends _$ManageCoinsNotifier {
   final _coinsFromWallet = <String, ManageCoinsGroup>{};
+  var _saveEnabled = true;
 
   @override
   Future<Map<String, ManageCoinsGroup>> build() async {
@@ -32,7 +33,7 @@ class ManageCoinsNotifier extends _$ManageCoinsNotifier {
       toExclude.addAll(coinGroup.coins.map((e) => e.coin.id));
       _coinsFromWallet[coinGroup.symbolGroup] = ManageCoinsGroup(
         coinsGroup: coinGroup,
-        isSelected: state.value?[coinGroup.symbolGroup]?.isSelected ?? true,
+        isSelected: true,
       );
     }
     final coinsService = await ref.watch(coinsServiceProvider.future);
@@ -74,7 +75,17 @@ class ManageCoinsNotifier extends _$ManageCoinsNotifier {
     state = AsyncData<Map<String, ManageCoinsGroup>>(currentMap);
   }
 
+  void disableSave() {
+    _saveEnabled = false;
+  }
+
+  void enableSave() {
+    _saveEnabled = true;
+  }
+
   Future<void> save() async {
+    if (!_saveEnabled) return;
+
     final currentWalletView = await ref.read(currentWalletViewDataProvider.future);
     final updatedCoins = state.value?.values
             .where((manageGroup) => manageGroup.isSelected)


### PR DESCRIPTION
## Description
Add enable/disable mechanism for provider to prevent saving the prev state of the coin list.

## Task ID
ION-3017

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore