### PR TITLE
feat: make message status provider scoped

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -593,9 +593,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  appsflyer_sdk: 583722545afc0f208067ef5635061133d797a91c
+  appsflyer_sdk: 8c19d2faa90094292e5a1849cd77549e75817334
   AppsFlyerFramework: fe5303bffcdfd941d5f570c2d21eaaea982e7bdc
-  audio_waveforms: a6dde7fe7c0ea05f06ffbdb0f7c1b2b2ba6cedcf
+  audio_waveforms: cd736909ebc6b6a164eb74701d8c705ce3241e1c
   BanubaARCloudSDK: e82c8eb19757b1a8d83167a4985a7eb1f00f80cc
   BanubaAudioBrowserSDK: f54c8c98ce489c1d5df8f1a117dddebceab2b6e2
   BanubaLicenseServicingSDK: 8aa68274c447aa0d05a810a2709a5eb088d3a837
@@ -605,8 +605,8 @@ SPEC CHECKSUMS:
   BanubaUtilities: f32f40d15dc3d363ced801095b43ac8d4280e004
   BanubaVideoEditorCore: c5a48af314ad8e50cd376bb5427e48501d4eef9a
   BanubaVideoEditorSDK: b34f1d79674c89f9b0b26de737f91806bb04ed76
-  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
-  blurhash_ffi: 87aab623d744d4d6cd6057d285bd2258df904786
+  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
+  blurhash_ffi: 4831b96320d4273876c9a2fd3f7d50b8a3a53509
   BNBAcneEyebagsRemoval: 3a35ebc546ef90aeb1915d9976c77e917be1fe6e
   BNBBackground: 350c0ca73cd1fabc04e850be044b86c90cd3a5ff
   BNBEffectPlayer: bcddb2e93efe20ac5c5e173cd0bc15f1db30226b
@@ -619,69 +619,69 @@ SPEC CHECKSUMS:
   BNBSdkApi: c5913e3ed9aecf7d60b3ccfded6a2db859685bc6
   BNBSdkCore: ece3f323706277bba806bd52e80719ffb72cd279
   BNBSkin: 12d53f218f10e890c4b762e20919d94044228369
-  camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  camera_avfoundation: adb0207d868b2d873e895371d88448399ab78d87
+  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  external_app_launcher: 3411245965270a74040a3de17e27bd02b8abb905
-  ffmpeg_kit_flutter: 03e1c7562aee29a33b03def7b10a2fbc0456c63d
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
-  file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
+  external_app_launcher: ad55ac844aa21f2d2197d7cec58ff0d0dc40bbc0
+  ffmpeg_kit_flutter: 1a001ee5bc75256bb9eaf34971b4779a629f4cb6
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_saver: 503e386464dbe118f630e17b4c2e1190fa0cf808
   Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
-  firebase_analytics: 1998960b8fa16fd0cd9e77a6f9fd35a2009ad65e
-  firebase_core: 2d4534e7b489907dcede540c835b48981d890943
-  firebase_messaging: 75bc93a4df25faccad67f6662ae872ac9ae69b64
+  firebase_analytics: 4b8609ce8d2e0c8928472bec8d9753a8f1835eb6
+  firebase_core: 432718558359a8c08762151b5f49bb0f093eb6e0
+  firebase_messaging: 3b99522baf7480dfb4b7683d2b34e842d577c362
   FirebaseAnalytics: 4e42333f02cf78ed93703a5c36f36dd518aebdef
   FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
   FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
   FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
   FirebaseMessaging: 2b9f56aa4ed286e1f0ce2ee1d413aabb8f9f5cb9
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
-  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
-  flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
-  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
+  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
+  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
+  flutter_keyboard_visibility_temp_fork: 8a8809c4129e31d25fca77446e0f3fd548122ced
+  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
   GoogleAppMeasurement: 36684bfb3ee034e2b42b4321eb19da3a1b81e65d
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  icloud_storage: e55639f0c0d7cb2b0ba9c0b3d5968ccca9cd9aa2
-  image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
-  ion_screenshot_detector: 12965038c2274b1876c39ee328507e8bb9c7b794
-  local_auth_crypto: 0f489ce05f51504fc091a53ce357e98313696085
-  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
+  icloud_storage: d9ac7a33ced81df08ba7ea1bf3099cc0ee58f60a
+  image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
+  ion_screenshot_detector: 8332b6aedff48dc5dedc0c5a0be24aa5acff9ac9
+  local_auth_crypto: 3ee858ca5d40c9da56dcd1fe8d814e92438a9371
+  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  passkeys_ios: 939d7d44f825048c8dffd4644f52444164c80ecd
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  photo_manager: d2fbcc0f2d82458700ee6256a15018210a81d413
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  passkeys_ios: fdae8c06e2178a9fcb9261a6cb21fb9a06a81d53
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  qr_code_scanner_plus: 7e087021bc69873140e0754750eb87d867bed755
-  quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
+  qr_code_scanner_plus: 3bfe4deb7f28996a63a2a580819d49dae80d5ed3
+  quill_native_bridge_ios: 2b01d585fcc73d0f5eed78c0bd244ee564b06f5a
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SecureBiometricSwift: f8a373c07fb46c9ca1b2b53be51a485d2828a3d8
-  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
+  sensors_plus: 7229095999f30740798f0eeef5cd120357a8f4f2
   Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
