### PR TITLE
fix(chat): prevent displaying blurhash when actual media is ready to display

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/visual_media_message/visual_media_content.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/visual_media_message/visual_media_content.dart
@@ -79,7 +79,7 @@ class VisualMediaContent extends HookConsumerWidget {
         key: Key(messageMediaTableData.id.toString()),
         alignment: Alignment.center,
         children: [
-          if (mediaAttachment?.blurhash != null)
+          if (mediaAttachment?.blurhash != null && localFile.value == null)
             ClipRRect(
               borderRadius: BorderRadius.circular(height <= 30.0.s ? 2.0.s : 5.0.s),
               child: SizedBox(


### PR DESCRIPTION
## Description
This PR fix stops blurhash from displaying when a local file is available in the visual media message component. As a result, in the stack, if we use blurhash under the image and it has a transparent area, it appears as if it hasn't loaded.

## Additional Notes
N/A

## Task ID
ION-3006

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<img width="180" alt="image" src="https://github.com/user-attachments/assets/4820df5a-8dba-41af-87ce-6d667f42b803">
