### PR TITLE
fix: prevent duplicate loading indicators during pull-to-refresh in reply list

### DIFF
--- a/lib/app/components/scroll_view/load_more_builder.dart
+++ b/lib/app/components/scroll_view/load_more_builder.dart
@@ -14,6 +14,7 @@ class LoadMoreBuilder extends HookWidget {
     Widget Function(BuildContext context, List<Widget> slivers)? builder,
     this.loadMoreOffset,
     this.forceLoadMore = false,
+    this.showIndicator = true,
     super.key,
   }) : builder = builder ??
             ((BuildContext context, List<Widget> slivers) => CustomScrollView(slivers: slivers));
@@ -29,6 +30,8 @@ class LoadMoreBuilder extends HookWidget {
   final bool hasMore;
 
   final bool forceLoadMore;
+
+  final bool showIndicator;
 
   @override
   Widget build(BuildContext context) {
@@ -57,7 +60,7 @@ class LoadMoreBuilder extends HookWidget {
       onNotification: (notification) => _onMetricsChanged(notification, loadMore),
       child: builder(
         context,
-        loading.value
+        loading.value && showIndicator
             ? [
                 ...slivers,
                 SliverToBoxAdapter(


### PR DESCRIPTION
## Description
 Fixed double-loading indicators appearing during pull-to-refresh on the reply page.

 **Problem:**
  - Two loading indicators were shown simultaneously when refreshing replies
  - Pull-to-refresh indicator at top + LoadMoreBuilder indicator at bottom

  **Solution:**
  - Added `showIndicator` parameter to `LoadMoreBuilder`
  - Track refresh state in `ReplyList` using `useState` hook
  - Hide LoadMoreBuilder indicator during pull-to-refresh

## Task ID
3099

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
