### PR TITLE
fix: prevent flicker issue on conversations page

### DIFF
--- a/lib/app/features/user_profile/providers/user_metadata_from_db_provider.r.dart
+++ b/lib/app/features/user_profile/providers/user_metadata_from_db_provider.r.dart
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user_profile/database/dao/user_metadata_dao.m.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -10,10 +11,7 @@ part 'user_metadata_from_db_provider.r.g.dart';
 class UserMetadataFromDbNotifier extends _$UserMetadataFromDbNotifier {
   @override
   UserMetadataEntity? build(String masterPubkey) {
-    ref.watch(userMetadataDaoProvider).get(masterPubkey).then((metadata) {
-      state = metadata;
-    });
-
+    keepAliveWhenAuthenticated(ref);
     final subscription = ref.watch(userMetadataDaoProvider).watch(masterPubkey).listen((metadata) {
       state = metadata;
     });


### PR DESCRIPTION
## Description
This PR fixes the flicker issue when user scrolls the conversation page. `UserMetadataFromDbNotifier` keeps the previous value even chat tile widget is disposed so when it ll be rendered again, it uses the existing user metadata to prevent flicker issue.

## Additional Notes
N/A

## Task ID
ION-3132

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
