### PR TITLE
fix: automatically close main modal after post creation from the profile tab

### DIFF
--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -107,9 +107,17 @@ class FeedMainModalPage extends ConsumerWidget {
 
               return MainModalItem(
                 item: type,
-                onTap: () {
+                onTap: () async {
                   final createFlowRouteLocation = _getCreateFlowRouteLocation(type);
-                  context.go(createFlowRouteLocation);
+                  final result = await context.push<bool>(createFlowRouteLocation);
+
+                  if ((result ?? false) && context.mounted) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (context.mounted) {
+                        context.pop();
+                      }
+                    });
+                  }
                 },
                 index: index,
               );


### PR DESCRIPTION
## Description
Fixed an issue where the main modal remained open after publishing a post from the profile tab.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
