### PR TITLE
fix: make Amount field editable on SendCoinsForm

### DIFF
--- a/lib/app/features/wallets/providers/send_asset_form_provider.r.dart
+++ b/lib/app/features/wallets/providers/send_asset_form_provider.r.dart
@@ -158,6 +158,7 @@ class SendAssetFormController extends _$SendAssetFormController {
           amount: parsedAmount,
           amountUSD: parsedAmount * (coin.selectedOption?.coin.priceUSD ?? 0),
         ),
+        exceedsMaxAmount: false,
       );
     }
   }

--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -175,7 +175,6 @@ class SendCoinsForm extends HookConsumerWidget {
                         controller: amountController,
                         maxValue: coin?.selectedOption?.amount ?? 0,
                         coinAbbreviation: coin?.coinsGroup.abbreviation ?? '',
-                        enabled: formController.request == null,
                         errorText:
                             exceedsMaxAmount ? locale.wallet_coin_amount_insufficient_funds : null,
                       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2352,7 +2352,7 @@ packages:
     source: hosted
     version: "2.6.1"
   rxdart:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"


### PR DESCRIPTION
## Description
Previously, if someone requested more money than the user had available, the user couldn’t send any amount in response to that request. This PR allows the Amount field to be editable in such cases, so the user can choose to send a smaller amount instead.

## Task ID
ION-2852

## Type of Change
- [x] Bug fix
