### PR TITLE
fix: remove gradient flickering from stories cells, wait for all stories to load before displaying them

### DIFF
--- a/lib/app/features/feed/stories/providers/feed_stories_provider.c.dart
+++ b/lib/app/features/feed/stories/providers/feed_stories_provider.c.dart
@@ -25,6 +25,9 @@ class FeedStories extends _$FeedStories with DelegatedPagedNotifier {
       FeedFilter.following => ref.watch(feedFollowingContentProvider(FeedType.story)),
       FeedFilter.forYou => ref.watch(feedForYouContentProvider(FeedType.story)),
     };
+    if (data.isLoading) {
+      return (items: null, hasMore: false);
+    }
     return (items: _groupByPubkey(data.items), hasMore: data.hasMore);
   }
 

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list.dart
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
@@ -46,10 +44,7 @@ class StoryList extends ConsumerWidget {
           }
 
           final pubkey = filteredPubkeys[index - 1];
-          return StoryListItem(
-            pubkey: pubkey,
-            gradient: storyBorderGradients[Random().nextInt(storyBorderGradients.length)],
-          );
+          return StoryListItem(pubkey: pubkey);
         },
       ),
     );

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/components/story_list_item.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/feed/stories/providers/feed_stories_provider.c.dart';
 import 'package:ion/app/features/feed/stories/providers/viewed_stories_provider.c.dart';
 import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/components/story_item_content.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/mock.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.c.dart';
 import 'package:ion/app/router/app_routes.c.dart';
 
@@ -13,17 +14,16 @@ class StoryListItem extends HookConsumerWidget {
   const StoryListItem({
     required this.pubkey,
     super.key,
-    this.gradient,
   });
 
   final String pubkey;
-  final Gradient? gradient;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userMetadata = ref.watch(cachedUserMetadataProvider(pubkey));
     final userStories = ref.watch(feedStoriesByPubkeyProvider(pubkey));
     final viewedStories = ref.watch(viewedStoriesControllerProvider);
+    final gradient = useRef(storyBorderGradients[random.nextInt(storyBorderGradients.length)]);
 
     final allStoriesViewed = useMemoized(
       () => userStories.first.stories.every(
@@ -41,7 +41,7 @@ class StoryListItem extends HookConsumerWidget {
       child: StoryItemContent(
         pubkey: pubkey,
         name: userMetadata.data.name,
-        gradient: gradient,
+        gradient: gradient.value,
         isViewed: allStoriesViewed,
         onTap: () => StoryViewerRoute(pubkey: pubkey).push<void>(context),
       ),

--- a/lib/app/features/ion_connect/providers/entities_paged_data_provider.c.dart
+++ b/lib/app/features/ion_connect/providers/entities_paged_data_provider.c.dart
@@ -24,6 +24,7 @@ abstract class PagedNotifier {
 abstract class PagedState {
   Set<IonConnectEntity>? get items;
   bool get hasMore;
+  bool get isLoading;
 }
 
 mixin DelegatedPagedNotifier implements PagedNotifier {


### PR DESCRIPTION


## Description
This PR:
1. Make it so that stories loader is shown until all of the stories are done loading before displaying them
2. Move gradient property inside the story cell so it doesn't get randomily regenerated each time a rebuild from ListView happens.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
