### PR TITLE
fix: put the background in the stack to the correct place to avoid absorbing pointer

### DIFF
--- a/lib/app/router/components/navigation_app_bar/collapsing_app_bar.dart
+++ b/lib/app/router/components/navigation_app_bar/collapsing_app_bar.dart
@@ -45,15 +45,15 @@ class CollapsingAppBar extends StatelessWidget {
             child: Stack(
               clipBehavior: Clip.none,
               children: [
-                Padding(
-                  padding: EdgeInsetsDirectional.only(bottom: bottomOffset),
-                  child: child,
-                ),
                 Positioned.fill(
                   child: ColoredBox(
                     color: context.theme.appColors.onPrimaryAccent
                         .withValues(alpha: overlayOpacity.toDouble()),
                   ),
+                ),
+                Padding(
+                  padding: EdgeInsetsDirectional.only(bottom: bottomOffset),
+                  child: child,
                 ),
               ],
             ),


### PR DESCRIPTION
## Description
Show the background behind the `child`, so the first one will not absorb the pointer.

## Task ID
ION-3092

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
https://github.com/user-attachments/assets/4f5e99d9-ea9d-4848-a897-f5f7bacf67cc

