### PR TITLE
fix: message list rebuild issue causing flicker and audio playback interruption

### DIFF
--- a/lib/app/features/chat/views/components/scroll_to_bottom_button.dart
+++ b/lib/app/features/chat/views/components/scroll_to_bottom_button.dart
@@ -4,31 +4,30 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:ion/app/extensions/extensions.dart';
-import 'package:ion/app/hooks/use_on_init.dart';
 import 'package:ion/generated/assets.gen.dart';
-import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ScrollToBottomButton extends HookWidget {
   const ScrollToBottomButton({
-    required this.scrollOffsetListener,
+    required this.scrollController,
     required this.onTap,
     super.key,
   });
   static final _offsetThreshold = 16.s;
 
   final VoidCallback onTap;
-  final ScrollOffsetListener scrollOffsetListener;
+  final ScrollController scrollController;
 
   @override
   Widget build(BuildContext context) {
-    final totalScrollOffset = useState<double>(0);
+    final isVisible = useState(false);
 
-    useOnInit(() {
-      scrollOffsetListener.changes.listen(
-        (offset) {
-          totalScrollOffset.value += offset;
-        },
-      );
+    useEffect(() {
+      void listener() {
+        isVisible.value = scrollController.offset > _offsetThreshold;
+      }
+
+      scrollController.addListener(listener);
+      return () => scrollController.removeListener(listener);
     });
 
     return PositionedDirectional(
@@ -45,7 +44,7 @@ class ScrollToBottomButton extends HookWidget {
             ),
           );
         },
-        child: totalScrollOffset.value > _offsetThreshold
+        child: isVisible.value
             ? _ScrollButton(
                 onTap: onTap,
               )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2424,14 +2424,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  scrollable_positioned_list:
-    dependency: "direct main"
-    description:
-      name: scrollable_positioned_list
-      sha256: "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.8"
   sensors_plus:
     dependency: "direct main"
     description:
@@ -2741,6 +2733,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  super_sliver_list:
+    dependency: "direct main"
+    description:
+      name: super_sliver_list
+      sha256: b1e1e64d08ce40e459b9bb5d9f8e361617c26b8c9f3bb967760b0f436b6e3f56
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   synchronized:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,7 +131,6 @@ dependencies:
   qr_flutter: ^4.1.0
   riverpod_annotation: ^2.6.1
   screenshot: ^3.0.0
-  scrollable_positioned_list: ^0.3.8
   sensors_plus: ^6.1.1
   sentry_flutter: ^8.14.2
   share_plus: ^10.0.2
@@ -143,6 +142,7 @@ dependencies:
   smooth_sheets: ^1.0.0-f324.0.10.2
   social_sharing_plus: ^1.2.3
   stream_transform: ^2.1.1
+  super_sliver_list: ^0.4.1
   synchronized: ^3.3.0+3
   talker_dio_logger: 4.7.1
   talker_flutter: 4.7.1


### PR DESCRIPTION
## Description
This PR replaces [scrollable_positioned_list](https://pub.dev/packages/scrollable_positioned_list) with [super_sliver_list](https://pub.dev/packages/super_sliver_list) to avoid unnecessary rebuilds in the message list.

Previously, when a message was added or removed, `scrollable_positioned_list` caused all visible items to rebuild. This led to UI flickering and issues like stopping an ongoing voice message playback.

By switching to `super_sliver_list` and using `findChildIndexCallback`, we can target specific items without triggering a full rebuild. This improves performance and prevent flicker issue of voice, photo, video messages.

## Additional Notes
- Tested the scroll to item and it works well.

## Task ID
3206

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/3ee3d533-accf-4cf3-9d2c-3c0301d0b486


