### PR TITLE
fix(chat): prevent overflow when message contains new lines

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/text_message/text_message.dart
@@ -147,8 +147,7 @@ class _TextMessageContent extends HookWidget {
     )..layout(maxWidth: maxAvailableWidth - metadataWidth.value.s);
 
     final oneLineMetrics = oneLineTextPainter.computeLineMetrics();
-    final multiline = oneLineMetrics.length > 1;
-
+    final multiline = oneLineMetrics.length > 1 && !oneLineMetrics.every((m) => m.hardBreak);
     if (hasReactionsOrMetadata) {
       return _TextRichContent(text: content, textStyle: textStyle);
     }


### PR DESCRIPTION
## Description
This PR fixes a layout issue where chat messages containing manually added new lines (\n) could cause overflow in the message bubble.

## Additional Notes
N/A

## Task ID
3248

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="280" alt="image" src="https://github.com/user-attachments/assets/793622e4-a961-47de-a29d-ffee179e5f88">
