### PR TITLE
fix: remove keepAlive from storyViewingControllerProvider so it resets the indexed when stories viewer is reentered

### DIFF
--- a/lib/app/features/feed/stories/data/models/story_viewer_state.f.dart
+++ b/lib/app/features/feed/stories/data/models/story_viewer_state.f.dart
@@ -35,5 +35,11 @@ class StoryViewerState with _$StoryViewerState {
     return currentUserStories.stories[currentStoryIndex];
   }
 
+  List<ModifiablePostEntity> get currentStoriesList {
+    if (userStories.isEmpty) return [];
+
+    return userStories[currentUserIndex].stories;
+  }
+
   UserStories? get currentUser => userStories[currentUserIndex];
 }

--- a/lib/app/features/feed/stories/providers/story_viewing_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_viewing_provider.r.dart
@@ -16,7 +16,7 @@ part 'story_viewing_provider.r.g.dart';
 ///
 /// This controller maintains the state of currently viewed stories and provides methods
 /// to navigate between stories and users.
-@Riverpod(keepAlive: true)
+@riverpod
 class StoryViewingController extends _$StoryViewingController {
   @override
   StoryViewerState build(String pubkey, {bool showOnlySelectedUser = false}) {

--- a/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_viewer_page.dart
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -36,19 +36,6 @@ class StoryViewerPage extends HookConsumerWidget {
     final storyViewerState = ref
         .watch(storyViewingControllerProvider(pubkey, showOnlySelectedUser: showOnlySelectedUser));
 
-    useEffect(
-      () {
-        return () {
-          if (context.mounted) {
-            ref.invalidate(
-              storyViewingControllerProvider(pubkey, showOnlySelectedUser: showOnlySelectedUser),
-            );
-          }
-        };
-      },
-      [],
-    );
-
     useOnInit(
       () {
         if (storyViewerState.userStories.isEmpty && context.mounted && context.canPop()) {
@@ -60,13 +47,16 @@ class StoryViewerPage extends HookConsumerWidget {
 
     useOnInit(
       () async {
-        if (initialStoryReference != null) {
+        final viewedStories = ref.read(viewedStoriesControllerProvider);
+        final firstNotViewedStory = storyViewerState.currentStoriesList
+            .firstWhereOrNull((story) => !viewedStories.contains(story.id));
+        if (initialStoryReference != null || firstNotViewedStory != null) {
           ref
               .watch(
                 storyViewingControllerProvider(pubkey, showOnlySelectedUser: showOnlySelectedUser)
                     .notifier,
               )
-              .moveToStory(initialStoryReference!);
+              .moveToStory(initialStoryReference ?? firstNotViewedStory!.toEventReference());
         }
       },
       [storyViewerState.userStories.isEmpty],


### PR DESCRIPTION


## Description
This PR fixes:

1. An issue where after viewing multiple stories multiple times, `storyViewingControllerProvider` returned controllers with wrong, old indexes and caused random stories to be displayed instead of the correct ones.

2. If there are multiple stories for a given user but some of them were already viewed, it starts displaying from the unseed ones.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
