### PR TITLE
fix: remove flicker when scrolling to replied message in chat

### DIFF
--- a/lib/app/features/chat/recent_chats/providers/replied_message_list_item_provider.r.dart
+++ b/lib/app/features/chat/recent_chats/providers/replied_message_list_item_provider.r.dart
@@ -9,7 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'replied_message_list_item_provider.r.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true, dependencies: [])
 Stream<EventMessage?> repliedMessageListItem(Ref ref, ChatMessageInfoItem messageItem) {
   final entity = ReplaceablePrivateDirectMessageEntity.fromEventMessage(messageItem.eventMessage);
 

--- a/lib/app/features/chat/views/pages/conversation_page/conversation_page.dart
+++ b/lib/app/features/chat/views/pages/conversation_page/conversation_page.dart
@@ -9,6 +9,7 @@ import 'package:ion/app/features/chat/e2ee/views/pages/one_to_one_messages_page.
 import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
 import 'package:ion/app/features/chat/providers/conversation_type_provider.r.dart';
 import 'package:ion/app/features/chat/providers/message_status_provider.r.dart';
+import 'package:ion/app/features/chat/recent_chats/providers/replied_message_list_item_provider.r.dart';
 
 class ConversationPage extends HookConsumerWidget {
   const ConversationPage({
@@ -36,7 +37,7 @@ class ConversationPage extends HookConsumerWidget {
             return ChannelMessagingPage(communityId: conversationId!);
           case ConversationType.oneToOne:
             return ProviderScope(
-              overrides: const [messageStatusProvider],
+              overrides: const [messageStatusProvider, repliedMessageListItemProvider],
               child: OneToOneMessagesPage(
                 receiverMasterPubkey: receiverMasterPubkey!,
               ),


### PR DESCRIPTION
## Description
This PR fixes a visual flicker that occurred when scrolling to a replied message in chat. The layout now updates smoothly when the replied message becomes visible.

## Additional Notes
N/A

## Task ID
3139

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
