### PR TITLE
fix: prevent loop when no previous interest data

### DIFF
--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -251,7 +251,7 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
       '$_logTag Got [$requestedCount] events with [${modifier.name}] modifier, remaining: [$remaining], tries left: [${retryCounter.triesLeft}]',
     );
 
-    if (remaining > 0 && requestedCount != 0) {
+    if (requestedCount > 0 && remaining > 0) {
       yield* _fetchInterestsEntities(
         modifier: modifier,
         limit: remaining,

--- a/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
+++ b/lib/app/features/feed/providers/feed_for_you_content_provider.m.dart
@@ -251,7 +251,7 @@ class FeedForYouContent extends _$FeedForYouContent implements PagedNotifier {
       '$_logTag Got [$requestedCount] events with [${modifier.name}] modifier, remaining: [$remaining], tries left: [${retryCounter.triesLeft}]',
     );
 
-    if (remaining > 0) {
+    if (remaining > 0 && requestedCount != 0) {
       yield* _fetchInterestsEntities(
         modifier: modifier,
         limit: remaining,


### PR DESCRIPTION
## Description
This PR prevents unnecessary recursive calls in `_fetchInterestsEntities` by ensuring we only recurse when `requestedCount > 0`. Previously, the function could call itself even when no new entities were returned, potentially causing infinite or redundant loops when no data is available from the relays.

## Additional Notes
N/A

## Task ID
3159-3160-3163

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