-  sentry_flutter: 27892878729f42701297c628eb90e7c6529f3684
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  sentry_flutter: 2df8b0aab7e4aba81261c230cbea31c82a62dd1b
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
-  sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2
+  sqlite3_flutter_libs: 487032b9008b28de37c72a3aa66849ef3745f3e6
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  ua_client_hints: 92fe0d139619b73ec9fcb46cc7e079a26178f586
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
-  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
+  ua_client_hints: aeabd123262c087f0ce151ef96fa3ab77bfc8b38
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
+  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
 
 PODFILE CHECKSUM: 85595aa132a3b2515307ae95e0669dda99be902d
 

--- a/lib/app/features/chat/providers/message_status_provider.r.dart
+++ b/lib/app/features/chat/providers/message_status_provider.r.dart
@@ -12,8 +12,7 @@ import 'package:stream_transform/stream_transform.dart';
 
 part 'message_status_provider.r.g.dart';
 
-@riverpod
-//TODO: Make this provider alive till conversation page is opened
+@Riverpod(keepAlive: true, dependencies: [])
 Stream<MessageDeliveryStatus> messageStatus(
   Ref ref,
   EventReference eventReference,

--- a/lib/app/features/chat/views/pages/conversation_page/conversation_page.dart
+++ b/lib/app/features/chat/views/pages/conversation_page/conversation_page.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/features/chat/e2ee/views/pages/group_messages_page.dart'
 import 'package:ion/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart';
 import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
 import 'package:ion/app/features/chat/providers/conversation_type_provider.r.dart';
+import 'package:ion/app/features/chat/providers/message_status_provider.r.dart';
 
 class ConversationPage extends HookConsumerWidget {
   const ConversationPage({
@@ -34,8 +35,11 @@ class ConversationPage extends HookConsumerWidget {
           case ConversationType.community:
             return ChannelMessagingPage(communityId: conversationId!);
           case ConversationType.oneToOne:
-            return OneToOneMessagesPage(
-              receiverMasterPubkey: receiverMasterPubkey!,
+            return ProviderScope(
+              overrides: const [messageStatusProvider],
+              child: OneToOneMessagesPage(
+                receiverMasterPubkey: receiverMasterPubkey!,
+              ),
             );
         }
       },

--- a/lib/app/services/logger/logger.dart
+++ b/lib/app/services/logger/logger.dart
@@ -73,6 +73,7 @@ class Logger {
           printProviderUpdated: _verboseRiverpod,
           printStateFullData: _verboseRiverpod,
           printFailFullData: _verboseRiverpod,
+          printProviderFailed: _verboseRiverpod,
         ),
       );
 


### PR DESCRIPTION
## Description
- Make message status provider alive and scoped within conversation page

## Additional Notes
- Verified that provider is init, updated and disposed when we leave conversation message page

## Task ID
ION-3148

## Type of Change
- [x] Refactoring
