### PR TITLE
feat(wallet): add Receive NFT button to NFT tab

### DIFF
--- a/lib/app/features/wallets/views/pages/wallet_page/components/empty_state/empty_state.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/empty_state/empty_state.dart
@@ -55,8 +55,8 @@ class EmptyState extends ConsumerWidget {
                         ),
                         SizedBox(height: 8.s),
                         TextButton(
-                          onPressed: () async {
-                            await SelectNetworkToReceiveNftRoute().push<void>(ref.context);
+                          onPressed: () {
+                            SelectNetworkToReceiveNftRoute().push<void>(ref.context);
                           },
                           child: Text(
                             context.i18n.wallet_receive_nft,

--- a/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nfts_tab_footer.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nfts_tab_footer.dart
@@ -3,12 +3,9 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
-import 'package:ion/app/features/core/model/feature_flags.dart';
-import 'package:ion/app/features/core/providers/feature_flags_provider.r.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/components/bottom_action/bottom_action.dart';
-import 'package:ion/app/features/wallets/views/pages/wallet_page/components/nfts/constants.dart';
-import 'package:ion/app/features/wallets/views/pages/wallet_page/providers/search_visibility_provider.r.dart';
 import 'package:ion/app/features/wallets/views/pages/wallet_page/tab_type.dart';
+import 'package:ion/app/router/app_routes.gr.dart';
 
 class NftsTabFooter extends ConsumerWidget {
   const NftsTabFooter({
@@ -19,21 +16,16 @@ class NftsTabFooter extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final searchVisibleProvider = walletSearchVisibilityProvider(tabType);
-    final isSearchVisible = ref.watch(searchVisibleProvider);
-    final buyNftFeatureEnabled =
-        ref.watch(featureFlagsProvider.notifier).get(WalletFeatureFlag.buyNftEnabled);
-
     return SliverToBoxAdapter(
-      child: buyNftFeatureEnabled && !isSearchVisible
-          ? ScreenSideOffset.small(
-              child: BottomAction(
-                asset: tabType.bottomActionAsset,
-                title: tabType.getBottomActionTitle(context),
-                onTap: () {},
-              ),
-            )
-          : SizedBox(height: NftConstants.gridSpacing),
+      child: ScreenSideOffset.small(
+        child: BottomAction(
+          asset: tabType.bottomActionAsset,
+          title: tabType.getBottomActionTitle(context),
+          onTap: () async {
+            await SelectNetworkToReceiveNftRoute().push<void>(ref.context);
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nfts_tab_footer.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/components/nfts/nfts_tab_footer.dart
@@ -21,8 +21,8 @@ class NftsTabFooter extends ConsumerWidget {
         child: BottomAction(
           asset: tabType.bottomActionAsset,
           title: tabType.getBottomActionTitle(context),
-          onTap: () async {
-            await SelectNetworkToReceiveNftRoute().push<void>(ref.context);
+          onTap: () {
+            SelectNetworkToReceiveNftRoute().push<void>(ref.context);
           },
         ),
       ),

--- a/lib/app/features/wallets/views/pages/wallet_page/tab_type.dart
+++ b/lib/app/features/wallets/views/pages/wallet_page/tab_type.dart
@@ -26,7 +26,7 @@ enum WalletTabType {
   String get bottomActionAsset {
     return switch (this) {
       WalletTabType.coins => Assets.svg.iconButtonManagecoin,
-      WalletTabType.nfts => Assets.svg.iconButtonWalletnft,
+      WalletTabType.nfts => Assets.svg.iconPostAddanswer,
     };
   }
 
@@ -40,7 +40,7 @@ enum WalletTabType {
   String getBottomActionTitle(BuildContext context) {
     return switch (this) {
       WalletTabType.coins => context.i18n.wallet_manage_coins,
-      WalletTabType.nfts => context.i18n.wallet_buy_nfts,
+      WalletTabType.nfts => context.i18n.wallet_receive_nft,
     };
   }
 


### PR DESCRIPTION
## Description
Previosly we didn't show "Receive NFT" button if user already has at least 1 NFT. This PR makes it to show that button always.

## Task ID
ION-3328

## Type of Change
- [x] New feature

## Screenshots
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-07-21 at 16 33 58" src="https://github.com/user-attachments/assets/d2903910-96fb-4d9c-af86-749332db84d8" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-07-21 at 16 34 35" src="https://github.com/user-attachments/assets/8d997ed8-b3cd-488f-9cca-411e1f235c1b" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-07-21 at 16 34 41" src="https://github.com/user-attachments/assets/7f578bfa-8bd9-4668-9357-bb55fffa36a5" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-07-21 at 16 35 17" src="https://github.com/user-attachments/assets/51fc3d43-f5f2-4868-ade5-3d9444aed347" />

