### PR TITLE
fix: border radius for vertical story videos

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -49,12 +49,18 @@ class VideoStoryViewer extends HookConsumerWidget {
       },
     );
 
+    Widget videoPlayer = CachedVideoPlayerPlus(videoController);
+
     final aspect = videoController.value.aspectRatio;
-    return Center(
-      child: AspectRatio(
-        aspectRatio: aspect,
-        child: CachedVideoPlayerPlus(videoController),
-      ),
-    );
+    final isHorizontal = aspect > 1.0;
+    if (isHorizontal) {
+      videoPlayer = Center(
+        child: AspectRatio(
+          aspectRatio: aspect,
+          child: videoPlayer,
+        ),
+      );
+    }
+    return videoPlayer;
   }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where vertical videos had their corners cut in stories viewer.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
