### PR TITLE
fix: ui issue shared post with mention

### DIFF
--- a/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
@@ -124,7 +124,7 @@ class PostBody extends HookConsumerWidget {
                             )
                           : null,
                       enableInteractiveSelection: isTextSelectable,
-                      tagsColor: accentTheme ? context.theme.appColors.lightBlue : null,
+                      tagsColor: accentTheme ? context.theme.appColors.anakiwa : null,
                     ),
                   if (hasOverflow)
                     Align(

--- a/lib/app/templates/basic.json
+++ b/lib/app/templates/basic.json
@@ -29,7 +29,8 @@
         "pink": "#A640FF",
         "medBlue": "#4340FF",
         "postContent": "#0F1419",
-        "lossRed": "#FF396E"
+        "lossRed": "#FF396E",
+        "anakiwa": "#91D4FF"
       },
       "dark": {
         "primaryAccent": "#0166FF",
@@ -59,7 +60,8 @@
         "pink": "#A640FF",
         "medBlue": "#4340FF",
         "postContent": "#0F1419",
-        "lossRed": "#FF396E"
+        "lossRed": "#FF396E",
+        "anakiwa": "#91D4FF"
       }
     },
     "textThemes": {

--- a/lib/app/templates/template.f.dart
+++ b/lib/app/templates/template.f.dart
@@ -41,11 +41,13 @@ class TemplateColors with _$TemplateColors {
     Color medBlue,
     Color postContent,
     Color lossRed,
+    Color anakiwa,
   ) = _TemplateColors;
 
   factory TemplateColors.fromJson(Map<String, dynamic> json) => _$TemplateColorsFromJson(json);
 
   factory TemplateColors.empty() => const TemplateColors(
+        Colors.transparent,
         Colors.transparent,
         Colors.transparent,
         Colors.transparent,

--- a/lib/app/theme/app_colors.dart
+++ b/lib/app/theme/app_colors.dart
@@ -33,6 +33,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
     required this.medBlue,
     required this.postContent,
     required this.lossRed,
+    required this.anakiwa,
   });
 
   factory AppColorsExtension.fromTemplate(TemplateColors templateColors) {
@@ -65,6 +66,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       medBlue: templateColors.medBlue,
       postContent: templateColors.postContent,
       lossRed: templateColors.lossRed,
+      anakiwa: templateColors.anakiwa,
     );
   }
 
@@ -98,6 +100,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       medBlue: const Color(0xFF4340FF),
       postContent: const Color(0xFF0F1419),
       lossRed: const Color(0xFFFF396E),
+      anakiwa: const Color(0xFF91D4FF),
     );
   }
 
@@ -129,6 +132,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
   final Color medBlue;
   final Color postContent;
   final Color lossRed;
+  final Color anakiwa;
 
   @override
   ThemeExtension<AppColorsExtension> copyWith({
@@ -160,6 +164,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
     Color? medBlue,
     Color? postContent,
     Color? lossRed,
+    Color? anakiwa,
   }) {
     return AppColorsExtension(
       primaryAccent: primaryAccent ?? this.primaryAccent,
@@ -190,6 +195,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       medBlue: medBlue ?? this.medBlue,
       postContent: postContent ?? this.postContent,
       lossRed: lossRed ?? this.lossRed,
+      anakiwa: anakiwa ?? this.anakiwa,
     );
   }
 
@@ -231,6 +237,7 @@ class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
       medBlue: Color.lerp(medBlue, other.medBlue, t)!,
       postContent: Color.lerp(postContent, other.postContent, t)!,
       lossRed: Color.lerp(lossRed, other.lossRed, t)!,
+      anakiwa: Color.lerp(anakiwa, other.anakiwa, t)!,
     );
   }
 }


### PR DESCRIPTION
## Description
This PR introduces a new color named `anakiwa` to the app’s color scheme. It is used specifically to style mention text within shared post messages.

## Additional Notes
N/A

## Task ID
3242

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

 <img width="280" alt="image" src="https://github.com/user-attachments/assets/18405912-e4e3-4a51-94c5-5a4f597972ea">


