### PR TITLE
fix: remove unnecessary padding from post carousel

### DIFF
--- a/lib/app/features/feed/views/components/post/components/post_body/components/post_media/components/post_media_carousel_vertical.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/components/post_media/components/post_media_carousel_vertical.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/feed/views/components/post/components/post_body/components/post_media/components/post_media_index_indicator.dart';
@@ -36,9 +35,6 @@ class PostMediaCarouselVertical extends HookConsumerWidget {
     return SizedBox(
       height: itemWidth / aspectRatio,
       child: ListView.separated(
-        padding: EdgeInsets.symmetric(
-          horizontal: ScreenSideOffset.defaultSmallMargin,
-        ),
         itemCount: media.length,
         scrollDirection: Axis.horizontal,
         separatorBuilder: (context, index) {


### PR DESCRIPTION
## Description
This PR remove extra padding from `PostMediaCarouselVertical` widget.

## Additional Notes
N/A

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="280" alt="image" src="https://github.com/user-attachments/assets/4f1ce5ae-421e-43b2-be66-591e6a16b881">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/b2ec26f8-465b-4e16-abd1-e88c3269a890">

