### PR TITLE
fix: increase max aspect ratio for feed images to 3

### DIFF
--- a/lib/app/services/media_service/aspect_ratio.dart
+++ b/lib/app/services/media_service/aspect_ratio.dart
@@ -37,7 +37,7 @@ class MediaAspectRatioResult {
 }
 
 const minVerticalMediaAspectRatio = 0.85;
-const maxHorizontalMediaAspectRatio = 2.0;
+const maxHorizontalMediaAspectRatio = 3.0;
 
 /// Calculates the aspect ratio for a list of media items.
 ///


### PR DESCRIPTION
## Description
This PR increases max aspect ratio for feed images from 2 to 3 to better handle very wide images.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
Before:
![ScreenShot 2025-07-02 at 12 44 27@2x](https://github.com/user-attachments/assets/810d81e9-2381-4f56-a00f-5d07d50945d4)

After:
![ScreenShot 2025-07-02 at 12 43 53@2x](https://github.com/user-attachments/assets/c75bdbe7-0817-4abd-8755-fa8107eff8a5)
