### PR TITLE
chore: remove unnecessary inner join with eventMessageTable in getUnreadMessagesCount

### DIFF
--- a/lib/app/features/chat/model/database/dao/conversation_message_dao.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_message_dao.dart
@@ -25,10 +25,6 @@ class ConversationMessageDao extends DatabaseAccessor<ChatDatabase>
   }) {
     final query = select(conversationMessageTable).join([
       innerJoin(
-        eventMessageTable,
-        eventMessageTable.eventReference.equalsExp(conversationMessageTable.messageEventReference),
-      ),
-      innerJoin(
         messageStatusTable,
         messageStatusTable.messageEventReference
             .equalsExp(conversationMessageTable.messageEventReference),


### PR DESCRIPTION
## Description
This PR removes the unnecessary inner join with eventMessageTable in `getUnreadMessagesCount`

## Additional Notes
N/A

## Task ID
ION-3127

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
