### PR TITLE
fix: story preview shown after video edit flow is cancelled

### DIFF
--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/video_preview_edit_cover.dart
@@ -25,7 +25,7 @@ class VideoPreviewEditCover extends ConsumerWidget {
         try {
           final editedMedia = await ref.read(editMediaProvider(attachedVideo).future);
 
-          if (editedMedia.path != attachedVideo.path) {
+          if (editedMedia != null && editedMedia.path != attachedVideo.path) {
             final timestamp = DateTime.now().millisecondsSinceEpoch;
             attachedVideoNotifier.value = attachedVideo.copyWith(
               path: editedMedia.path,

--- a/lib/app/features/feed/stories/providers/media_editing_service.r.dart
+++ b/lib/app/features/feed/stories/providers/media_editing_service.r.dart
@@ -25,7 +25,7 @@ class MediaEditingService {
 
     if (!isCameraPaused) await camera.pauseCamera();
     try {
-      return (await _ref.read(editMediaProvider(file).future)).path;
+      return (await _ref.read(editMediaProvider(file).future))?.path;
     } finally {
       if (resumeCamera && !isCameraPaused) await camera.resumeCamera();
     }

--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -75,7 +75,7 @@ class FeedMainModalPage extends ConsumerWidget {
 
                       if (result != null && result.isNotEmpty && context.mounted) {
                         final editedMedia = await ref.read(editMediaProvider(result[0]).future);
-                        if (!context.mounted) return;
+                        if (!context.mounted || editedMedia == null) return;
                         final editingResult = await CreateVideoRoute(
                               videoPath: editedMedia.path,
                               videoThumbPath: editedMedia.thumb,

--- a/lib/app/services/media_service/banuba_service.r.dart
+++ b/lib/app/services/media_service/banuba_service.r.dart
@@ -46,7 +46,7 @@ class BanubaService {
     );
   }
 
-  Future<String> editPhoto(String filePath) async {
+  Future<String?> editPhoto(String filePath) async {
     try {
       await _initPhotoEditor();
 
@@ -59,7 +59,7 @@ class BanubaService {
         final exportedPhotoFilePath = result[argExportedPhotoFile];
 
         if (exportedPhotoFilePath == null) {
-          return filePath;
+          return null;
         }
 
         if (Platform.isAndroid) {
@@ -69,7 +69,7 @@ class BanubaService {
 
         return exportedPhotoFilePath as String;
       }
-      return filePath;
+      return null;
     } on PlatformException catch (e) {
       Logger.log(
         'Start Photo Editor error',
@@ -80,7 +80,7 @@ class BanubaService {
     }
   }
 
-  Future<EditVideResult> editVideo(
+  Future<EditVideResult?> editVideo(
     String filePath, {
     Duration? maxVideoDuration = const Duration(seconds: 60),
   }) async {
@@ -102,7 +102,7 @@ class BanubaService {
       final thumb = result[argExportedVideoCoverPreview] as String;
       return (newPath: newPath, thumb: thumb);
     }
-    return (newPath: filePath, thumb: null);
+    return null;
   }
 }
 
@@ -112,7 +112,7 @@ BanubaService banubaService(Ref ref) {
 }
 
 @riverpod
-Future<MediaFile> editMedia(Ref ref, MediaFile mediaFile) async {
+Future<MediaFile?> editMedia(Ref ref, MediaFile mediaFile) async {
   final filePath = path.isAbsolute(mediaFile.path)
       ? mediaFile.path
       : await ref.read(assetFilePathProvider(mediaFile.path).future);
@@ -140,9 +140,11 @@ Future<MediaFile> editMedia(Ref ref, MediaFile mediaFile) async {
   switch (mediaType) {
     case MediaType.image:
       final newPath = await ref.read(banubaServiceProvider).editPhoto(filePath);
+      if (newPath == null) return null;
       return mediaFile.copyWith(path: newPath);
     case MediaType.video:
       final editVideoData = await ref.read(banubaServiceProvider).editVideo(filePath);
+      if (editVideoData == null) return null;
       return mediaFile.copyWith(path: editVideoData.newPath, thumb: editVideoData.thumb);
     case MediaType.unknown || MediaType.audio:
       throw Exception('Unknown media type');


### PR DESCRIPTION
## Description
This PR fixes an issue where canceling the video editing flow for stories would still end up with navigation to story preview page

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
