### PR TITLE
fix: allow maximum video length in banuba on ios to get under 60 seconds

### DIFF
--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "492bba29fb731f23a78487efd646c3e6401255eae7f930473fd211677cc342cf",
+  "originHash" : "8cdf2790c121d22496f0f992474f271dda4d8eb105f1ec9e4d4af32d4d204673",
   "pins" : [
     {
       "identity" : "cryptoswift",

--- a/ios/Runner/VideoEditorModule.swift
+++ b/ios/Runner/VideoEditorModule.swift
@@ -117,6 +117,7 @@ class VideoEditorModule: VideoEditor {
         var config = videoEditorSDK?.currentConfiguration
         config?.videoEditorViewConfiguration.primaryAspectRatio = AspectRatio(videoAspectRatio: aspectRatio)
         config?.videoDurationConfiguration.maximumVideoDuration = TimeInterval(maxVideoDuration)
+        config?.videoDurationConfiguration.videoDurations = [TimeInterval(maxVideoDuration)]
         if let newConfig = config {
             videoEditorSDK?.updateVideoEditorConfig(newConfig)
         }


### PR DESCRIPTION
## Description
This PR fixes an issue where even if the `maxVideoDuration` was set to less than 60 seconds, it was capped to 60 seconds on ios.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
