### PR TITLE
feat: disable cover selection for stories creation flow

### DIFF
--- a/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/ion/app/MainActivity.kt
@@ -99,6 +99,8 @@ class MainActivity : FlutterFragmentActivity() {
                 METHOD_START_VIDEO_EDITOR_TRIMMER -> {
                     val videoFilePath = call.argument("videoFilePath") as? String
                     val maxVideoDurationMs = call.argument<Int?>("maxVideoDurationMs")
+                    val coverSelectionEnabled =
+                        call.argument<Boolean?>("coverSelectionEnabled") ?: true
                     val trimmerVideoUri = videoFilePath?.let { Uri.fromFile(File(it)) }
                     if (trimmerVideoUri == null) {
                         exportResult?.error("ERR_START_TRIMMER_MISSING_VIDEO", "", null)
@@ -114,7 +116,12 @@ class MainActivity : FlutterFragmentActivity() {
                                         }
 
                                     videoEditorModule = VideoEditorModule().apply {
-                                        initialize(application, aspectRatio, maxVideoDurationMs?.toLong())
+                                        initialize(
+                                            application,
+                                            aspectRatio,
+                                            maxVideoDurationMs?.toLong(),
+                                            coverSelectionEnabled,
+                                        )
                                     }
                                     startVideoEditorModeTrimmer(trimmerVideoUri)
                                 } else {

--- a/android/app/src/main/kotlin/io/ion/app/VideoEditorModule.kt
+++ b/android/app/src/main/kotlin/io/ion/app/VideoEditorModule.kt
@@ -19,6 +19,7 @@ import com.banuba.sdk.ve.di.VeSdkKoinModule
 import com.banuba.sdk.ve.flow.di.VeFlowKoinModule
 import com.banuba.sdk.veui.data.EditorConfig
 import com.banuba.sdk.veui.di.VeUiSdkKoinModule
+import com.banuba.sdk.veui.domain.CoverProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 import org.koin.core.qualifier.named
@@ -30,6 +31,7 @@ class VideoEditorModule {
         application: Application,
         videoAspectRatio: Double?,
         maxVideoDurationMs: Long? = 60_000,
+        coverSelectionEnabled: Boolean = true,
     ) {
         startKoin {
             androidContext(application)
@@ -53,7 +55,11 @@ class VideoEditorModule {
                 GalleryKoinModule().module,
 
                 // Sample integration module
-                SampleIntegrationVeKoinModule(videoAspectRatio, maxVideoDurationMs).module,
+                SampleIntegrationVeKoinModule(
+                    videoAspectRatio,
+                    maxVideoDurationMs,
+                    coverSelectionEnabled,
+                ).module,
             )
         }
     }
@@ -68,6 +74,7 @@ class VideoEditorModule {
 private class SampleIntegrationVeKoinModule(
     videoAspectRatio: Double?,
     maxVideoDurationMs: Long? = 60_000,
+    coverSelectionEnabled: Boolean = true,
 ) {
     val module = module {
         single<ArEffectsRepositoryProvider>(createdAtStart = true) {
@@ -86,6 +93,10 @@ private class SampleIntegrationVeKoinModule(
             named("musicTrackProvider")
         ) {
             AudioBrowserMusicProvider()
+        }
+
+        single<CoverProvider>(createdAtStart = true) {
+            if (coverSelectionEnabled) CoverProvider.EXTENDED else CoverProvider.NONE
         }
 
         single(createdAtStart = true) {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -202,12 +202,14 @@ class AudioFocusHandler: NSObject {
                     let arguments = methodCall.arguments as? [String: Any]
                                     let trimmerVideoFilePath = arguments?["videoFilePath"] as? String
                     let maxVideoDurationMs = arguments?["maxVideoDurationMs"] as? Int ?? 60000
+                    let coverSelectionEnabled = arguments?["coverSelectionEnabled"] as? Bool ?? true
                     let maxVideoDurationSec = maxVideoDurationMs / 1000
                                     if let videoFilePath = trimmerVideoFilePath {
                                         videoEditor.openVideoEditorTrimmer(
                                             fromViewController: controller,
                                             videoURL: URL(fileURLWithPath: videoFilePath),
                                             maxVideoDuration: maxVideoDurationSec,
+                                            coverSelectionEnabled: coverSelectionEnabled,
                                             flutterResult: result
                                         )
                                     } else {

--- a/ios/Runner/VideoEditorModule.swift
+++ b/ios/Runner/VideoEditorModule.swift
@@ -11,7 +11,7 @@ protocol VideoEditor {
     
     func openVideoEditorPIP(fromViewController controller: FlutterViewController, videoURL: URL, flutterResult: @escaping FlutterResult)
     
-    func openVideoEditorTrimmer(fromViewController controller: FlutterViewController, videoURL: URL, maxVideoDuration: Int, flutterResult: @escaping FlutterResult)
+    func openVideoEditorTrimmer(fromViewController controller: FlutterViewController, videoURL: URL, maxVideoDuration: Int, coverSelectionEnabled: Bool, flutterResult: @escaping FlutterResult)
 }
 
 class VideoEditorModule: VideoEditor {
@@ -92,6 +92,7 @@ class VideoEditorModule: VideoEditor {
         fromViewController controller: FlutterViewController,
         videoURL: URL,
         maxVideoDuration: Int = 60,
+        coverSelectionEnabled: Bool,
         flutterResult: @escaping FlutterResult
     ) {
         self.flutterResult = flutterResult
@@ -118,6 +119,7 @@ class VideoEditorModule: VideoEditor {
         config?.videoEditorViewConfiguration.primaryAspectRatio = AspectRatio(videoAspectRatio: aspectRatio)
         config?.videoDurationConfiguration.maximumVideoDuration = TimeInterval(maxVideoDuration)
         config?.videoDurationConfiguration.videoDurations = [TimeInterval(maxVideoDuration)]
+        config?.featureConfiguration.isVideoCoverSelectionEnabled = coverSelectionEnabled
         if let newConfig = config {
             videoEditorSDK?.updateVideoEditorConfig(newConfig)
         }

--- a/lib/app/features/feed/stories/providers/media_editing_service.r.dart
+++ b/lib/app/features/feed/stories/providers/media_editing_service.r.dart
@@ -20,7 +20,11 @@ class MediaEditingService {
 
   final Ref _ref;
 
-  Future<String?> edit(MediaFile file, {bool resumeCamera = true}) async {
+  Future<String?> edit(
+    MediaFile file, {
+    bool resumeCamera = true,
+    bool videoCoverSelectionEnabled = true,
+  }) async {
     final camera = _ref.read(cameraControllerNotifierProvider.notifier);
     final isCameraPaused = _ref.read(cameraControllerNotifierProvider) is CameraPaused;
 
@@ -30,6 +34,7 @@ class MediaEditingService {
         editMediaProvider(
           file,
           maxVideoDuration: VideoConstants.storyVideoMaxDuration,
+          videoCoverSelectionEnabled: videoCoverSelectionEnabled,
         ).future,
       ))
           ?.path;

--- a/lib/app/features/feed/stories/views/pages/story_record_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_record_page.dart
@@ -106,8 +106,11 @@ class StoryRecordPage extends HookConsumerWidget {
         final mediaType = MediaType.fromMimeType(file.mimeType ?? '');
 
         if (mediaType == MediaType.video) {
-          final edited =
-              await ref.read(mediaEditingServiceProvider).edit(file, resumeCamera: false);
+          final edited = await ref.read(mediaEditingServiceProvider).edit(
+                file,
+                resumeCamera: false,
+                videoCoverSelectionEnabled: false,
+              );
 
           if (edited != null && edited != file.path && context.mounted) {
             await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<void>(context);
@@ -157,7 +160,11 @@ class StoryRecordPage extends HookConsumerWidget {
     final mediaType = MediaType.fromMimeType(file.mimeType ?? '');
 
     if (mediaType == MediaType.video) {
-      final edited = await ref.read(mediaEditingServiceProvider).edit(file, resumeCamera: false);
+      final edited = await ref.read(mediaEditingServiceProvider).edit(
+            file,
+            resumeCamera: false,
+            videoCoverSelectionEnabled: false,
+          );
 
       if (edited != null && edited != file.path && context.mounted) {
         await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<void>(context);

--- a/lib/app/services/media_service/banuba_service.r.dart
+++ b/lib/app/services/media_service/banuba_service.r.dart
@@ -34,6 +34,7 @@ class BanubaService {
   static const methodStartVideoEditorTrimmer = 'startVideoEditorTrimmer';
   static const argVideoFilePath = 'videoFilePath';
   static const argMaxVideoDurationMs = 'maxVideoDurationMs';
+  static const argCoverSelectionEnabled = 'coverSelectionEnabled';
   static const argExportedVideoFile = 'argExportedVideoFilePath';
   static const argExportedVideoCoverPreview = 'argExportedVideoCoverPreviewPath';
 
@@ -83,6 +84,7 @@ class BanubaService {
   Future<EditVideResult?> editVideo(
     String filePath, {
     Duration? maxVideoDuration = const Duration(seconds: 60),
+    bool coverSelectionEnabled = true,
   }) async {
     await platformChannel.invokeMethod(
       methodInitVideoEditor,
@@ -94,6 +96,7 @@ class BanubaService {
       {
         argVideoFilePath: filePath,
         argMaxVideoDurationMs: maxVideoDuration?.inMilliseconds,
+        argCoverSelectionEnabled: coverSelectionEnabled,
       },
     );
 
@@ -116,6 +119,7 @@ Future<MediaFile?> editMedia(
   Ref ref,
   MediaFile mediaFile, {
   Duration? maxVideoDuration,
+  bool videoCoverSelectionEnabled = true,
 }) async {
   final filePath = path.isAbsolute(mediaFile.path)
       ? mediaFile.path
@@ -150,6 +154,7 @@ Future<MediaFile?> editMedia(
       final editVideoData = await ref.read(banubaServiceProvider).editVideo(
             filePath,
             maxVideoDuration: maxVideoDuration,
+            coverSelectionEnabled: videoCoverSelectionEnabled,
           );
       if (editVideoData == null) return null;
       return mediaFile.copyWith(path: editVideoData.newPath, thumb: editVideoData.thumb);


### PR DESCRIPTION
## Description
This PR disabled banuba editor step with video cover flow selection for stories.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/afb18121-6cb8-4cf1-893d-7763fdb96a57


