### PR TITLE
fix: add custom title and description for SendEventException

### DIFF
--- a/lib/app/features/core/providers/exception_presenter_provider.r.dart
+++ b/lib/app/features/core/providers/exception_presenter_provider.r.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/providers/env_provider.r.dart';
+import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/generated/assets.gen.dart';
 import 'package:ion_identity_client/ion_identity.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -49,7 +50,8 @@ class ExceptionPresenter {
     return switch (error) {
       PaymentNoDestinationException() => locale.error_payment_no_destination_title,
       final IONIdentityException identityException => identityException.title(context),
-      _ => context.i18n.error_general_title,
+      SendEventException => locale.error_network_sync_failed_title,
+      _ => locale.error_general_title,
     };
   }
 
@@ -62,6 +64,7 @@ class ExceptionPresenter {
       Object _ when showDebugInfo => error.toString(),
       IONException(code: final int code) =>
         context.i18n.error_general_description(context.i18n.error_general_error_code(code)),
+      SendEventException => locale.error_network_sync_failed_description,
       _ => context.i18n.error_general_description('')
     };
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -601,6 +601,8 @@
   "error_identity_2fa_required_description": "Two-factor authentication is required to access this account. Please complete the 2FA process to proceed.",
   "error_payment_no_destination_title": "Unable to Transfer",
   "error_payment_no_destination_description": "To receive this coin, the receiver must have an existing {abbreviation} balance",
+  "error_network_sync_failed_title": "Network sync failed",
+  "error_network_sync_failed_description": "Please retry or reopen the app.",
   "warning_avoid_storing_keys": "Avoid storing keys on any device to prevent losing access to funds in case of a hack",
   "warning_authenticator_setup": "Keep this key safe to restore access if you lose your device.",
   "authenticator_setup_title": "Authenticator setup",


### PR DESCRIPTION
## Description
Previously on the onboarding we were showing a not user friendly error message, like `SendEventException: events[{"kind":0, "id": ....`.
I replaced it with a custom error messages.

## Task ID
ION-3271

## Type of Change
- [x] Bug fix