### PR TITLE
fix: use correct loading indicator for stories images

### DIFF
--- a/lib/app/components/image/ion_network_image.dart
+++ b/lib/app/components/image/ion_network_image.dart
@@ -101,6 +101,7 @@ class IonNetworkImage extends StatelessWidget {
       memCacheWidth: memCacheWidth,
       memCacheHeight: memCacheHeight,
       imageBuilder: imageBuilder,
+      progressIndicatorBuilder: progressIndicatorBuilder,
     );
   }
 }

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/image_story_viewer.dart
@@ -35,7 +35,7 @@ class ImageStoryViewer extends ConsumerWidget {
       authorPubkey: authorPubkey,
       cacheManager: cacheManager,
       filterQuality: FilterQuality.high,
-      progressIndicatorBuilder: (_, __, ___) => const CenteredLoadingIndicator(),
+      placeholder: (_, __) => const CenteredLoadingIndicator(),
       imageBuilder: (context, imageProvider) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (context.mounted) {


### PR DESCRIPTION
## Description
This PR fixes an issue where a broken image icon was shown for loading story images instead of loading indicator.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
