### PR TITLE
feat: limit story video length to 60 seconds

### DIFF
--- a/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
@@ -97,7 +97,8 @@ class MainActivity : FlutterFragmentActivity() {
                 }
 
                 METHOD_START_VIDEO_EDITOR_TRIMMER -> {
-                    val videoFilePath = call.arguments as? String
+                    val videoFilePath = call.argument("videoFilePath") as? String
+                    val maxVideoDurationMs = call.argument<Int?>("maxVideoDurationMs")
                     val trimmerVideoUri = videoFilePath?.let { Uri.fromFile(File(it)) }
                     if (trimmerVideoUri == null) {
                         exportResult?.error("ERR_START_TRIMMER_MISSING_VIDEO", "", null)
@@ -113,7 +114,7 @@ class MainActivity : FlutterFragmentActivity() {
                                         }
 
                                     videoEditorModule = VideoEditorModule().apply {
-                                        initialize(application, aspectRatio)
+                                        initialize(application, aspectRatio, maxVideoDurationMs?.toLong())
                                     }
                                     startVideoEditorModeTrimmer(trimmerVideoUri)
                                 } else {

--- a/android/app/src/main/kotlin/io/ion/app/VideoEditorModule.kt
+++ b/android/app/src/main/kotlin/io/ion/app/VideoEditorModule.kt
@@ -26,7 +26,11 @@ import org.koin.dsl.module
 
 class VideoEditorModule {
 
-    fun initialize(application: Application, videoAspectRatio: Double?) {
+    fun initialize(
+        application: Application,
+        videoAspectRatio: Double?,
+        maxVideoDurationMs: Long? = 60_000,
+    ) {
         startKoin {
             androidContext(application)
             allowOverride(true)
@@ -49,7 +53,7 @@ class VideoEditorModule {
                 GalleryKoinModule().module,
 
                 // Sample integration module
-                SampleIntegrationVeKoinModule(videoAspectRatio).module,
+                SampleIntegrationVeKoinModule(videoAspectRatio, maxVideoDurationMs).module,
             )
         }
     }
@@ -61,8 +65,10 @@ class VideoEditorModule {
  * Some dependencies has no default implementations. It means that
  * these classes fully depends on your requirements
  */
-private class SampleIntegrationVeKoinModule(videoAspectRatio: Double?) {
-
+private class SampleIntegrationVeKoinModule(
+    videoAspectRatio: Double?,
+    maxVideoDurationMs: Long? = 60_000,
+) {
     val module = module {
         single<ArEffectsRepositoryProvider>(createdAtStart = true) {
             ArEffectsRepositoryProvider(
@@ -82,12 +88,13 @@ private class SampleIntegrationVeKoinModule(videoAspectRatio: Double?) {
             AudioBrowserMusicProvider()
         }
 
-        if (videoAspectRatio != null) {
-            single(createdAtStart = true) {
-                EditorConfig(
-                    aspectSettings = EditorAspectSettings.detectAspectSettings(videoAspectRatio),
-                )
-            }
+        single(createdAtStart = true) {
+            EditorConfig(
+                aspectSettings = if (videoAspectRatio != null) EditorAspectSettings.detectAspectSettings(
+                    videoAspectRatio
+                ) else null,
+                maxTotalVideoDurationMs = maxVideoDurationMs ?: 60_000,
+            )
         }
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -197,11 +197,15 @@ class AudioFocusHandler: NSObject {
                                         flutterResult: result
                                     )
                 case AppDelegate.methodStartVideoEditorTrimmer:
-                                    let trimmerVideoFilePath = methodCall.arguments as? String
+                    let arguments = methodCall.arguments as? [String: Any]
+                                    let trimmerVideoFilePath = arguments?["videoFilePath"] as? String
+                    let maxVideoDurationMs = arguments?["maxVideoDurationMs"] as? Int ?? 60000
+                    let maxVideoDurationSec = maxVideoDurationMs / 1000
                                     if let videoFilePath = trimmerVideoFilePath {
                                         videoEditor.openVideoEditorTrimmer(
                                             fromViewController: controller,
                                             videoURL: URL(fileURLWithPath: videoFilePath),
+                                            maxVideoDuration: maxVideoDurationSec,
                                             flutterResult: result
                                         )
                                     } else {

--- a/ios/Runner/VideoEditorModule.swift
+++ b/ios/Runner/VideoEditorModule.swift
@@ -11,7 +11,7 @@ protocol VideoEditor {
     
     func openVideoEditorPIP(fromViewController controller: FlutterViewController, videoURL: URL, flutterResult: @escaping FlutterResult)
     
-    func openVideoEditorTrimmer(fromViewController controller: FlutterViewController, videoURL: URL, flutterResult: @escaping FlutterResult)
+    func openVideoEditorTrimmer(fromViewController controller: FlutterViewController, videoURL: URL, maxVideoDuration: Int, flutterResult: @escaping FlutterResult)
 }
 
 class VideoEditorModule: VideoEditor {
@@ -91,6 +91,7 @@ class VideoEditorModule: VideoEditor {
     func openVideoEditorTrimmer(
         fromViewController controller: FlutterViewController,
         videoURL: URL,
+        maxVideoDuration: Int = 60,
         flutterResult: @escaping FlutterResult
     ) {
         self.flutterResult = flutterResult
@@ -113,8 +114,9 @@ class VideoEditorModule: VideoEditor {
         let height = abs(size.height)
         let aspectRatio = width / height
 
-        let config = videoEditorSDK?.currentConfiguration
+        var config = videoEditorSDK?.currentConfiguration
         config?.videoEditorViewConfiguration.primaryAspectRatio = AspectRatio(videoAspectRatio: aspectRatio)
+        config?.videoDurationConfiguration.maximumVideoDuration = TimeInterval(maxVideoDuration)
         if let newConfig = config {
             videoEditorSDK?.updateVideoEditorConfig(newConfig)
         }

--- a/lib/app/services/media_service/banuba_service.r.dart
+++ b/lib/app/services/media_service/banuba_service.r.dart
@@ -18,6 +18,7 @@ part 'banuba_service.r.g.dart';
 
 class BanubaService {
   const BanubaService(this.env);
+
   final Env env;
 
   // For Photo Editor
@@ -29,6 +30,8 @@ class BanubaService {
   static const methodInitVideoEditor = 'initVideoEditor';
   static const methodStartVideoEditor = 'startVideoEditor';
   static const methodStartVideoEditorTrimmer = 'startVideoEditorTrimmer';
+  static const argVideoFilePath = 'videoFilePath';
+  static const argMaxVideoDurationMs = 'maxVideoDurationMs';
   static const argExportedVideoFile = 'argExportedVideoFilePath';
 
   static const platformChannel = MethodChannel('banubaSdkChannel');
@@ -74,7 +77,10 @@ class BanubaService {
     }
   }
 
-  Future<String> editVideo(String filePath) async {
+  Future<String> editVideo(
+    String filePath, {
+    Duration? maxVideoDuration = const Duration(seconds: 60),
+  }) async {
     await platformChannel.invokeMethod(
       methodInitVideoEditor,
       env.get<String>(EnvVariable.BANUBA_TOKEN),
@@ -82,7 +88,10 @@ class BanubaService {
 
     final result = await platformChannel.invokeMethod(
       methodStartVideoEditorTrimmer,
-      filePath,
+      {
+        argVideoFilePath: filePath,
+        argMaxVideoDurationMs: maxVideoDuration?.inMilliseconds,
+      },
     );
 
     if (result is Map) {


### PR DESCRIPTION
## Description
This PR changes banuba editor maximum video length setting from default 120 seconds to 60 seconds for stories.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
