### PR TITLE
fix: stop posted story images from saving to phone photo gallery

### DIFF
--- a/ios/Runner/PhotoEditorModule.swift
+++ b/ios/Runner/PhotoEditorModule.swift
@@ -13,7 +13,8 @@ class PhotoEditorModule: BanubaPhotoEditorDelegate {
     private var flutterResult: FlutterResult?
     
     init(token: String, flutterResult: @escaping FlutterResult) {
-        let configuration = PhotoEditorConfig()
+        var configuration = PhotoEditorConfig()
+        configuration.editorScreenConfiguration = .init(saveResultToPhotoLibrary: false)
         photoEditorSDK = BanubaPhotoEditor(
             token: token,
             configuration: configuration


### PR DESCRIPTION
## Description
This PR fixes an issue where any image that went through banuba editor ended up being saved to device's photo gallery

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
