### PR TITLE
refactor: rename pubkey to masterPubkey for clarity in event references

### DIFF
--- a/lib/app/extensions/delta.dart
+++ b/lib/app/extensions/delta.dart
@@ -15,7 +15,7 @@ extension DeltaExt on Delta {
         if (attributes.containsKey(textEditorProfileKey)) {
           final encodedRef = attributes[textEditorProfileKey] as String;
           final eventReference = EventReference.fromEncoded(encodedRef);
-          pubkeys.add(eventReference.pubkey);
+          pubkeys.add(eventReference.masterPubkey);
         }
       }
     }

--- a/lib/app/features/auth/providers/paginated_users_metadata_provider.r.dart
+++ b/lib/app/features/auth/providers/paginated_users_metadata_provider.r.dart
@@ -75,7 +75,7 @@ class PaginatedUsersMetadata extends _$PaginatedUsersMetadata {
           // Try each relay in random order until we get metadata
           for (final relay in creator.ionConnectRelays.toList()..shuffle()) {
             final entityEventReference = ReplaceableEventReference(
-              pubkey: creator.masterPubKey,
+              masterPubkey: creator.masterPubKey,
               kind: UserMetadataEntity.kind,
             );
             final cachedEntity =

--- a/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.f.dart
+++ b/lib/app/features/chat/e2ee/model/entities/private_direct_message_data.f.dart
@@ -159,7 +159,7 @@ class ReplaceablePrivateDirectMessageData
     return ReplaceableEventReference(
       kind: ReplaceablePrivateDirectMessageEntity.kind,
       dTag: messageId,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 

--- a/lib/app/features/chat/e2ee/providers/e2ee_delete_event_provider.r.dart
+++ b/lib/app/features/chat/e2ee/providers/e2ee_delete_event_provider.r.dart
@@ -103,7 +103,7 @@ Future<void> _deleteReaction({
       EventToDelete(
         eventReference: ImmutableEventReference(
           eventId: reactionEvent.id,
-          pubkey: reactionEvent.masterPubkey,
+          masterPubkey: reactionEvent.masterPubkey,
           kind: PrivateMessageReactionEntity.kind,
         ),
       ),

--- a/lib/app/features/chat/providers/share_post_to_chat_provider.r.dart
+++ b/lib/app/features/chat/providers/share_post_to_chat_provider.r.dart
@@ -159,7 +159,7 @@ class SharePostToChat extends _$SharePostToChat {
                   eventReference: ImmutableEventReference(
                     eventId: kind16Rumor.id,
                     kind: GenericRepostEntity.kind,
-                    pubkey: kind16Rumor.masterPubkey,
+                    masterPubkey: kind16Rumor.masterPubkey,
                   ),
                 ),
               );

--- a/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
+++ b/lib/app/features/chat/recent_chats/views/components/recent_chat_tile/recent_chat_tile.dart
@@ -330,7 +330,7 @@ class ChatPreview extends HookConsumerWidget {
       MessageType.profile => ref
               .watch(
                 userMetadataProvider(
-                  EventReference.fromEncoded(lastMessageContent).pubkey,
+                  EventReference.fromEncoded(lastMessageContent).masterPubkey,
                 ),
               )
               .valueOrNull
@@ -371,7 +371,7 @@ class ChatPreview extends HookConsumerWidget {
   }
 
   String _getMoneySentTitle(WidgetRef ref, String messageContent) {
-    final messagePubkey = EventReference.fromEncoded(lastMessageContent).pubkey;
+    final messagePubkey = EventReference.fromEncoded(lastMessageContent).masterPubkey;
     final isMyPubkey = ref.watch(currentPubkeySelectorProvider) == messagePubkey;
     return isMyPubkey
         ? ref.context.i18n.chat_money_sent_title

--- a/lib/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart
+++ b/lib/app/features/chat/views/components/message_items/message_item_wrapper/message_item_wrapper.dart
@@ -175,7 +175,7 @@ ChatMessageInfoItem? getRepliedMessageListItem({
   final repliedEntity = ReplaceablePrivateDirectMessageEntity.fromEventMessage(repliedEventMessage);
 
   if (repliedEntity.data.messageType == MessageType.profile) {
-    final profilePubkey = EventReference.fromEncoded(repliedEntity.data.content).pubkey;
+    final profilePubkey = EventReference.fromEncoded(repliedEntity.data.content).masterPubkey;
 
     final userMetadata = ref.watch(userMetadataProvider(profilePubkey)).valueOrNull;
 

--- a/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/money_message/money_message.dart
@@ -78,7 +78,7 @@ class _RequestedMoneyMessage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isMe = ref.watch(isCurrentUserSelectorProvider(eventReference.pubkey));
+    final isMe = ref.watch(isCurrentUserSelectorProvider(eventReference.masterPubkey));
 
     final fundsRequest = ref.watch(fundsRequestForMessageProvider(eventMessage)).value;
 
@@ -132,7 +132,7 @@ class _SentMoneyMessage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isMe = ref.watch(isCurrentUserSelectorProvider(eventReference.pubkey));
+    final isMe = ref.watch(isCurrentUserSelectorProvider(eventReference.masterPubkey));
 
     final transactionData = ref.watch(transactionDataForMessageProvider(eventMessage)).value;
 

--- a/lib/app/features/chat/views/components/message_items/message_types/profile_share_message/profile_share_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/profile_share_message/profile_share_message.dart
@@ -36,7 +36,7 @@ class ProfileShareMessage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isMe = ref.watch(isCurrentUserSelectorProvider(eventMessage.masterPubkey));
     final entity = ReplaceablePrivateDirectMessageEntity.fromEventMessage(eventMessage);
-    final profilePubkey = EventReference.fromEncoded(entity.data.content).pubkey;
+    final profilePubkey = EventReference.fromEncoded(entity.data.content).masterPubkey;
 
     final userMetadata = ref.watch(userMetadataProvider(profilePubkey)).valueOrNull;
 

--- a/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
+++ b/lib/app/features/chat/views/components/message_items/messaging_bottom_bar/components/more_content_view.dart
@@ -119,7 +119,7 @@ class MoreContentView extends ConsumerWidget {
                   final selectedProfilePubkey = await SendProfileModalRoute().push<String>(context);
                   if (selectedProfilePubkey != null) {
                     final eventReference = ReplaceableEventReference(
-                      pubkey: selectedProfilePubkey,
+                      masterPubkey: selectedProfilePubkey,
                       kind: UserMetadataEntity.kind,
                     );
 

--- a/lib/app/features/chat/views/pages/share_via_message_modal/components/share_options.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/components/share_options.dart
@@ -134,7 +134,7 @@ class ShareOptions extends HookConsumerWidget {
         return;
       }
 
-      final userMetadataAsyncValue = ref.read(userMetadataProvider(eventReference.pubkey));
+      final userMetadataAsyncValue = ref.read(userMetadataProvider(eventReference.masterPubkey));
       final postEntityAsyncValue = ref.read(
         ionConnectEntityWithCountersProvider(eventReference: eventReference),
       );
@@ -151,7 +151,7 @@ class ShareOptions extends HookConsumerWidget {
             eventReference: eventReference,
           ).overrideWithValue(postEntityAsyncValue),
           // ignore: scoped_providers_should_specify_dependencies
-          userMetadataProvider(eventReference.pubkey).overrideWith(
+          userMetadataProvider(eventReference.masterPubkey).overrideWith(
             (_) async => userMetadataAsyncValue.valueOrNull,
           ),
         ],

--- a/lib/app/features/chat/views/pages/share_via_message_modal/components/share_post_to_story_content.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/components/share_post_to_story_content.dart
@@ -36,7 +36,7 @@ class SharePostToStoryContent extends StatelessWidget {
                 footer: const SizedBox.shrink(),
                 topOffset: 0,
                 header: UserInfo(
-                  pubkey: eventReference.pubkey,
+                  pubkey: eventReference.masterPubkey,
                   createdAt: postItselfEntity.data.publishedAt.value,
                   trailing: const SizedBox.shrink(),
                 ),

--- a/lib/app/features/feed/create_post/providers/create_post_notifier.m.dart
+++ b/lib/app/features/feed/create_post/providers/create_post_notifier.m.dart
@@ -287,12 +287,12 @@ class CreatePostNotifier extends _$CreatePostNotifier {
     final metadataBuilders = <EventsMetadataBuilder>[];
 
     if (quotedEvent != null) {
-      pubkeysToPublish.add(quotedEvent.pubkey);
+      pubkeysToPublish.add(quotedEvent.masterPubkey);
     } else if (parentEntity != null) {
       final rootRelatedEvent = postData.rootRelatedEvent;
       pubkeysToPublish.addAll([
         parentEntity.masterPubkey,
-        if (rootRelatedEvent != null) rootRelatedEvent.eventReference.pubkey,
+        if (rootRelatedEvent != null) rootRelatedEvent.eventReference.masterPubkey,
       ]);
       final rootRef = rootRelatedEvent?.eventReference;
       final rootEntity = (rootRef != null
@@ -482,7 +482,7 @@ class CreatePostNotifier extends _$CreatePostNotifier {
   }) {
     final allPubkeys = <RelatedPubkey>{...mentions};
     if (quotedEvent != null) {
-      allPubkeys.add(RelatedPubkey(value: quotedEvent.pubkey));
+      allPubkeys.add(RelatedPubkey(value: quotedEvent.masterPubkey));
     }
 
     if (parentEntity != null) {

--- a/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
+++ b/lib/app/features/feed/create_post/views/components/reply_input_field/reply_input_field.dart
@@ -95,7 +95,7 @@ class ReplyInputField extends HookConsumerWidget {
               !(suggestionsState.isVisible && suggestionsState.suggestions.isNotEmpty))
             Padding(
               padding: EdgeInsetsDirectional.only(bottom: 12.0.s),
-              child: ReplyAuthorHeader(pubkey: eventReference.pubkey),
+              child: ReplyAuthorHeader(pubkey: eventReference.masterPubkey),
             ),
           Row(
             children: [

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/parent_entity.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/parent_entity.dart
@@ -31,7 +31,7 @@ class ParentEntity extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final parentEntity =
         ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
-    final userMetadata = ref.watch(userMetadataProvider(eventReference.pubkey)).valueOrNull;
+    final userMetadata = ref.watch(userMetadataProvider(eventReference.masterPubkey)).valueOrNull;
 
     if (parentEntity == null || userMetadata == null) {
       return const Skeleton(child: PostSkeleton());

--- a/lib/app/features/feed/create_post/views/pages/post_form_modal/components/quoted_entity.dart
+++ b/lib/app/features/feed/create_post/views/pages/post_form_modal/components/quoted_entity.dart
@@ -40,7 +40,7 @@ class QuotedEntity extends HookConsumerWidget {
               child: Post(
                 eventReference: eventReference,
                 displayQuote: false,
-                header: UserInfo(pubkey: eventReference.pubkey),
+                header: UserInfo(pubkey: eventReference.masterPubkey),
                 footer: const SizedBox.shrink(),
               ),
             );

--- a/lib/app/features/feed/data/models/bookmarks/bookmarks.f.dart
+++ b/lib/app/features/feed/data/models/bookmarks/bookmarks.f.dart
@@ -88,7 +88,7 @@ class BookmarksData with _$BookmarksData implements EventSerializable, Replaceab
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: BookmarksEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/feed/data/models/bookmarks/bookmarks_set.f.dart
+++ b/lib/app/features/feed/data/models/bookmarks/bookmarks_set.f.dart
@@ -126,7 +126,7 @@ class BookmarksSetData with _$BookmarksSetData implements EventSerializable, Rep
   @override
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: type,
       kind: BookmarksSetEntity.kind,
     );

--- a/lib/app/features/feed/data/models/entities/article_data.f.dart
+++ b/lib/app/features/feed/data/models/entities/article_data.f.dart
@@ -190,7 +190,7 @@ class ArticleData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: ArticleEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: replaceableEventId.value,
     );
   }

--- a/lib/app/features/feed/data/models/entities/event_count_error_entity.f.dart
+++ b/lib/app/features/feed/data/models/entities/event_count_error_entity.f.dart
@@ -69,7 +69,7 @@ class EventCountErrorData with _$EventCountErrorData {
     final masterPubkey = tags[MasterPubkeyTag.tagName]!.first[1];
 
     final eventReference =
-        eventId != null ? ImmutableEventReference(eventId: eventId, pubkey: pubkey) : null;
+        eventId != null ? ImmutableEventReference(eventId: eventId, masterPubkey: pubkey) : null;
 
     if (eventReference == null) {
       throw IncorrectEventTagsException(eventId: eventMessage.id);

--- a/lib/app/features/feed/data/models/entities/event_count_result_data.f.dart
+++ b/lib/app/features/feed/data/models/entities/event_count_result_data.f.dart
@@ -118,7 +118,7 @@ class EventCountResultData with _$EventCountResultData {
     final eventReference = eventRef != null
         ? ReplaceableEventReference.fromString(eventRef)
         : eventId != null
-            ? ImmutableEventReference(eventId: eventId, pubkey: pubkey)
+            ? ImmutableEventReference(eventId: eventId, masterPubkey: pubkey)
             : null;
 
     if (eventReference == null) {

--- a/lib/app/features/feed/data/models/entities/generic_repost.f.dart
+++ b/lib/app/features/feed/data/models/entities/generic_repost.f.dart
@@ -76,7 +76,7 @@ class GenericRepostData with _$GenericRepostData implements EventSerializable {
     final eventReference = eventRef != null
         ? ReplaceableEventReference.fromString(eventRef)
         : eventId != null
-            ? ImmutableEventReference(eventId: eventId, pubkey: pubkey)
+            ? ImmutableEventReference(eventId: eventId, masterPubkey: pubkey)
             : null;
 
     if (eventReference == null) {
@@ -102,7 +102,7 @@ class GenericRepostData with _$GenericRepostData implements EventSerializable {
       content: repostedEvent != null ? jsonEncode(repostedEvent!.toJson().last) : '',
       tags: [
         ...tags,
-        ['p', eventReference.pubkey],
+        ['p', eventReference.masterPubkey],
         ['k', kind.toString()],
         eventReference.toTag(),
       ],

--- a/lib/app/features/feed/data/models/entities/modifiable_post_data.f.dart
+++ b/lib/app/features/feed/data/models/entities/modifiable_post_data.f.dart
@@ -173,7 +173,7 @@ class ModifiablePostData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: ModifiablePostEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: replaceableEventId.value,
     );
   }

--- a/lib/app/features/feed/data/models/entities/reaction_data.f.dart
+++ b/lib/app/features/feed/data/models/entities/reaction_data.f.dart
@@ -82,7 +82,7 @@ class ReactionData with _$ReactionData implements EventSerializable {
     final eventReference = eventRef != null
         ? ReplaceableEventReference.fromString(eventRef)
         : eventId != null
-            ? ImmutableEventReference(eventId: eventId, pubkey: pubkey)
+            ? ImmutableEventReference(eventId: eventId, masterPubkey: pubkey)
             : null;
 
     if (eventReference == null) {
@@ -109,7 +109,7 @@ class ReactionData with _$ReactionData implements EventSerializable {
       content: content,
       tags: [
         ...tags,
-        ['p', eventReference.pubkey],
+        ['p', eventReference.masterPubkey],
         ['k', kind.toString()],
         eventReference.toTag(),
       ],

--- a/lib/app/features/feed/data/models/entities/repost_data.f.dart
+++ b/lib/app/features/feed/data/models/entities/repost_data.f.dart
@@ -75,7 +75,7 @@ class RepostData with _$RepostData implements EventSerializable {
     }
 
     return RepostData(
-      eventReference: ImmutableEventReference(eventId: eventId, pubkey: pubkey),
+      eventReference: ImmutableEventReference(eventId: eventId, masterPubkey: pubkey),
       repostedEvent: null,
     );
   }
@@ -93,7 +93,7 @@ class RepostData with _$RepostData implements EventSerializable {
       content: repostedEvent != null ? jsonEncode(repostedEvent!.toJson().last) : '',
       tags: [
         ...tags,
-        ['p', eventReference.pubkey],
+        ['p', eventReference.masterPubkey],
         ['e', eventReference.eventId],
       ],
     );

--- a/lib/app/features/feed/notifications/data/model/ion_notification.dart
+++ b/lib/app/features/feed/notifications/data/model/ion_notification.dart
@@ -26,7 +26,7 @@ final class CommentIonNotification extends IonNotification {
     required this.type,
     required this.eventReference,
     required super.timestamp,
-  }) : super(pubkeys: [eventReference.pubkey]);
+  }) : super(pubkeys: [eventReference.masterPubkey]);
 
   final CommentIonNotificationType type;
 
@@ -118,7 +118,7 @@ final class ContentIonNotification extends IonNotification {
     required this.type,
     required this.eventReference,
     required super.timestamp,
-  }) : super(pubkeys: [eventReference.pubkey]);
+  }) : super(pubkeys: [eventReference.masterPubkey]);
 
   final ContentIonNotificationType type;
 

--- a/lib/app/features/feed/providers/bookmarks_notifier.r.dart
+++ b/lib/app/features/feed/providers/bookmarks_notifier.r.dart
@@ -40,7 +40,7 @@ Future<Map<BookmarksSetType, BookmarksSetEntity?>> bookmarks(
     bookmarkTypesList.map((type) {
       final cacheKey = CacheableEntity.cacheKeyBuilder(
         eventReference: ReplaceableEventReference(
-          pubkey: pubkey,
+          masterPubkey: pubkey,
           kind: BookmarksSetEntity.kind,
           dTag: type.dTagName,
         ),

--- a/lib/app/features/feed/providers/delete_entity_provider.r.dart
+++ b/lib/app/features/feed/providers/delete_entity_provider.r.dart
@@ -125,13 +125,13 @@ Future<void> _deleteFromServer(Ref ref, IonConnectEntity entity) async {
   };
 
   final pubkeysToPublish = switch (entity) {
-    ReactionEntity() => [entity.data.eventReference.pubkey],
+    ReactionEntity() => [entity.data.eventReference.masterPubkey],
     PostEntity() => parseAndConvertDelta(
         entity.data.richText?.content,
         entity.data.content,
       ).extractPubkeys(),
-    RepostEntity() => [entity.data.eventReference.pubkey],
-    GenericRepostEntity() => [entity.data.eventReference.pubkey],
+    RepostEntity() => [entity.data.eventReference.masterPubkey],
+    GenericRepostEntity() => [entity.data.eventReference.masterPubkey],
     _ => <String>[],
   };
 
@@ -139,7 +139,7 @@ Future<void> _deleteFromServer(Ref ref, IonConnectEntity entity) async {
     events: [
       EventToDelete(
         eventReference: ImmutableEventReference(
-          pubkey: entity.masterPubkey,
+          masterPubkey: entity.masterPubkey,
           eventId: entity.id,
           kind: entityKind,
         ),

--- a/lib/app/features/feed/providers/feed_bookmarks_notifier.r.dart
+++ b/lib/app/features/feed/providers/feed_bookmarks_notifier.r.dart
@@ -249,7 +249,7 @@ class FeedBookmarkCollectionsNotifier extends _$FeedBookmarkCollectionsNotifier 
       final bookmarksData = BookmarksData(
         eventReferences: [
           ReplaceableEventReference(
-            pubkey: currentPubkey,
+            masterPubkey: currentPubkey,
             kind: BookmarksSetEntity.kind,
             dTag: BookmarksSetType.homeFeedCollections.dTagName,
           ),
@@ -259,7 +259,7 @@ class FeedBookmarkCollectionsNotifier extends _$FeedBookmarkCollectionsNotifier 
         type: BookmarksSetType.homeFeedCollections.dTagName,
         eventReferences: [
           ReplaceableEventReference(
-            pubkey: currentPubkey,
+            masterPubkey: currentPubkey,
             kind: BookmarksSetEntity.kind,
             dTag: BookmarksSetType.homeFeedCollectionsAll.dTagName,
           ),
@@ -288,7 +288,7 @@ class FeedBookmarkCollectionsNotifier extends _$FeedBookmarkCollectionsNotifier 
         );
       bookmarkCollections.add(
         ReplaceableEventReference(
-          pubkey: currentPubkey,
+          masterPubkey: currentPubkey,
           kind: BookmarksSetEntity.kind,
           dTag: BookmarksSetType.homeFeedCollectionsAll.dTagName,
         ),
@@ -314,7 +314,7 @@ class FeedBookmarkCollectionsNotifier extends _$FeedBookmarkCollectionsNotifier 
     final updatedCollectionsRefs = <ReplaceableEventReference>[
       ...currentBookmarkCollectionsRefs,
       ReplaceableEventReference(
-        pubkey: currentPubkey,
+        masterPubkey: currentPubkey,
         kind: BookmarksSetEntity.kind,
         dTag: newCollectionData.type,
       ),

--- a/lib/app/features/feed/providers/replies_data_source_provider.r.dart
+++ b/lib/app/features/feed/providers/replies_data_source_provider.r.dart
@@ -34,7 +34,7 @@ List<EntitiesDataSource>? repliesDataSource(
 
   final dataSources = [
     EntitiesDataSource(
-      actionSource: ActionSourceUser(eventReference.pubkey),
+      actionSource: ActionSourceUser(eventReference.masterPubkey),
       entityFilter: (entity) =>
           (entity is ModifiablePostEntity &&
               entity.data.parentEvent?.eventReference == eventReference) ||

--- a/lib/app/features/feed/providers/repost_notifier.r.dart
+++ b/lib/app/features/feed/providers/repost_notifier.r.dart
@@ -74,7 +74,7 @@ class RepostNotifier extends _$RepostNotifier {
         ionNotifier.sendEvent(repostEvent),
         ionNotifier.sendEvent(
           repostEvent,
-          actionSource: ActionSourceUser(eventReference.pubkey),
+          actionSource: ActionSourceUser(eventReference.masterPubkey),
           metadataBuilders: [userEventsMetadataBuilder],
           cache: false,
         )

--- a/lib/app/features/feed/stories/providers/story_reply_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_reply_provider.r.dart
@@ -151,7 +151,7 @@ class StoryReply extends _$StoryReply {
             quotedEvent: QuotedImmutableEvent(
               eventReference: ImmutableEventReference(
                 eventId: kind16Rumor.id,
-                pubkey: kind16Rumor.masterPubkey,
+                masterPubkey: kind16Rumor.masterPubkey,
                 kind: GenericRepostEntity.kind,
               ),
             ),

--- a/lib/app/features/feed/views/components/article/article.dart
+++ b/lib/app/features/feed/views/components/article/article.dart
@@ -103,7 +103,7 @@ class Article extends ConsumerWidget {
             header!
           else if (isReplied) ...[
             UserInfo(
-              pubkey: eventReference.pubkey,
+              pubkey: eventReference.masterPubkey,
               createdAt: entity.data.publishedAt.value,
               timeFormat: timeFormat,
               trailing: showActionButtons
@@ -155,7 +155,7 @@ class Article extends ConsumerWidget {
                               header!
                             else if (!isReplied) ...[
                               UserInfo(
-                                pubkey: eventReference.pubkey,
+                                pubkey: eventReference.masterPubkey,
                                 createdAt: entity.data.publishedAt.value,
                                 timeFormat: timeFormat,
                                 trailing: showActionButtons
@@ -174,7 +174,7 @@ class Article extends ConsumerWidget {
                             ],
                             ArticleImage(
                               imageUrl: entity.data.image,
-                              authorPubkey: eventReference.pubkey,
+                              authorPubkey: eventReference.masterPubkey,
                               minutesToRead: calculateReadingTime(entity.data.content),
                             ),
                             SizedBox(height: 10.0.s),

--- a/lib/app/features/feed/views/components/overlay_menu/user_info_menu.dart
+++ b/lib/app/features/feed/views/components/overlay_menu/user_info_menu.dart
@@ -42,7 +42,7 @@ class UserInfoMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userMetadata = ref.watch(cachedUserMetadataProvider(eventReference.pubkey));
+    final userMetadata = ref.watch(cachedUserMetadataProvider(eventReference.masterPubkey));
     final isArticle = eventReference is ReplaceableEventReference &&
         (eventReference as ReplaceableEventReference).kind == ArticleEntity.kind;
 
@@ -64,7 +64,7 @@ class UserInfoMenu extends ConsumerWidget {
           children: [
             OverlayMenuContainer(
               child: _NotInterestedMenuItem(
-                pubkey: eventReference.pubkey,
+                pubkey: eventReference.masterPubkey,
                 closeMenu: closeMenu,
               ),
             ),
@@ -73,12 +73,12 @@ class UserInfoMenu extends ConsumerWidget {
               child: Column(
                 children: [
                   _FollowUserMenuItem(
-                    pubkey: eventReference.pubkey,
+                    pubkey: eventReference.masterPubkey,
                     username: userMetadata.data.name,
                     closeMenu: closeMenu,
                   ),
                   _BlockUserMenuItem(
-                    pubkey: eventReference.pubkey,
+                    pubkey: eventReference.masterPubkey,
                     username: userMetadata.data.name,
                     closeMenu: closeMenu,
                   ),

--- a/lib/app/features/feed/views/components/post/components/post_body/components/post_media/components/post_media_item.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/components/post_media/components/post_media_item.dart
@@ -56,13 +56,13 @@ class PostMediaItem extends HookWidget {
             MediaType.image => FeedIONConnectNetworkImage(
                 imageUrl: mediaItem.url,
                 fit: BoxFit.cover,
-                authorPubkey: eventReference.pubkey,
+                authorPubkey: eventReference.masterPubkey,
               ),
             MediaType.video => VideoPreview(
                 autoplay: videoAutoplay,
                 videoUrl: mediaItem.url,
+                authorPubkey: eventReference.masterPubkey,
                 thumbnailUrl: mediaItem.thumb,
-                authorPubkey: eventReference.pubkey,
                 framedEventReference: framedEventReference,
               ),
             _ => const SizedBox.shrink(),

--- a/lib/app/features/feed/views/components/post/post.dart
+++ b/lib/app/features/feed/views/components/post/post.dart
@@ -132,7 +132,7 @@ class Post extends ConsumerWidget {
         ScreenSideOffset.small(
           child: header ??
               UserInfo(
-                pubkey: eventReference.pubkey,
+                pubkey: eventReference.masterPubkey,
                 createdAt: entity is ModifiablePostEntity
                     ? entity.data.publishedAt.value
                     : entity.createdAt,
@@ -335,7 +335,7 @@ final class _QuotedPost extends ConsumerWidget {
             displayQuote: false,
             header: header ??
                 UserInfo(
-                  pubkey: eventReference.pubkey,
+                  pubkey: eventReference.masterPubkey,
                   createdAt: postEntity is ModifiablePostEntity
                       ? postEntity.data.publishedAt.value
                       : postEntity?.createdAt,

--- a/lib/app/features/feed/views/pages/article_details_page/article_details_page.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/article_details_page.dart
@@ -43,7 +43,8 @@ class ArticleDetailsPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final articleEntity =
         ref.watch(ionConnectEntityWithCountersProvider(eventReference: eventReference));
-    final isOwnedByCurrentUser = ref.watch(isCurrentUserSelectorProvider(eventReference.pubkey));
+    final isOwnedByCurrentUser =
+        ref.watch(isCurrentUserSelectorProvider(eventReference.masterPubkey));
 
     if (articleEntity is! ArticleEntity) {
       return const SizedBox.shrink();

--- a/lib/app/features/feed/views/pages/article_details_page/components/more_articles_from_author.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/more_articles_from_author.dart
@@ -24,7 +24,7 @@ class MoreArticlesFromAuthor extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final dataSource = ref.watch(userArticlesDataSourceProvider(eventReference.pubkey));
+    final dataSource = ref.watch(userArticlesDataSourceProvider(eventReference.masterPubkey));
     final entitiesPagedData = ref.watch(entitiesPagedDataProvider(dataSource));
 
     final articlesReferences = entitiesPagedData?.data.items
@@ -34,7 +34,7 @@ class MoreArticlesFromAuthor extends ConsumerWidget {
         .toList();
 
     final authorDisplayName = ref.watch(
-      userMetadataProvider(eventReference.pubkey)
+      userMetadataProvider(eventReference.masterPubkey)
           .select((value) => value.valueOrNull?.data.displayName),
     );
 
@@ -51,7 +51,7 @@ class MoreArticlesFromAuthor extends ConsumerWidget {
             count: articlesReferences.length,
             trailing: GestureDetector(
               onTap: () =>
-                  ArticlesFromAuthorRoute(pubkey: eventReference.pubkey).push<void>(context),
+                  ArticlesFromAuthorRoute(pubkey: eventReference.masterPubkey).push<void>(context),
               child: Assets.svg.iconButtonNext.icon(),
             ),
           ),

--- a/lib/app/features/feed/views/pages/article_details_page/components/user_biography.dart
+++ b/lib/app/features/feed/views/pages/article_details_page/components/user_biography.dart
@@ -31,14 +31,14 @@ class UserBiography extends ConsumerWidget {
       child: Column(
         children: [
           UserInfo(
-            pubkey: eventReference.pubkey,
+            pubkey: eventReference.masterPubkey,
           ),
           SizedBox(height: 12.0.s),
           UserAbout(
-            pubkey: eventReference.pubkey,
+            pubkey: eventReference.masterPubkey,
             padding: EdgeInsetsDirectional.only(bottom: 12.0.s),
           ),
-          UserInfoSummary(pubkey: eventReference.pubkey),
+          UserInfoSummary(pubkey: eventReference.masterPubkey),
         ],
       ),
     );

--- a/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_videos_list_item.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/trending_videos/components/trending_videos_list_item.dart
@@ -108,7 +108,7 @@ class _VideoContainer extends StatelessWidget {
           children: [
             FeedIONConnectNetworkImage(
               imageUrl: thumbnailUrl,
-              authorPubkey: eventReference.pubkey,
+              authorPubkey: eventReference.masterPubkey,
               fit: BoxFit.cover,
               height: size.height,
               width: size.width,
@@ -117,7 +117,7 @@ class _VideoContainer extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 _TopControls(eventReference: eventReference),
-                TrendingVideoAuthor(pubkey: eventReference.pubkey),
+                TrendingVideoAuthor(pubkey: eventReference.masterPubkey),
               ],
             ),
           ],

--- a/lib/app/features/feed/views/pages/fullscreen_media/components/image_carousel.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/components/image_carousel.dart
@@ -67,7 +67,7 @@ class ImageCarousel extends HookConsumerWidget {
               return CarouselImageItem(
                 key: ValueKey(images[index].url),
                 imageUrl: images[index].url,
-                authorPubkey: eventReference.pubkey,
+                authorPubkey: eventReference.masterPubkey,
                 zoomController: zoomController,
                 bottomOverlayBuilder: index == currentPage.value
                     ? (context) => SafeArea(

--- a/lib/app/features/feed/views/pages/fullscreen_media/components/single_media_view.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/components/single_media_view.dart
@@ -40,7 +40,7 @@ class SingleMediaView extends HookWidget {
         videoInfo: VideoPostInfo(videoPost: post),
         bottomOverlay: VideoActions(eventReference: eventReference),
         videoUrl: media.url,
-        authorPubkey: eventReference.pubkey,
+        authorPubkey: eventReference.masterPubkey,
         thumbnailUrl: media.thumb,
         blurhash: media.blurhash,
         aspectRatio: media.aspectRatio,
@@ -51,7 +51,7 @@ class SingleMediaView extends HookWidget {
 
     return FullscreenImage(
       imageUrl: media.url,
-      authorPubkey: eventReference.pubkey,
+      authorPubkey: eventReference.masterPubkey,
       bottomOverlayBuilder: (context) => SafeArea(
         top: false,
         child: ColoredBox(

--- a/lib/app/features/feed/views/pages/fullscreen_media/fullscreen_media_page.dart
+++ b/lib/app/features/feed/views/pages/fullscreen_media/fullscreen_media_page.dart
@@ -31,7 +31,8 @@ class FullscreenMediaPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     useStatusBarColor();
 
-    final isOwnedByCurrentUser = ref.watch(isCurrentUserSelectorProvider(eventReference.pubkey));
+    final isOwnedByCurrentUser =
+        ref.watch(isCurrentUserSelectorProvider(eventReference.masterPubkey));
 
     return Material(
       color: Colors.transparent,

--- a/lib/app/features/feed/views/pages/who_can_reply_info_modal/who_can_reply_info_modal.dart
+++ b/lib/app/features/feed/views/pages/who_can_reply_info_modal/who_can_reply_info_modal.dart
@@ -56,7 +56,7 @@ class WhoCanReplyInfoModal extends HookConsumerWidget {
     };
     if (whoCanReplySetting == null) return '';
 
-    final userMetadata = ref.watch(cachedUserMetadataProvider(eventReference.pubkey));
+    final userMetadata = ref.watch(cachedUserMetadataProvider(eventReference.masterPubkey));
     String commonDescription() => context.i18n.who_can_reply_info_modal_description(
           userMetadata?.data.displayName ?? '',
           context.i18n.who_can_reply_info_modal_setting(whoCanReplySetting.tagValue),

--- a/lib/app/features/ion_connect/model/deletion_request.f.dart
+++ b/lib/app/features/ion_connect/model/deletion_request.f.dart
@@ -70,7 +70,7 @@ class DeletionRequest with _$DeletionRequest implements EventSerializable {
         ImmutableEventReference(
           eventId: immutableEventIds[i].last,
           kind: int.parse(immutableEventKinds[i].last),
-          pubkey: eventMessage.masterPubkey,
+          masterPubkey: eventMessage.masterPubkey,
         ),
       ...replaceableEvents.map(ReplaceableEventReference.fromTag),
     ];

--- a/lib/app/features/ion_connect/model/event_reference.f.dart
+++ b/lib/app/features/ion_connect/model/event_reference.f.dart
@@ -41,7 +41,7 @@ abstract class EventReference {
     };
   }
 
-  String get pubkey;
+  String get masterPubkey;
 
   String encode();
 
@@ -55,7 +55,7 @@ abstract class EventReference {
 @Freezed(toStringOverride: false)
 class ImmutableEventReference with _$ImmutableEventReference implements EventReference {
   const factory ImmutableEventReference({
-    required String pubkey,
+    required String masterPubkey,
     required String eventId,
     int? kind,
   }) = _ImmutableEventReference;
@@ -67,7 +67,7 @@ class ImmutableEventReference with _$ImmutableEventReference implements EventRef
       throw IncorrectEventTagNameException(actual: tag[0], expected: tagName);
     }
 
-    return ImmutableEventReference(pubkey: tag[3], eventId: tag[1]);
+    return ImmutableEventReference(masterPubkey: tag[3], eventId: tag[1]);
   }
 
   factory ImmutableEventReference.fromShareableIdentifier(ShareableIdentifier identifier) {
@@ -77,12 +77,12 @@ class ImmutableEventReference with _$ImmutableEventReference implements EventRef
       throw IncorrectShareableIdentifierException(identifier);
     }
 
-    return ImmutableEventReference(eventId: special, pubkey: author, kind: kind);
+    return ImmutableEventReference(eventId: special, masterPubkey: author, kind: kind);
   }
 
   @override
   List<String> toTag() {
-    return [tagName, eventId, '', pubkey];
+    return [tagName, eventId, '', masterPubkey];
   }
 
   @override
@@ -91,7 +91,7 @@ class ImmutableEventReference with _$ImmutableEventReference implements EventRef
       IonConnectUriIdentifierService(bech32Service: Bech32Service()).encodeShareableIdentifiers(
         prefix: IonConnectProtocolIdentifierType.nevent,
         special: eventId,
-        author: pubkey,
+        author: masterPubkey,
         kind: kind,
       ),
     );
@@ -118,7 +118,7 @@ class ImmutableEventReference with _$ImmutableEventReference implements EventRef
 @Freezed(toStringOverride: false)
 class ReplaceableEventReference with _$ReplaceableEventReference implements EventReference {
   const factory ReplaceableEventReference({
-    required String pubkey,
+    required String masterPubkey,
     required int kind,
     @Default('') String dTag,
   }) = _ReplaceableEventReference;
@@ -139,7 +139,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
     if (prefix == IonConnectProtocolIdentifierType.nprofile) {
       return ReplaceableEventReference(
         kind: UserMetadataEntity.kind,
-        pubkey: special,
+        masterPubkey: special,
       );
     } else {
       if (author == null || kind == null) {
@@ -148,7 +148,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
 
       return ReplaceableEventReference(
         kind: kind,
-        pubkey: author,
+        masterPubkey: author,
         dTag: special,
       );
     }
@@ -159,7 +159,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
 
     return ReplaceableEventReference(
       kind: int.parse(parts[0]),
-      pubkey: parts[1],
+      masterPubkey: parts[1],
       dTag: parts[2],
     );
   }
@@ -168,7 +168,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
   List<String> toTag() {
     return [
       tagName,
-      [kind, pubkey, dTag].join(EventReference.separator),
+      [kind, masterPubkey, dTag].join(EventReference.separator),
     ];
   }
 
@@ -178,7 +178,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
       return IonConnectUriProtocolService().encode(
         IonConnectUriIdentifierService(bech32Service: Bech32Service()).encodeShareableIdentifiers(
           prefix: IonConnectProtocolIdentifierType.nprofile,
-          special: pubkey,
+          special: masterPubkey,
         ),
       );
     } else {
@@ -186,7 +186,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
         IonConnectUriIdentifierService(bech32Service: Bech32Service()).encodeShareableIdentifiers(
           prefix: IonConnectProtocolIdentifierType.naddr,
           special: dTag,
-          author: pubkey,
+          author: masterPubkey,
           kind: kind,
         ),
       );
@@ -200,7 +200,7 @@ class ReplaceableEventReference with _$ReplaceableEventReference implements Even
 
   @override
   String toString() {
-    return [kind, pubkey, dTag].join(EventReference.separator);
+    return [kind, masterPubkey, dTag].join(EventReference.separator);
   }
 
   static const String tagName = 'a';

--- a/lib/app/features/ion_connect/model/ion_connect_entity.dart
+++ b/lib/app/features/ion_connect/model/ion_connect_entity.dart
@@ -42,7 +42,7 @@ abstract mixin class IonConnectEntityReferenceable {
 mixin ImmutableEntity on IonConnectEntity implements IonConnectEntityReferenceable {
   @override
   ImmutableEventReference toEventReference() {
-    return ImmutableEventReference(eventId: id, pubkey: masterPubkey);
+    return ImmutableEventReference(eventId: id, masterPubkey: masterPubkey);
   }
 }
 

--- a/lib/app/features/ion_connect/model/mute_set.f.dart
+++ b/lib/app/features/ion_connect/model/mute_set.f.dart
@@ -111,7 +111,7 @@ class MuteSetData with _$MuteSetData implements EventSerializable, ReplaceableEn
   @override
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: type.dTagName,
       kind: MuteSetEntity.kind,
     );

--- a/lib/app/features/ion_connect/model/quoted_event.f.dart
+++ b/lib/app/features/ion_connect/model/quoted_event.f.dart
@@ -43,7 +43,7 @@ class QuotedReplaceableEvent with _$QuotedReplaceableEvent implements QuotedEven
 
   @override
   List<String> toTag() {
-    return [tagName, eventReference.toString(), '', eventReference.pubkey];
+    return [tagName, eventReference.toString(), '', eventReference.masterPubkey];
   }
 
   static const String tagName = 'Q';
@@ -66,13 +66,13 @@ class QuotedImmutableEvent with _$QuotedImmutableEvent implements QuotedEvent {
       throw IncorrectEventTagException(tag: tag.toString());
     }
     return QuotedImmutableEvent(
-      eventReference: ImmutableEventReference(eventId: tag[1], pubkey: tag[3]),
+      eventReference: ImmutableEventReference(eventId: tag[1], masterPubkey: tag[3]),
     );
   }
 
   @override
   List<String> toTag() {
-    return [tagName, eventReference.toString(), '', eventReference.pubkey];
+    return [tagName, eventReference.toString(), '', eventReference.masterPubkey];
   }
 
   static const String tagName = 'q';

--- a/lib/app/features/ion_connect/model/related_event.f.dart
+++ b/lib/app/features/ion_connect/model/related_event.f.dart
@@ -23,12 +23,12 @@ abstract class RelatedEvent {
     return switch (eventReference) {
       ImmutableEventReference() => RelatedImmutableEvent(
           eventReference: eventReference,
-          pubkey: eventReference.pubkey,
+          pubkey: eventReference.masterPubkey,
           marker: marker,
         ),
       ReplaceableEventReference() => RelatedReplaceableEvent(
           eventReference: eventReference,
-          pubkey: eventReference.pubkey,
+          pubkey: eventReference.masterPubkey,
           marker: marker,
         ),
       _ => throw UnsupportedEventReference(eventReference),
@@ -72,7 +72,7 @@ class RelatedImmutableEvent with _$RelatedImmutableEvent implements RelatedEvent
     }
 
     return RelatedImmutableEvent(
-      eventReference: ImmutableEventReference(eventId: tag[1], pubkey: tag[4]),
+      eventReference: ImmutableEventReference(eventId: tag[1], masterPubkey: tag[4]),
       marker: RelatedEventMarker.values.byName(tag[3]),
       pubkey: tag[4],
     );

--- a/lib/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart
@@ -32,7 +32,7 @@ Future<IonConnectEntity?> ionConnectNetworkEntity(
   String? search,
   ActionSource? actionSource,
 }) async {
-  final aSource = actionSource ?? ActionSourceUser(eventReference.pubkey);
+  final aSource = actionSource ?? ActionSourceUser(eventReference.masterPubkey);
   if (eventReference is ImmutableEventReference) {
     final requestMessage = RequestMessage()
       ..addFilter(
@@ -52,7 +52,7 @@ Future<IonConnectEntity?> ionConnectNetworkEntity(
       ..addFilter(
         RequestFilter(
           kinds: [eventReference.kind],
-          authors: [eventReference.pubkey],
+          authors: [eventReference.masterPubkey],
           tags: {
             if (eventReference.dTag.isNotEmpty) '#d': [eventReference.dTag],
           },

--- a/lib/app/features/optimistic_ui/features/likes/like_sync_strategy_provider.r.dart
+++ b/lib/app/features/optimistic_ui/features/likes/like_sync_strategy_provider.r.dart
@@ -26,7 +26,7 @@ SyncStrategy<PostLike> likeSyncStrategy(Ref ref) {
         ionNotifier.sendEvent(reactionEvent),
         ionNotifier.sendEvent(
           reactionEvent,
-          actionSource: ActionSourceUser(reaction.eventReference.pubkey),
+          actionSource: ActionSourceUser(reaction.eventReference.masterPubkey),
           metadataBuilders: [userEventsMetadataBuilder],
           cache: false,
         ),

--- a/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
+++ b/lib/app/features/push_notifications/data/models/ion_connect_push_data_payload.f.dart
@@ -92,7 +92,8 @@ class IonConnectPushDataPayload {
       return PushNotificationType.repost;
     } else if (entity is ModifiablePostEntity || entity is PostEntity) {
       final currentUserMention =
-          ReplaceableEventReference(pubkey: currentPubkey, kind: UserMetadataEntity.kind).encode();
+          ReplaceableEventReference(masterPubkey: currentPubkey, kind: UserMetadataEntity.kind)
+              .encode();
       final content = switch (entity) {
         ModifiablePostEntity() => entity.data.content,
         PostEntity() => entity.data.content,
@@ -202,11 +203,11 @@ class IonConnectPushDataPayload {
       return relatedPubkeys != null &&
           relatedPubkeys.any((relatedPubkey) => relatedPubkey.value == currentPubkey);
     } else if (entity is GenericRepostEntity) {
-      return entity.data.eventReference.pubkey == currentPubkey;
+      return entity.data.eventReference.masterPubkey == currentPubkey;
     } else if (entity is RepostEntity) {
-      return entity.data.eventReference.pubkey == currentPubkey;
+      return entity.data.eventReference.masterPubkey == currentPubkey;
     } else if (entity is ReactionEntity) {
-      return entity.data.eventReference.pubkey == currentPubkey;
+      return entity.data.eventReference.masterPubkey == currentPubkey;
     } else if (entity is FollowListEntity) {
       return entity.pubkeys.lastOrNull == currentPubkey;
     } else if (entity is IonConnectGiftWrapEntity) {

--- a/lib/app/features/push_notifications/data/models/push_subscription.f.dart
+++ b/lib/app/features/push_notifications/data/models/push_subscription.f.dart
@@ -111,7 +111,7 @@ class PushSubscriptionData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: PushSubscriptionEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: deviceId,
     );
   }

--- a/lib/app/features/push_notifications/providers/push_subscription_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/push_subscription_provider.r.dart
@@ -20,7 +20,7 @@ Future<PushSubscriptionEntity?> currentUserPushSubscription(Ref ref) async {
   final deviceId = await ref.watch(deviceIdServiceProvider).get();
 
   final eventReference = ReplaceableEventReference(
-    pubkey: currentPubkey,
+    masterPubkey: currentPubkey,
     kind: PushSubscriptionEntity.kind,
     dTag: deviceId,
   );

--- a/lib/app/features/push_notifications/providers/push_subscription_sync_provider.r.dart
+++ b/lib/app/features/push_notifications/providers/push_subscription_sync_provider.r.dart
@@ -57,7 +57,7 @@ class PushSubscriptionSync extends _$PushSubscriptionSync {
             events: [
               EventToDelete(
                 eventReference: ImmutableEventReference(
-                  pubkey: entity.masterPubkey,
+                  masterPubkey: entity.masterPubkey,
                   eventId: entity.id,
                   kind: PushSubscriptionEntity.kind,
                 ),

--- a/lib/app/features/user/model/account_notifications_sets.f.dart
+++ b/lib/app/features/user/model/account_notifications_sets.f.dart
@@ -122,7 +122,7 @@ class AccountNotificationSetData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: AccountNotificationSetEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: type.dTagName,
     );
   }

--- a/lib/app/features/user/model/badges/badge_definition.f.dart
+++ b/lib/app/features/user/model/badges/badge_definition.f.dart
@@ -156,7 +156,7 @@ class BadgeDefinitionData
   @override
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: badge.value,
       kind: BadgeDefinitionEntity.kind,
     );

--- a/lib/app/features/user/model/badges/profile_badges.f.dart
+++ b/lib/app/features/user/model/badges/profile_badges.f.dart
@@ -113,7 +113,7 @@ class ProfileBadgesData
   @override
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: ProfileBadgesEntity.dTag,
       kind: ProfileBadgesEntity.kind,
     );

--- a/lib/app/features/user/model/block_list.f.dart
+++ b/lib/app/features/user/model/block_list.f.dart
@@ -81,7 +81,7 @@ class BlockListData with _$BlockListData implements EventSerializable, Replaceab
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: BlockListEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/model/follow_list.f.dart
+++ b/lib/app/features/user/model/follow_list.f.dart
@@ -87,7 +87,7 @@ class FollowListData with _$FollowListData implements EventSerializable, Replace
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: FollowListEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/model/interest_set.f.dart
+++ b/lib/app/features/user/model/interest_set.f.dart
@@ -96,7 +96,7 @@ class InterestSetData with _$InterestSetData implements EventSerializable, Repla
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: InterestSetEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
       dTag: type.toShortString(),
     );
   }

--- a/lib/app/features/user/model/interests.f.dart
+++ b/lib/app/features/user/model/interests.f.dart
@@ -89,7 +89,7 @@ class InterestsData with _$InterestsData implements EventSerializable, Replaceab
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: InterestsEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/model/user_chat_relays.f.dart
+++ b/lib/app/features/user/model/user_chat_relays.f.dart
@@ -95,7 +95,7 @@ class UserChatRelaysData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: UserChatRelaysEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 

--- a/lib/app/features/user/model/user_delegation.f.dart
+++ b/lib/app/features/user/model/user_delegation.f.dart
@@ -128,7 +128,7 @@ class UserDelegationData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: UserDelegationEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/model/user_file_storage_relays.f.dart
+++ b/lib/app/features/user/model/user_file_storage_relays.f.dart
@@ -95,7 +95,7 @@ class UserFileStorageRelaysData
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: UserFileStorageRelaysEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/model/user_metadata.f.dart
+++ b/lib/app/features/user/model/user_metadata.f.dart
@@ -143,7 +143,7 @@ class UserMetadata with _$UserMetadata implements EventSerializable, Replaceable
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: UserMetadataEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/model/user_relays.f.dart
+++ b/lib/app/features/user/model/user_relays.f.dart
@@ -92,7 +92,7 @@ class UserRelaysData with _$UserRelaysData implements EventSerializable, Replace
   ReplaceableEventReference toReplaceableEventReference(String pubkey) {
     return ReplaceableEventReference(
       kind: UserRelaysEntity.kind,
-      pubkey: pubkey,
+      masterPubkey: pubkey,
     );
   }
 }

--- a/lib/app/features/user/pages/profile_page/components/header/context_menu.dart
+++ b/lib/app/features/user/pages/profile_page/components/header/context_menu.dart
@@ -44,7 +44,7 @@ class ContextMenu extends ConsumerWidget {
                 closeMenu();
                 ShareViaMessageModalRoute(
                   eventReference:
-                      ReplaceableEventReference(pubkey: pubkey, kind: UserMetadataEntity.kind)
+                      ReplaceableEventReference(masterPubkey: pubkey, kind: UserMetadataEntity.kind)
                           .encode(),
                 ).push<void>(context);
               },

--- a/lib/app/features/user/providers/account_notifications_sync_provider.r.dart
+++ b/lib/app/features/user/providers/account_notifications_sync_provider.r.dart
@@ -156,7 +156,7 @@ class AccountNotificationsSync extends _$AccountNotificationsSync {
       final accountNotificationSet = await ref.read(
         ionConnectEntityProvider(
           eventReference: ReplaceableEventReference(
-            pubkey: currentPubkey,
+            masterPubkey: currentPubkey,
             kind: AccountNotificationSetEntity.kind,
             dTag: setType.dTagName,
           ),
@@ -190,7 +190,7 @@ class AccountNotificationsSync extends _$AccountNotificationsSync {
       final accountNotificationSet = await ref.read(
         ionConnectEntityProvider(
           eventReference: ReplaceableEventReference(
-            pubkey: currentPubkey,
+            masterPubkey: currentPubkey,
             kind: AccountNotificationSetEntity.kind,
             dTag: setType.dTagName,
           ),
@@ -300,7 +300,7 @@ class AccountNotificationsSync extends _$AccountNotificationsSync {
     final notificationSet = await ref.read(
       ionConnectEntityProvider(
         eventReference: ReplaceableEventReference(
-          pubkey: currentPubkey,
+          masterPubkey: currentPubkey,
           kind: AccountNotificationSetEntity.kind,
           dTag: setType.dTagName,
         ),

--- a/lib/app/features/user/providers/badge_award_handler.r.dart
+++ b/lib/app/features/user/providers/badge_award_handler.r.dart
@@ -43,7 +43,7 @@ class BadgeAwardHandler extends GlobalSubscriptionEventHandler {
     final eventRef = badgeAwardEntity.data.badgeDefinitionRef;
     if (eventRef.kind == BadgeDefinitionEntity.kind &&
         eventRef.dTag == BadgeDefinitionEntity.verifiedBadgeDTag &&
-        (pubkeys.isEmpty || pubkeys.contains(eventRef.pubkey))) {
+        (pubkeys.isEmpty || pubkeys.contains(eventRef.masterPubkey))) {
       final updatedData = await ref.read(
         updatedProfileBadgesProvider(
           BadgeEntry(

--- a/lib/app/features/user/providers/badges_notifier.r.dart
+++ b/lib/app/features/user/providers/badges_notifier.r.dart
@@ -30,7 +30,7 @@ BadgeAwardEntity? cachedBadgeAward(
 ) {
   final badgeAwardEntityList = servicePubkeys.map((pubkey) {
     final cacheKey = CacheableEntity.cacheKeyBuilder(
-      eventReference: ImmutableEventReference(pubkey: pubkey, eventId: eventId),
+      eventReference: ImmutableEventReference(masterPubkey: pubkey, eventId: eventId),
     );
     return ref.watch(
       ionConnectCacheProvider.select(cacheSelector<BadgeAwardEntity>(cacheKey)),
@@ -48,7 +48,7 @@ ProfileBadgesEntity? cachedProfileBadgesData(
   return ref.watch(
     ionConnectCachedEntityProvider(
       eventReference: ReplaceableEventReference(
-        pubkey: pubkey,
+        masterPubkey: pubkey,
         kind: ProfileBadgesEntity.kind,
         dTag: ProfileBadgesEntity.dTag,
       ),
@@ -70,7 +70,7 @@ Future<BadgeDefinitionEntity?> badgeDefinitionEntity(
       .map((pubkey) {
         final cacheKey = CacheableEntity.cacheKeyBuilder(
           eventReference: ReplaceableEventReference(
-            pubkey: pubkey,
+            masterPubkey: pubkey,
             kind: BadgeDefinitionEntity.kind,
             dTag: dTag,
           ),
@@ -90,7 +90,7 @@ Future<BadgeDefinitionEntity?> badgeDefinitionEntity(
     final fetchedEntity = await ref.watch(
       ionConnectNetworkEntityProvider(
         eventReference: ReplaceableEventReference(
-          pubkey: pubkey,
+          masterPubkey: pubkey,
           kind: BadgeDefinitionEntity.kind,
           dTag: dTag,
         ),
@@ -113,7 +113,7 @@ Future<ProfileBadgesData?> profileBadgesData(
   final profileBadgesEntity = await ref.watch(
     ionConnectEntityProvider(
       eventReference: ReplaceableEventReference(
-        pubkey: pubkey,
+        masterPubkey: pubkey,
         kind: ProfileBadgesEntity.kind,
         dTag: ProfileBadgesEntity.dTag,
       ),
@@ -130,7 +130,7 @@ bool isValidVerifiedBadgeDefinition(
   List<String> servicePubkeys,
 ) {
   return badgeRef.dTag == BadgeDefinitionEntity.verifiedBadgeDTag &&
-      (servicePubkeys.isEmpty || servicePubkeys.contains(badgeRef.pubkey)) &&
+      (servicePubkeys.isEmpty || servicePubkeys.contains(badgeRef.masterPubkey)) &&
       badgeRef.kind == BadgeDefinitionEntity.kind;
 }
 
@@ -141,7 +141,7 @@ bool isValidNicknameProofBadgeDefinition(
   List<String> servicePubkeys,
 ) {
   return badgeRef.dTag.startsWith(BadgeDefinitionEntity.usernameProofOfOwnershipBadgeDTag) &&
-      (servicePubkeys.isEmpty || servicePubkeys.contains(badgeRef.pubkey)) &&
+      (servicePubkeys.isEmpty || servicePubkeys.contains(badgeRef.masterPubkey)) &&
       badgeRef.kind == BadgeDefinitionEntity.kind;
 }
 
@@ -220,7 +220,7 @@ Future<VerifiedBadgeEntities?> currentUserVerifiedBadgeData(Ref ref) async {
   final profileEntity = ref.watch(
     ionConnectCachedEntityProvider(
       eventReference: ReplaceableEventReference(
-        pubkey: currentPubkey,
+        masterPubkey: currentPubkey,
         kind: ProfileBadgesEntity.kind,
         dTag: ProfileBadgesEntity.dTag,
       ),
@@ -243,7 +243,7 @@ Future<VerifiedBadgeEntities?> currentUserVerifiedBadgeData(Ref ref) async {
       ? ref.watch(
           ionConnectCachedEntityProvider(
             eventReference: ReplaceableEventReference(
-              pubkey: verifiedEntry.definitionRef.pubkey,
+              masterPubkey: verifiedEntry.definitionRef.masterPubkey,
               kind: BadgeDefinitionEntity.kind,
               dTag: BadgeDefinitionEntity.verifiedBadgeDTag,
             ),

--- a/lib/app/features/user/providers/follow_list_provider.r.dart
+++ b/lib/app/features/user/providers/follow_list_provider.r.dart
@@ -23,7 +23,7 @@ Future<FollowListEntity?> followList(
 }) async {
   return await ref.watch(
     ionConnectEntityProvider(
-      eventReference: ReplaceableEventReference(pubkey: pubkey, kind: FollowListEntity.kind),
+      eventReference: ReplaceableEventReference(masterPubkey: pubkey, kind: FollowListEntity.kind),
       network: network,
       cache: cache,
     ).future,

--- a/lib/app/features/user/providers/muted_users_notifier.r.dart
+++ b/lib/app/features/user/providers/muted_users_notifier.r.dart
@@ -52,7 +52,7 @@ MuteSetEntity? cachedMutedUsers(Ref ref) {
   return ref.watch(
     ionConnectSyncEntityProvider(
       eventReference: ReplaceableEventReference(
-        pubkey: currentUserMasterPubkey,
+        masterPubkey: currentUserMasterPubkey,
         kind: MuteSetEntity.kind,
         dTag: MuteSetType.notInterested.dTagName,
       ),

--- a/lib/app/features/user/providers/report_notifier.m.dart
+++ b/lib/app/features/user/providers/report_notifier.m.dart
@@ -7,8 +7,8 @@ import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/services/mail/mail.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'report_notifier.m.g.dart';
 part 'report_notifier.m.freezed.dart';
+part 'report_notifier.m.g.dart';
 
 @freezed
 sealed class ReportReason with _$ReportReason {
@@ -40,7 +40,7 @@ class ReportNotifier extends _$ReportNotifier {
   String _getReportBody(ReportReason reason) {
     return switch (reason) {
       ReportReasonUser() =>
-        'This is a report for the user ${ReplaceableEventReference(pubkey: reason.pubkey, kind: UserMetadataEntity.kind).encode()}',
+        'This is a report for the user ${ReplaceableEventReference(masterPubkey: reason.pubkey, kind: UserMetadataEntity.kind).encode()}',
       ReportReasonContent() => 'This is a report for the content ${reason.eventReference.encode()}',
       ReportReasonConversation() =>
         'This is a report for the conversation ${reason.conversationId}',

--- a/lib/app/features/user/providers/request_coins_submit_notifier.r.dart
+++ b/lib/app/features/user/providers/request_coins_submit_notifier.r.dart
@@ -59,7 +59,7 @@ class RequestCoinsSubmitNotifier extends _$RequestCoinsSubmitNotifier {
 
       final eventReference = ImmutableEventReference(
         eventId: event.id,
-        pubkey: currentUserPubkey,
+        masterPubkey: currentUserPubkey,
         kind: event.kind,
       );
 

--- a/lib/app/features/user/providers/user_delegation_provider.r.dart
+++ b/lib/app/features/user/providers/user_delegation_provider.r.dart
@@ -50,7 +50,7 @@ Future<UserDelegationEntity?> cachedUserDelegation(Ref ref, String pubkey) async
       cacheSelector<UserDelegationEntity>(
         CacheableEntity.cacheKeyBuilder(
           eventReference: ReplaceableEventReference(
-            pubkey: pubkey,
+            masterPubkey: pubkey,
             kind: UserDelegationEntity.kind,
           ),
         ),

--- a/lib/app/features/user/providers/user_file_storage_relay_provider.r.dart
+++ b/lib/app/features/user/providers/user_file_storage_relay_provider.r.dart
@@ -16,7 +16,7 @@ Future<UserFileStorageRelaysEntity?> userFileStorageRelay(
   return await ref.watch(
     ionConnectEntityProvider(
       eventReference: ReplaceableEventReference(
-        pubkey: pubkey,
+        masterPubkey: pubkey,
         kind: UserFileStorageRelaysEntity.kind,
       ),
     ).future,

--- a/lib/app/features/user/providers/user_interests_set_provider.r.dart
+++ b/lib/app/features/user/providers/user_interests_set_provider.r.dart
@@ -22,7 +22,7 @@ Future<InterestSetEntity?> userInterestsSet(
   return await ref.watch(
     ionConnectEntityProvider(
       eventReference: ReplaceableEventReference(
-        pubkey: pubkey,
+        masterPubkey: pubkey,
         kind: InterestSetEntity.kind,
         dTag: type.toShortString(),
       ),

--- a/lib/app/features/user/providers/user_metadata_provider.r.dart
+++ b/lib/app/features/user/providers/user_metadata_provider.r.dart
@@ -20,7 +20,8 @@ Future<UserMetadataEntity?> userMetadata(
 }) async {
   return await ref.watch(
     ionConnectEntityProvider(
-      eventReference: ReplaceableEventReference(pubkey: pubkey, kind: UserMetadataEntity.kind),
+      eventReference:
+          ReplaceableEventReference(masterPubkey: pubkey, kind: UserMetadataEntity.kind),
       // if profile badges data for pubkey is already cached - no need for the search
       search: ref.watch(cachedProfileBadgesDataProvider(pubkey)) == null
           ? ProfileBadgesSearchExtension(forKind: UserMetadataEntity.kind).toString()
@@ -37,7 +38,8 @@ UserMetadataEntity? cachedUserMetadata(
 ) {
   return ref.watch(
     ionConnectSyncEntityProvider(
-      eventReference: ReplaceableEventReference(pubkey: pubkey, kind: UserMetadataEntity.kind),
+      eventReference:
+          ReplaceableEventReference(masterPubkey: pubkey, kind: UserMetadataEntity.kind),
       // if profile badges data for pubkey is already cached - no need for the search
       search: ref.watch(cachedProfileBadgesDataProvider(pubkey)) == null
           ? ProfileBadgesSearchExtension(forKind: UserMetadataEntity.kind).toString()

--- a/lib/app/features/user/providers/user_relays_manager.r.dart
+++ b/lib/app/features/user/providers/user_relays_manager.r.dart
@@ -120,7 +120,7 @@ class UserRelaysManager extends _$UserRelaysManager {
     final eventReferences = pubkeys
         .map(
           (pubkey) => ReplaceableEventReference(
-            pubkey: pubkey,
+            masterPubkey: pubkey,
             kind: UserRelaysEntity.kind,
           ),
         )

--- a/lib/app/features/user/providers/user_specific_notifications_provider.r.dart
+++ b/lib/app/features/user/providers/user_specific_notifications_provider.r.dart
@@ -32,7 +32,7 @@ class UserSpecificNotifications extends _$UserSpecificNotifications {
       final accountNotificationSet = await ref.watch(
         ionConnectEntityProvider(
           eventReference: ReplaceableEventReference(
-            pubkey: currentPubkey,
+            masterPubkey: currentPubkey,
             kind: AccountNotificationSetEntity.kind,
             dTag: setType.dTagName,
           ),
@@ -108,7 +108,7 @@ class UserSpecificNotifications extends _$UserSpecificNotifications {
     final accountNotificationSet = await ref.read(
       ionConnectEntityProvider(
         eventReference: ReplaceableEventReference(
-          pubkey: currentPubkey,
+          masterPubkey: currentPubkey,
           kind: AccountNotificationSetEntity.kind,
           dTag: setType.dTagName,
         ),
@@ -143,7 +143,7 @@ class UserSpecificNotifications extends _$UserSpecificNotifications {
     final accountNotificationSet = await ref.read(
       ionConnectEntityProvider(
         eventReference: ReplaceableEventReference(
-          pubkey: currentPubkey,
+          masterPubkey: currentPubkey,
           kind: AccountNotificationSetEntity.kind,
           dTag: setType.dTagName,
         ),

--- a/lib/app/features/user_profile/providers/user_profile_sync_provider.r.dart
+++ b/lib/app/features/user_profile/providers/user_profile_sync_provider.r.dart
@@ -162,7 +162,7 @@ class UserProfileSync extends _$UserProfileSync {
         final profileBadge = await ref.watch(
           ionConnectNetworkEntityProvider(
             eventReference: ReplaceableEventReference(
-              pubkey: masterPubkey,
+              masterPubkey: masterPubkey,
               kind: ProfileBadgesEntity.kind,
               dTag: ProfileBadgesEntity.dTag,
             ),
@@ -206,7 +206,7 @@ class UserProfileSync extends _$UserProfileSync {
             final verifiedBadgeDefinition = await ref.watch(
               ionConnectNetworkEntityProvider(
                 eventReference: ReplaceableEventReference(
-                  pubkey: servicePubkey,
+                  masterPubkey: servicePubkey,
                   kind: BadgeDefinitionEntity.kind,
                   dTag: verifiedEntry.definitionRef.dTag,
                 ),
@@ -231,7 +231,7 @@ class UserProfileSync extends _$UserProfileSync {
                 eventReference: ReplaceableEventReference(
                   kind: BadgeDefinitionEntity.kind,
                   dTag: proofOfNameEntry.definitionRef.dTag,
-                  pubkey: proofOfNameEntry.definitionRef.pubkey,
+                  masterPubkey: proofOfNameEntry.definitionRef.masterPubkey,
                 ),
                 actionSource: const ActionSourceCurrentUser(),
               ).future,
@@ -278,7 +278,7 @@ class UserProfileSync extends _$UserProfileSync {
             final verifiedBadgeAward = await ref.watch(
               ionConnectNetworkEntityProvider(
                 eventReference: ImmutableEventReference(
-                  pubkey: servicePubkey,
+                  masterPubkey: servicePubkey,
                   eventId: verifiedEntry.awardId,
                 ),
                 actionSource: const ActionSourceCurrentUser(),
@@ -300,7 +300,7 @@ class UserProfileSync extends _$UserProfileSync {
             final proofOfNameBadgeAward = await ref.watch(
               ionConnectNetworkEntityProvider(
                 eventReference: ImmutableEventReference(
-                  pubkey: servicePubkey,
+                  masterPubkey: servicePubkey,
                   eventId: proofOfNameEntry.awardId,
                 ),
                 actionSource: const ActionSourceCurrentUser(),

--- a/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
+++ b/lib/app/features/video/views/pages/videos_vertical_scroll_page.dart
@@ -109,7 +109,7 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
     final currentEventReference = useState<EventReference>(eventReference);
 
     final isOwnedByCurrentUser =
-        ref.watch(isCurrentUserSelectorProvider(currentEventReference.value.pubkey));
+        ref.watch(isCurrentUserSelectorProvider(currentEventReference.value.masterPubkey));
 
     useEffect(
       () {
@@ -183,7 +183,7 @@ class VideosVerticalScrollPage extends HookConsumerWidget {
             bottomOverlay:
                 VideoActions(eventReference: flattenedVideos[index].entity.toEventReference()),
             videoUrl: flattenedVideos[index].media.url,
-            authorPubkey: eventReference.pubkey,
+            authorPubkey: eventReference.masterPubkey,
             thumbnailUrl: flattenedVideos[index].media.thumb,
             blurhash: flattenedVideos[index].media.blurhash,
             aspectRatio: flattenedVideos[index].media.aspectRatio,

--- a/lib/app/features/wallets/providers/send_coins_notifier_provider.r.dart
+++ b/lib/app/features/wallets/providers/send_coins_notifier_provider.r.dart
@@ -280,7 +280,7 @@ class SendCoinsNotifier extends _$SendCoinsNotifier {
 
     final eventReference = ImmutableEventReference(
       eventId: event.id,
-      pubkey: currentUserPubkey,
+      masterPubkey: currentUserPubkey,
       kind: event.kind,
     );
     final content = eventReference.encode();

--- a/test/app/features/optimistic_ui/likes/like_intent_strategy_test.dart
+++ b/test/app/features/optimistic_ui/likes/like_intent_strategy_test.dart
@@ -13,7 +13,7 @@ class _MockReactionEntity extends Mock implements ReactionEntity {}
 void main() {
   group('ToggleLikeIntent.optimistic()', () {
     const ref = ImmutableEventReference(
-      pubkey: 'pubkey42',
+      masterPubkey: 'pubkey42',
       eventId: '42',
       kind: 1,
     );
@@ -59,7 +59,7 @@ void main() {
     });
 
     const ref = ImmutableEventReference(
-      pubkey: 'pubkey42',
+      masterPubkey: 'pubkey42',
       eventId: '42',
       kind: 1,
     );

--- a/test/app/services/ion_connect/model/event_reference.dart
+++ b/test/app/services/ion_connect/model/event_reference.dart
@@ -14,7 +14,7 @@ void main() {
         'nostr:nevent1qqsyj6lj9dmwvd2nkt9vwrzyk5uxwd5tfdmpypf693uxp8e3gseyspczyr6awp2zve8x2uvm2hvdvfgt04guh048wy2p9ka4ysggdqkt6lcdgxatx7l';
 
     test('encode produces correct output', () {
-      const reference = ImmutableEventReference(pubkey: pubkey, eventId: eventId);
+      const reference = ImmutableEventReference(masterPubkey: pubkey, eventId: eventId);
 
       expect(reference.encode(), equals(encoded));
     });
@@ -23,7 +23,7 @@ void main() {
       final reference = EventReference.fromEncoded(encoded);
 
       expect(reference, isA<ImmutableEventReference>());
-      expect(reference.pubkey, equals(pubkey));
+      expect(reference.masterPubkey, equals(pubkey));
       expect((reference as ImmutableEventReference).eventId, equals(eventId));
     });
   });
@@ -36,7 +36,7 @@ void main() {
         'nostr:naddr1qpqrgwfkvfnryvnzxumx2d3nx56nxc3jvdskxdesvv6rgc34xvurvdenxcuxydrzxumrzv3sx5ekzvnrxuurvvpevcenzdp5xvergwpsxupzpawhq4pxvnn9wxd4tkxky59h65wth6nhz9qjmw6jgyyxst9a0ux5qvzqqqr4muv6xeqv';
 
     test('encode produces correct output', () {
-      const reference = ReplaceableEventReference(pubkey: pubkey, kind: kind, dTag: dTag);
+      const reference = ReplaceableEventReference(masterPubkey: pubkey, kind: kind, dTag: dTag);
 
       expect(reference.encode(), equals(encoded));
     });
@@ -45,7 +45,7 @@ void main() {
       final reference = EventReference.fromEncoded(encoded);
 
       expect(reference, isA<ReplaceableEventReference>());
-      expect((reference as ReplaceableEventReference).pubkey, equals(pubkey));
+      expect((reference as ReplaceableEventReference).masterPubkey, equals(pubkey));
       expect(reference.dTag, equals(dTag));
       expect(reference.kind, equals(kind));
     });
@@ -58,7 +58,7 @@ void main() {
         'nostr:naddr1qqqqyg846uz5yejwv4cek4wc6cjskl23ewl2wug5ztdm2fqss6pvh4ls6spsgqqqyufq4vsghj';
 
     test('encode produces correct output', () {
-      const reference = ReplaceableEventReference(pubkey: pubkey, kind: kind);
+      const reference = ReplaceableEventReference(masterPubkey: pubkey, kind: kind);
 
       expect(reference.encode(), equals(encoded));
     });
@@ -67,7 +67,7 @@ void main() {
       final reference = EventReference.fromEncoded(encoded);
 
       expect(reference, isA<ReplaceableEventReference>());
-      expect((reference as ReplaceableEventReference).pubkey, equals(pubkey));
+      expect((reference as ReplaceableEventReference).masterPubkey, equals(pubkey));
       expect(reference.kind, equals(kind));
     });
   });
@@ -78,7 +78,7 @@ void main() {
     const encoded = 'nostr:nprofile1qqs0t4c9gfnyuet3nd2a3439pd74rja75ac3gykmk5jppp5ze0tlp4q9xpcn0';
 
     test('encode produces correct output', () {
-      const reference = ReplaceableEventReference(pubkey: pubkey, kind: kind);
+      const reference = ReplaceableEventReference(masterPubkey: pubkey, kind: kind);
 
       expect(reference.encode(), equals(encoded));
     });
@@ -87,7 +87,7 @@ void main() {
       final reference = EventReference.fromEncoded(encoded);
 
       expect(reference, isA<ReplaceableEventReference>());
-      expect((reference as ReplaceableEventReference).pubkey, equals(pubkey));
+      expect((reference as ReplaceableEventReference).masterPubkey, equals(pubkey));
       expect(reference.kind, equals(kind));
     });
   });

--- a/test/user/interests_test.dart
+++ b/test/user/interests_test.dart
@@ -34,7 +34,7 @@ void main() {
       expect(interest.data.hashtags[0], 'tag');
       expect(
         interest.data.interestSetRefs[0],
-        const ReplaceableEventReference(kind: 2, pubkey: '13', dTag: '123'),
+        const ReplaceableEventReference(kind: 2, masterPubkey: '13', dTag: '123'),
       );
     });
   });


### PR DESCRIPTION
## Description
This PR renames pubkey to masterPubkey across the project to reduce confusion around event references and improve naming consistency. This change enhances code readability and clarifies the distinction between signer and master identity.

## Additional Notes
https://github.com/ice-blockchain/ion-app/pull/1469#discussion_r2158153896

## Task ID
ION-3020

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
