### PR TITLE
fix: same story visible on both pages when swiping between users in story viewer page

### DIFF
--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
@@ -89,16 +89,29 @@ class SharedStoryMessage extends HookConsumerWidget {
             GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () async {
-                var storyViewerState =
-                    ref.read(storyViewingControllerProvider(storyEntity.masterPubkey));
+                var storyViewerState = ref.read(
+                  userStoriesViewingNotifierProvider(
+                    storyEntity.masterPubkey,
+                    showOnlySelectedUser: true,
+                  ),
+                );
 
                 if (storyViewerState.userStories.isEmpty) {
                   await ref
-                      .read(storyViewingControllerProvider(storyEntity.masterPubkey).notifier)
+                      .read(
+                        userStoriesViewingNotifierProvider(
+                          storyEntity.masterPubkey,
+                          showOnlySelectedUser: true,
+                        ).notifier,
+                      )
                       .setUserStoryByReference(storyEntity.toEventReference());
 
-                  storyViewerState =
-                      ref.read(storyViewingControllerProvider(storyEntity.masterPubkey));
+                  storyViewerState = ref.read(
+                    userStoriesViewingNotifierProvider(
+                      storyEntity.masterPubkey,
+                      showOnlySelectedUser: true,
+                    ),
+                  );
                 }
 
                 if (context.mounted && storyViewerState.userStories.isNotEmpty) {

--- a/lib/app/features/feed/stories/data/models/story_viewer_state.f.dart
+++ b/lib/app/features/feed/stories/data/models/story_viewer_state.f.dart
@@ -6,16 +6,26 @@ import 'package:ion/app/features/feed/stories/data/models/user_story.f.dart';
 part 'story_viewer_state.f.freezed.dart';
 
 @freezed
-class StoryViewerState with _$StoryViewerState {
-  const factory StoryViewerState({
-    required List<UserStory> userStories,
-    required int currentUserIndex,
+class SingleUserStoriesViewerState with _$SingleUserStoriesViewerState {
+  const factory SingleUserStoriesViewerState({
+    required String pubkey,
     required int currentStoryIndex,
-  }) = _StoryViewerState;
+  }) = _SingleUserStoriesViewerState;
 
-  const StoryViewerState._();
+  const SingleUserStoriesViewerState._();
 
   bool get hasPreviousStory => currentStoryIndex > 0;
+}
+
+@freezed
+class UserStoriesViewerState with _$UserStoriesViewerState {
+  const factory UserStoriesViewerState({
+    required List<UserStory> userStories,
+    required int currentUserIndex,
+  }) = _UserStoriesViewerState;
+
+  const UserStoriesViewerState._();
+
   bool get hasNextUser => currentUserIndex < userStories.length - 1;
   bool get hasPreviousUser => currentUserIndex > 0;
 
@@ -32,6 +42,10 @@ class StoryViewerState with _$StoryViewerState {
   }
 
   String get nextUserPubkey {
-    return userStories.elementAtOrNull(currentUserIndex + 1)?.pubkey ?? '';
+    return pubkeyAtIndex(currentUserIndex + 1);
+  }
+
+  String pubkeyAtIndex(int index) {
+    return userStories.elementAtOrNull(index)?.pubkey ?? '';
   }
 }

--- a/lib/app/features/feed/stories/hooks/use_story_progress_controller.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_progress_controller.dart
@@ -42,7 +42,7 @@ StoryProgressControllerResult useStoryProgressController({
     ref: ref,
   );
 
-  final video = isVideo
+  final video = isVideo && isCurrent
       ? ref
           .watch(
             videoControllerProvider(

--- a/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
+++ b/lib/app/features/feed/stories/hooks/use_story_video_playback.dart
@@ -20,9 +20,12 @@ void useStoryVideoPlayback({
   if (controller == null || !controller.value.isInitialized) return;
 
   final paused = ref.watch(storyPauseControllerProvider);
-  final viewing = ref.watch(storyViewingControllerProvider(viewerPubkey));
+  final currentStoryIndex = ref.watch(
+    singleUserStoryViewingControllerProvider(viewerPubkey)
+        .select((state) => state.currentStoryIndex),
+  );
   final stories = ref.watch(userStoriesProvider(viewerPubkey))?.toList() ?? [];
-  final story = stories.elementAtOrNull(viewing.currentStoryIndex);
+  final story = stories.elementAtOrNull(currentStoryIndex);
   final isCurrent = story?.id == storyId;
 
   final hasStarted = useRef(false);

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart
@@ -23,11 +23,13 @@ class StoryContent extends HookConsumerWidget {
   const StoryContent({
     required this.story,
     required this.viewerPubkey,
+    required this.onNext,
     super.key,
   });
 
   final ModifiablePostEntity story;
   final String viewerPubkey;
+  final VoidCallback onNext;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -56,8 +58,10 @@ class StoryContent extends HookConsumerWidget {
             ),
             clipBehavior: Clip.hardEdge,
             child: StoryViewerContent(
+              key: Key(story.id),
               post: story,
               viewerPubkey: viewerPubkey,
+              onNext: onNext,
             ),
           ),
         ),

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/core/user_story_page_view.dart
@@ -4,50 +4,80 @@ import 'package:flutter/material.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/ion_loading_indicator.dart';
+import 'package:ion/app/features/feed/stories/data/models/stories_references.f.dart';
 import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
+import 'package:ion/app/features/feed/stories/providers/viewed_stories_provider.r.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_content.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_viewer/components/core/story_gesture_handler.dart';
+import 'package:ion/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart';
+import 'package:ion/app/hooks/use_on_init.dart';
 
-class UserStoryPageView extends ConsumerWidget {
+class UserStoryPageView extends HookConsumerWidget {
   const UserStoryPageView({
     required this.isCurrentUser,
-    required this.onNextStory,
-    required this.onPreviousStory,
     required this.onNextUser,
     required this.onPreviousUser,
+    required this.onClose,
     required this.pubkey,
     super.key,
   });
 
   final bool isCurrentUser;
-  final VoidCallback onNextStory;
-  final VoidCallback onPreviousStory;
   final VoidCallback onNextUser;
   final VoidCallback onPreviousUser;
+  final VoidCallback onClose;
   final String pubkey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final storyState = ref.watch(storyViewingControllerProvider(pubkey));
-    final stories = ref.watch(userStoriesProvider(storyState.currentUserPubkey))?.toList() ?? [];
+    final singleUserStoriesViewingState = ref.watch(
+      singleUserStoryViewingControllerProvider(pubkey),
+    );
+    final singleUserStoriesNotifier = ref.watch(
+      singleUserStoryViewingControllerProvider(pubkey).notifier,
+    );
+    final stories = ref.watch(userStoriesProvider(pubkey))?.toList() ?? [];
+    final storiesReferences = StoriesReferences(stories.map((e) => e.toEventReference()));
     if (stories.isEmpty) {
       return const Center(
         child: IONLoadingIndicator(),
       );
     }
-    final currentStory = isCurrentUser ? stories[storyState.currentStoryIndex] : stories.first;
+
+    final currentStory =
+        isCurrentUser ? stories[singleUserStoriesViewingState.currentStoryIndex] : stories.first;
+    useOnInit(
+      () {
+        ref
+            .read(viewedStoriesControllerProvider(storiesReferences).notifier)
+            .markStoryAsViewed(currentStory);
+      },
+      [currentStory.id],
+    );
+
+    usePreloadStoryMedia(
+      ref,
+      stories.elementAtOrNull(singleUserStoriesViewingState.currentStoryIndex + 1),
+    );
 
     return KeyboardVisibilityProvider(
       child: StoryGestureHandler(
         key: storyGestureKeyFor(pubkey),
         viewerPubkey: pubkey,
-        onTapLeft: () => storyState.currentStoryIndex > 0 ? onPreviousStory() : onPreviousUser(),
-        onTapRight: () =>
-            storyState.currentStoryIndex < stories.length - 1 ? onNextStory() : onNextUser(),
+        onTapLeft: () => singleUserStoriesNotifier.rewind(onRewoundAll: onPreviousUser),
+        onTapRight: () => singleUserStoriesNotifier.advance(
+          storiesLength: stories.length,
+          onSeenAll: onNextUser,
+        ),
         child: StoryContent(
+          key: Key(currentStory.id),
           story: currentStory,
           viewerPubkey: pubkey,
+          onNext: () => singleUserStoriesNotifier.advance(
+            storiesLength: stories.length,
+            onSeenAll: onNextUser,
+          ),
         ),
       ),
     );

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/story_viewer_content.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/story_viewer_content.dart
@@ -10,11 +10,13 @@ class StoryViewerContent extends StatelessWidget {
   const StoryViewerContent({
     required this.post,
     required this.viewerPubkey,
+    required this.onNext,
     super.key,
   });
 
   final ModifiablePostEntity post;
   final String viewerPubkey;
+  final VoidCallback onNext;
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +35,7 @@ class StoryViewerContent extends StatelessWidget {
           authorPubkey: post.masterPubkey,
           storyId: post.id,
           viewerPubkey: viewerPubkey,
+          onVideoCompleted: onNext,
         ),
       _ => const CenteredLoadingIndicator(),
     };

--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -2,13 +2,10 @@
 
 import 'package:cached_video_player_plus/cached_video_player_plus.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
 import 'package:ion/app/features/feed/stories/hooks/use_story_video_playback.dart';
-import 'package:ion/app/features/feed/stories/providers/story_viewing_provider.r.dart';
-import 'package:ion/app/features/feed/stories/providers/user_stories_provider.r.dart';
 
 class VideoStoryViewer extends HookConsumerWidget {
   const VideoStoryViewer({
@@ -16,6 +13,7 @@ class VideoStoryViewer extends HookConsumerWidget {
     required this.authorPubkey,
     required this.storyId,
     required this.viewerPubkey,
+    required this.onVideoCompleted,
     super.key,
   });
 
@@ -23,6 +21,7 @@ class VideoStoryViewer extends HookConsumerWidget {
   final String authorPubkey;
   final String storyId;
   final String viewerPubkey;
+  final VoidCallback onVideoCompleted;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -38,25 +37,12 @@ class VideoStoryViewer extends HookConsumerWidget {
       return const CenteredLoadingIndicator();
     }
 
-    final stories = ref
-            .watch(
-              userStoriesProvider(
-                ref.watch(storyViewingControllerProvider(viewerPubkey)).currentUserPubkey,
-              ),
-            )
-            ?.toList() ??
-        [];
-
     useStoryVideoPlayback(
       ref: ref,
       controller: videoController,
       storyId: storyId,
       viewerPubkey: viewerPubkey,
-      onCompleted: () {
-        ref
-            .read(storyViewingControllerProvider(viewerPubkey).notifier)
-            .advance(stories: stories, onClose: () => context.pop());
-      },
+      onCompleted: onVideoCompleted,
     );
 
     Widget videoPlayer = CachedVideoPlayerPlus(videoController);

--- a/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
+++ b/lib/app/features/feed/views/pages/feed_page/components/stories/hooks/use_preload_story_media.dart
@@ -2,19 +2,27 @@
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
+import 'package:ion/app/features/core/providers/video_player_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/stories/providers/story_image_loading_provider.r.dart';
 import 'package:ion/app/hooks/use_on_init.dart';
 
-void usePreloadStoryImage(WidgetRef ref, ModifiablePostEntity? story) {
+void usePreloadStoryMedia(WidgetRef ref, ModifiablePostEntity? story) {
   useOnInit(
     () {
       if (story == null) return;
       final media = story.data.primaryMedia;
-      if (media != null && media.mediaType == MediaType.image) {
+      if (media == null) return;
+      if (media.mediaType == MediaType.image) {
         ref.read(storyImageCacheManagerProvider).downloadFile(media.url);
+      } else if (media.mediaType == MediaType.video) {
+        ref.read(
+          videoControllerProvider(
+            VideoControllerParams(sourcePath: media.url, authorPubkey: story.masterPubkey),
+          ),
+        );
       }
     },
-    [story],
+    [story?.id],
   );
 }

--- a/lib/app/features/feed/views/pages/topics_modal/selected_topics.dart
+++ b/lib/app/features/feed/views/pages/topics_modal/selected_topics.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/feed/data/models/feed_interests.f.dart';
 import 'package:ion/app/features/feed/data/models/feed_type.dart';
@@ -46,7 +47,9 @@ class SelectedTopics extends HookConsumerWidget {
         child: ListView.separated(
           scrollDirection: Axis.horizontal,
           itemCount: selected.length,
-          padding: EdgeInsetsDirectional.symmetric(horizontal: 16.s),
+          padding: EdgeInsetsDirectional.symmetric(
+            horizontal: ScreenSideOffset.defaultSmallMargin,
+          ),
           separatorBuilder: (_, __) => SizedBox(width: 8.s),
           itemBuilder: (context, index) {
             final subcategoryKey = selected.elementAt(index);

--- a/test/app/features/stories/data/story_models_test.dart
+++ b/test/app/features/stories/data/story_models_test.dart
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ion/app/features/feed/stories/data/models/story_viewer_state.f.dart';
-import 'package:ion/app/features/feed/stories/data/models/user_story.f.dart';
+import 'package:ion/app/features/feed/stories/data/models/models.dart';
 
 import '../../../../fixtures/posts/post_fixtures.dart';
 
@@ -16,54 +15,72 @@ void main() {
     story: buildPost('b1'),
   );
 
-  group('StoryViewerState navigation getters', () {
-    test('hasPreviousStory behave at boundaries', () {
-      var state = StoryViewerState(
-        userStories: [userA, userB],
-        currentUserIndex: 0,
+  group('SingleUserStoriesViewerState navigation getters', () {
+    test('hasPreviousStory behaves at boundaries', () {
+      var singleState = const SingleUserStoriesViewerState(
+        pubkey: 'alice',
         currentStoryIndex: 0,
       );
-      expect(state.hasPreviousStory, isFalse);
+      expect(singleState.hasPreviousStory, isFalse);
 
-      state = state.copyWith(currentStoryIndex: 1);
-      expect(state.hasPreviousStory, isTrue);
-    });
-
-    test('hasNextUser / hasPreviousUser behave at boundaries', () {
-      var state = StoryViewerState(
-        userStories: [userA, userB],
-        currentUserIndex: 0,
-        currentStoryIndex: 0,
-      );
-      expect(state.hasNextUser, isTrue);
-      expect(state.hasPreviousUser, isFalse);
-
-      state = state.copyWith(currentUserIndex: 1);
-      expect(state.hasNextUser, isFalse);
-      expect(state.hasPreviousUser, isTrue);
+      singleState = singleState.copyWith(currentStoryIndex: 1);
+      expect(singleState.hasPreviousStory, isTrue);
     });
   });
 
-  group('currentStory & currentUser getters', () {
-    test('currentStory returns correct entity', () {
-      final state = StoryViewerState(
+  group('UserStoriesViewerState navigation getters', () {
+    test('hasNextUser / hasPreviousUser behave at boundaries', () {
+      var multiState = UserStoriesViewerState(
+        userStories: [userA, userB],
+        currentUserIndex: 0,
+      );
+      expect(multiState.hasNextUser, isTrue);
+      expect(multiState.hasPreviousUser, isFalse);
+
+      multiState = multiState.copyWith(currentUserIndex: 1);
+      expect(multiState.hasNextUser, isFalse);
+      expect(multiState.hasPreviousUser, isTrue);
+    });
+  });
+
+  group('UserStoriesViewerState current getters', () {
+    test('currentStory & currentUserPubkey return correct values', () {
+      final multiState = UserStoriesViewerState(
         userStories: [userA, userB],
         currentUserIndex: 1,
-        currentStoryIndex: 0,
       );
 
-      expect(state.currentStory?.story.id, equals('b1'));
-      expect(state.currentUserPubkey, equals('bob'));
+      expect(multiState.currentStory?.story.id, equals('b1'));
+      expect(multiState.currentUserPubkey, equals('bob'));
     });
 
-    test('currentStory returns null when indices are out of range', () {
-      final state = StoryViewerState(
+    test('currentStory returns null when index is out of range', () {
+      final multiState = UserStoriesViewerState(
         userStories: [userA],
         currentUserIndex: 5,
-        currentStoryIndex: 0,
       );
 
-      expect(state.currentStory, isNull);
+      expect(multiState.currentStory, isNull);
+    });
+
+    test('nextUserPubkey returns correct pubkey or empty string', () {
+      var multiState = UserStoriesViewerState(
+        userStories: [userA, userB],
+        currentUserIndex: 0,
+      );
+      expect(multiState.nextUserPubkey, equals('bob'));
+
+      multiState = multiState.copyWith(currentUserIndex: 1);
+      expect(multiState.nextUserPubkey, equals(''));
+    });
+
+    test('pubkeyAtIndex returns pubkey or empty string', () {
+      final multiState = UserStoriesViewerState(
+        userStories: [userA, userB],
+        currentUserIndex: 0,
+      );
+      expect(multiState.pubkeyAtIndex(1), equals('bob'));
+      expect(multiState.pubkeyAtIndex(5), equals(''));
     });
   });
 }

--- a/test/app/features/stories/providers/story_controllers_test.dart
+++ b/test/app/features/stories/providers/story_controllers_test.dart
@@ -8,7 +8,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../../fixtures/stories/story_fixtures.dart';
 import '../../../../test_utils.dart';
-import '../data/fake_feed_stories_state.dart';
 
 final class MockFollowingFeedSeenEventsRepository extends Mock
     implements FollowingFeedSeenEventsRepository {}
@@ -18,100 +17,187 @@ void main() {
   const bob = StoryFixtures.bob;
 
   final aliceUserStories = StoryFixtures.userStory();
-  final aliceStories = StoryFixtures.stories(
-    count: 2,
-  );
-  final bobUserStories = StoryFixtures.userStory(
-    pubkey: bob,
-  );
+  final aliceStories = StoryFixtures.stories(count: 2);
+  final bobUserStories = StoryFixtures.userStory(pubkey: bob);
 
   final overrides = [
-    feedStoriesProvider.overrideWith(
-      () => FakeFeedStories([aliceUserStories, bobUserStories]),
-    ),
+    feedStoriesByPubkeyProvider(alice).overrideWithValue([aliceUserStories, bobUserStories]),
   ];
 
-  group('StoryViewingController navigation', () {
-    test('initial state starts at user 0, story 0', () {
+  group('UserStoriesViewingNotifier (multi-user)', () {
+    test('initial state starts at user index 0', () {
       final container = createContainer(overrides: overrides);
-      final state = container.read(storyViewingControllerProvider(alice));
-
-      expect(state.currentUserIndex, 0);
-      expect(state.currentStoryIndex, 0);
+      final state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
+      expect(state.currentUserIndex, equals(0));
     });
 
-    test('advance increments story index within the same user', () {
+    test('advance() moves to next user while in bounds', () {
       final container = createContainer(overrides: overrides);
+      final notifier = container.read(
+        userStoriesViewingNotifierProvider(alice).notifier,
+      );
+      final didAdvance = notifier.advance();
+      final state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
 
-      container
-          .read(storyViewingControllerProvider(alice).notifier)
-          .advance(stories: aliceStories); // a2
-
-      final state = container.read(storyViewingControllerProvider(alice));
-
-      expect(state.currentUserIndex, 0);
-      expect(state.currentStoryIndex, 1);
+      expect(didAdvance, isTrue);
+      expect(state.currentUserIndex, equals(1));
     });
 
-    test('advance on last story jumps to next user (story 0)', () {
+    test('advance() at last user calls onClose and does not change index', () {
       final container = createContainer(overrides: overrides);
+      final notifier = container.read(
+        userStoriesViewingNotifierProvider(alice).notifier,
+      )..advance(); // now at index 1 (Bob)
+      var wasClosed = false;
+      final didAdvance = notifier.advance(onClose: () => wasClosed = true);
+      final state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
 
-      container.read(storyViewingControllerProvider(alice).notifier)
-        ..advance(stories: aliceStories) // a2
-        ..advance(stories: aliceStories); // bob/b1
-
-      final state = container.read(storyViewingControllerProvider(alice));
-
-      expect(state.currentUserIndex, 1);
-      expect(state.currentStoryIndex, 0);
+      expect(didAdvance, isFalse);
+      expect(wasClosed, isTrue);
+      expect(state.currentUserIndex, equals(1));
     });
 
-    test('rewind at first story jumps to previous user (story 0)', () {
+    test('rewind() moves back one user while in bounds', () {
       final container = createContainer(overrides: overrides);
+      final notifier = container.read(
+        userStoriesViewingNotifierProvider(alice).notifier,
+      )..advance(); // move to Bob
+      final didRewind = notifier.rewind();
+      final state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
 
-      container.read(storyViewingControllerProvider(alice).notifier)
-        ..advance(stories: aliceStories) // a2
-        ..advance(stories: aliceStories) // bob/b1
-        ..rewind(); // back to Alice/a1
-
-      final state = container.read(storyViewingControllerProvider(alice));
-
-      expect(state.currentUserIndex, 0);
-      expect(state.currentStoryIndex, 0);
+      expect(didRewind, isTrue);
+      expect(state.currentUserIndex, equals(0));
     });
 
-    test('moveToUser always resets story index to 0', () {
+    test('rewind() at first user calls onClose and does not change index', () {
       final container = createContainer(overrides: overrides);
-      final notifier = container.read(storyViewingControllerProvider(alice).notifier)
-        ..moveToUser(1); // Bob
-      var state = container.read(storyViewingControllerProvider(alice));
-      expect(state.currentUserIndex, 1);
-      expect(state.currentStoryIndex, 0);
+      final notifier = container.read(
+        userStoriesViewingNotifierProvider(alice).notifier,
+      );
+      var wasClosed = false;
+      final didRewind = notifier.rewind(onClose: () => wasClosed = true);
+      final state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
 
-      notifier.moveToUser(0); // Alice
-      state = container.read(storyViewingControllerProvider(alice));
-      expect(state.currentUserIndex, 0);
-      expect(state.currentStoryIndex, 0);
+      expect(didRewind, isFalse);
+      expect(wasClosed, isTrue);
+      expect(state.currentUserIndex, equals(0));
     });
 
-    test(
-      'advance does not overwrite indices when moveToUser is called '
-      'with the current user (CubePageView onPageChanged)',
-      () {
-        final container = createContainer(overrides: overrides);
-        final notifier = container.read(storyViewingControllerProvider(alice).notifier)
-          ..advance(stories: aliceStories);
+    test('moveTo(index) sets the currentUserIndex (ignores –1)', () {
+      final container = createContainer(overrides: overrides);
+      final notifier = container.read(
+        userStoriesViewingNotifierProvider(alice).notifier,
+      )..moveTo(1);
+      var state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
+      expect(state.currentUserIndex, equals(1));
 
-        var state = container.read(storyViewingControllerProvider(alice));
-        expect(state.currentUserIndex, 0);
-        expect(state.currentStoryIndex, 1);
+      notifier.moveTo(-1);
+      state = container.read(
+        userStoriesViewingNotifierProvider(alice),
+      );
+      expect(state.currentUserIndex, equals(1));
+    });
+  });
 
-        notifier.moveToUser(state.currentUserIndex);
+  group('SingleUserStoryViewingController (single-user)', () {
+    test('initial state starts at story index 0', () {
+      final container = createContainer();
+      final state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+      expect(state.currentStoryIndex, equals(0));
+    });
 
-        state = container.read(storyViewingControllerProvider(alice));
-        expect(state.currentUserIndex, 0);
-        expect(state.currentStoryIndex, 1);
-      },
-    );
+    test('advance() increments storyIndex while in bounds', () {
+      final container = createContainer();
+      final notifier = container.read(
+        singleUserStoryViewingControllerProvider(alice).notifier,
+      );
+      final didAdvance = notifier.advance(storiesLength: aliceStories.length);
+      final state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+
+      expect(didAdvance, isTrue);
+      expect(state.currentStoryIndex, equals(1));
+    });
+
+    test('advance() at last story calls onSeenAll and does not change index', () {
+      final container = createContainer();
+      final notifier = container.read(
+        singleUserStoryViewingControllerProvider(alice).notifier,
+      )..advance(storiesLength: aliceStories.length); // now at 1
+      var wasSeenAll = false;
+      final didAdvance = notifier.advance(
+        storiesLength: aliceStories.length,
+        onSeenAll: () => wasSeenAll = true,
+      );
+      final state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+
+      expect(didAdvance, isFalse);
+      expect(wasSeenAll, isTrue);
+      expect(state.currentStoryIndex, equals(1));
+    });
+
+    test('rewind() decrements storyIndex while in bounds', () {
+      final container = createContainer();
+      final notifier = container.read(
+        singleUserStoryViewingControllerProvider(alice).notifier,
+      )..advance(storiesLength: aliceStories.length);
+      final didRewind = notifier.rewind();
+      final state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+
+      expect(didRewind, isTrue);
+      expect(state.currentStoryIndex, equals(0));
+    });
+
+    test('rewind() at first story calls onRewoundAll and does not change index', () {
+      final container = createContainer();
+      final notifier = container.read(
+        singleUserStoryViewingControllerProvider(alice).notifier,
+      );
+      var wasRewoundAll = false;
+      final didRewind = notifier.rewind(onRewoundAll: () => wasRewoundAll = true);
+      final state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+
+      expect(didRewind, isFalse);
+      expect(wasRewoundAll, isTrue);
+      expect(state.currentStoryIndex, equals(0));
+    });
+
+    test('moveToStoryIndex(index) sets the storyIndex (ignores –1)', () {
+      final container = createContainer();
+      final notifier = container.read(
+        singleUserStoryViewingControllerProvider(alice).notifier,
+      )..moveToStoryIndex(1);
+      var state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+      expect(state.currentStoryIndex, equals(1));
+
+      notifier.moveToStoryIndex(-1);
+      state = container.read(
+        singleUserStoryViewingControllerProvider(alice),
+      );
+      expect(state.currentStoryIndex, equals(1));
+    });
   });
 }

--- a/test/robots/mixins/story_state_mixin.dart
+++ b/test/robots/mixins/story_state_mixin.dart
@@ -34,9 +34,12 @@ mixin StoryStateMixin on BaseRobot {
     required int userIndex,
     required int storyIndex,
   }) {
-    final state = container.read(storyViewingControllerProvider(viewerPubkey));
+    final storiesState = container.read(userStoriesViewingNotifierProvider(viewerPubkey));
+    final singleUserStoriesState = container.read(
+      singleUserStoryViewingControllerProvider(viewerPubkey),
+    );
 
-    expect(state.currentUserIndex, userIndex, reason: 'currentUserIndex');
-    expect(state.currentStoryIndex, storyIndex, reason: 'currentStoryIndex');
+    expect(storiesState.currentUserIndex, userIndex, reason: 'currentUserIndex');
+    expect(singleUserStoriesState.currentStoryIndex, storyIndex, reason: 'currentStoryIndex');
   }
 }

--- a/test/robots/stories/story_progress_bar_robot.dart
+++ b/test/robots/stories/story_progress_bar_robot.dart
@@ -30,7 +30,7 @@ class StoryProgressBarRobot extends BaseRobot with ProviderScopeMixin, StoryStat
     await tester.pumpWidget(
       RobotTestHarness(
         childBuilder: (_) => Scaffold(
-          body: StoryProgressBarContainer(pubkey: viewerPubkey),
+          body: StoryProgressBarContainer(pubkey: viewerPubkey, showOnlySelectedUser: true),
         ),
         overrides: [
           feedStoriesProvider.overrideWith(() => FakeFeedStories(stories)),
@@ -52,8 +52,8 @@ class StoryProgressBarRobot extends BaseRobot with ProviderScopeMixin, StoryStat
   Finder get _segmentFinder => find.byType(StoryProgressSegment);
 
   void advance({required List<ModifiablePostEntity> stories}) => container
-      .read(storyViewingControllerProvider(viewerPubkey).notifier)
-      .advance(stories: stories);
+      .read(singleUserStoryViewingControllerProvider(viewerPubkey).notifier)
+      .advance(storiesLength: stories.length);
 
   List<StoryProgressSegment> get segments =>
       tester.widgetList<StoryProgressSegment>(_segmentFinder).toList();

--- a/test/robots/stories/story_viewer_robot.dart
+++ b/test/robots/stories/story_viewer_robot.dart
@@ -133,7 +133,8 @@ class StoryViewerRobot extends BaseRobot with ProviderScopeMixin, StoryStateMixi
 
   void expectStoryIndex(int index) {
     expectViewerState(
-      userIndex: container.read(storyViewingControllerProvider(viewerPubkey)).currentUserIndex,
+      userIndex:
+          container.read(singleUserStoryViewingControllerProvider(viewerPubkey)).currentStoryIndex,
       storyIndex: index,
     );
   }
@@ -141,7 +142,7 @@ class StoryViewerRobot extends BaseRobot with ProviderScopeMixin, StoryStateMixi
   void expectUserIndex(int index) {
     expectViewerState(
       userIndex: index,
-      storyIndex: container.read(storyViewingControllerProvider(viewerPubkey)).currentStoryIndex,
+      storyIndex: container.read(userStoriesViewingNotifierProvider(viewerPubkey)).currentUserIndex,
     );
   }
 

--- a/test/robots/stories/video_playback_robot.dart
+++ b/test/robots/stories/video_playback_robot.dart
@@ -35,8 +35,9 @@ class _TestVideoPlayback extends HookConsumerWidget {
       controller: ctrl,
       storyId: post.id,
       viewerPubkey: viewerPubkey,
-      onCompleted: () =>
-          ref.read(storyViewingControllerProvider(viewerPubkey).notifier).advance(stories: []),
+      onCompleted: () => ref
+          .read(singleUserStoryViewingControllerProvider(viewerPubkey).notifier)
+          .advance(storiesLength: 0),
     );
 
     return const SizedBox.shrink();


### PR DESCRIPTION
## Description
This PR fixes an issue where swiping between users in story viewer page showed the same user on both side of the cube navigation.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3287

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/dc7a8283-7e4a-42dc-af71-22f97f934460


