### PR TITLE
fix: mark message as deleted immediately

### DIFF
--- a/lib/app/features/chat/model/database/dao/conversation_message_dao.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_message_dao.dart
@@ -199,6 +199,41 @@ class ConversationMessageDao extends DatabaseAccessor<ChatDatabase>
     }
   }
 
+  Future<void> revertDeletedMessages({
+    required Env env,
+    required String masterPubkey,
+    required String eventSignerPubkey,
+    required List<EventReference> eventReferences,
+  }) async {
+    for (final eventReference in eventReferences) {
+      final existingStatusRow = await (select(messageStatusTable)
+            ..where((table) => table.masterPubkey.equals(masterPubkey))
+            ..where((table) => table.pubkey.equals(eventSignerPubkey))
+            ..where((table) => table.messageEventReference.equalsValue(eventReference)))
+          .getSingleOrNull();
+
+      if (existingStatusRow == null) {
+        await into(messageStatusTable).insert(
+          MessageStatusTableCompanion.insert(
+            masterPubkey: masterPubkey,
+            pubkey: eventSignerPubkey,
+            messageEventReference: eventReference,
+            status: MessageDeliveryStatus.deleted,
+          ),
+        );
+        continue;
+      }
+
+      await (update(messageStatusTable)
+            ..where((table) => table.masterPubkey.equals(masterPubkey))
+            ..where((table) => table.pubkey.equals(eventSignerPubkey))
+            ..where((table) => table.messageEventReference.equalsValue(eventReference)))
+          .write(
+        const MessageStatusTableCompanion(status: Value(MessageDeliveryStatus.read)),
+      );
+    }
+  }
+
   Future<void> _removeExpiredMessages(List<EventReference> eventReferences, Env env) async {
     final expiration = env.get<int>(EnvVariable.GIFT_WRAP_EXPIRATION_HOURS);
 

--- a/lib/app/features/chat/model/database/dao/conversation_message_dao.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_message_dao.dart
@@ -218,7 +218,7 @@ class ConversationMessageDao extends DatabaseAccessor<ChatDatabase>
             masterPubkey: masterPubkey,
             pubkey: eventSignerPubkey,
             messageEventReference: eventReference,
-            status: MessageDeliveryStatus.deleted,
+            status: MessageDeliveryStatus.read,
           ),
         );
         continue;

--- a/lib/app/features/chat/model/database/dao/conversation_message_reaction_dao.r.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_message_reaction_dao.r.dart
@@ -41,6 +41,16 @@ class ConversationMessageReactionDao extends DatabaseAccessor<ChatDatabase>
     );
   }
 
+  Future<void> revertDeletedReaction({
+    required ImmutableEventReference reactionEventReference,
+  }) async {
+    await (update(reactionTable)
+          ..where((table) => table.reactionEventReference.equalsValue(reactionEventReference)))
+        .write(
+      const ReactionTableCompanion(isDeleted: Value(false)),
+    );
+  }
+
   Stream<List<MessageReactionGroup>> messageReactions(EventMessage kind14EventMessage) async* {
     final eventReference =
         ReplaceablePrivateDirectMessageEntity.fromEventMessage(kind14EventMessage)


### PR DESCRIPTION
## Description
 - Marks message as delete in local DB to represent result of user action
 - Revert change if request to send kind 5 failed

## Task ID
ION-3256

## Type of Change
- [x] Bug fix
- [x] Refactoring
