### PR TITLE
fix: remove leftover container after cancelling video message

### DIFF
--- a/lib/app/features/chat/model/database/dao/event_message_dao.dart
+++ b/lib/app/features/chat/model/database/dao/event_message_dao.dart
@@ -59,8 +59,28 @@ class EventMessageDao extends DatabaseAccessor<ChatDatabase> with _$EventMessage
   }
 
   Future<void> deleteByEventReference(EventReference eventReference) async {
-    await (delete(db.eventMessageTable)
-          ..where((table) => table.eventReference.equalsValue(eventReference)))
-        .go();
+    await db.batch((batch) {
+      batch
+        ..deleteWhere(
+          db.conversationMessageTable,
+          (table) => table.messageEventReference.equalsValue(eventReference),
+        )
+        ..deleteWhere(
+          db.messageMediaTable,
+          (table) => table.messageEventReference.equalsValue(eventReference),
+        )
+        ..deleteWhere(
+          db.messageStatusTable,
+          (table) => table.messageEventReference.equalsValue(eventReference),
+        )
+        ..deleteWhere(
+          db.reactionTable,
+          (table) => table.messageEventReference.equalsValue(eventReference),
+        )
+        ..deleteWhere(
+          db.eventMessageTable,
+          (table) => table.eventReference.equalsValue(eventReference),
+        );
+    });
   }
 }


### PR DESCRIPTION
## Description
Fixes an issue where a small empty container remained visible in the UI after cancelling a video message.

## Additional Notes
N/A

## Task ID
3255

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
https://github.com/user-attachments/assets/e114599d-129d-4aac-a7a3-f9804c9cc7ef


