### PR TITLE
feat: resume shared post video in chat from paused position on scroll return

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_post_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_post_message.dart
@@ -37,6 +37,8 @@ class SharedPostMessage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    useAutomaticKeepAlive();
+
     final isMe = ref.watch(isCurrentUserSelectorProvider(sharedEventMessage.masterPubkey));
 
     final postData = useMemoized(


### PR DESCRIPTION
## Description
Shared post videos in chat now continue playing from where they stopped when scrolled back into view. The paused position is saved using keep-alive.

## Additional Notes
N/A

## Task ID
3270

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/d8fce7bd-5630-4f26-a1cb-c1d6e2e2827c


