### PR TITLE
fix: stories visible on profile after posting

### DIFF
--- a/lib/app/features/feed/providers/user_posts_provider.r.dart
+++ b/lib/app/features/feed/providers/user_posts_provider.r.dart
@@ -56,9 +56,13 @@ class UserPosts extends _$UserPosts with DelegatedPagedNotifier {
       return false;
     }
 
-    return (entity is ModifiablePostEntity && entity.data.parentEvent == null) ||
+    return (entity is ModifiablePostEntity &&
+            entity.data.parentEvent == null &&
+            entity.data.expiration == null) ||
         entity is GenericRepostEntity ||
-        (entity is PostEntity && entity.data.parentEvent == null) ||
+        (entity is PostEntity &&
+            entity.data.parentEvent == null &&
+            entity.data.expiration == null) ||
         entity is RepostEntity ||
         entity is ArticleEntity;
   }


### PR DESCRIPTION
## Description
This PR fixes an issue where a created story was visible on profile's post's tab because of wrong subscription filter.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
