### PR TITLE
feat: crypto formatting

### DIFF
--- a/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
+++ b/lib/app/features/feed/views/components/post/components/post_body/post_body.dart
@@ -133,7 +133,6 @@ class PostBody extends HookConsumerWidget {
                   enableInteractiveSelection: isTextSelectable,
                   tagsColor: accentTheme ? context.theme.appColors.anakiwa : null,
                 ),
-          
               if (hasOverflow)
                 Text(
                   context.i18n.common_show_more,
@@ -143,13 +142,11 @@ class PostBody extends HookConsumerWidget {
                         : context.theme.appColors.darkBlue,
                   ),
                 ),
-          
               if (pollData != null)
                 PostPoll(
                   pollData: pollData,
                   postReference: entity.toEventReference(),
                 ),
-          
               if (media.isNotEmpty)
                 PostMedia(
                   media: media,
@@ -159,7 +156,6 @@ class PostBody extends HookConsumerWidget {
                   eventReference: entity.toEventReference(),
                   framedEventReference: framedEventReference,
                 ),
-          
               if (media.isEmpty && hasValidUrlMetadata)
                 UrlPreviewContent(
                   url: firstUrlInPost!,

--- a/lib/app/features/wallets/views/components/coins_list/coin_item.dart
+++ b/lib/app/features/wallets/views/components/coins_list/coin_item.dart
@@ -11,6 +11,7 @@ import 'package:ion/app/features/wallets/model/coins_group.f.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/user_preferences_selectors.r.dart';
 import 'package:ion/app/features/wallets/views/components/coins_list/unseen_transaction_indicator.dart';
 import 'package:ion/app/features/wallets/views/pages/coins_flow/coin_details/providers/network_selector_notifier.r.dart';
+import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 import 'package:ion/app/utils/precache_pictures.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -64,7 +65,7 @@ class CoinsGroupItem extends HookConsumerWidget {
                   ),
                 ),
               Text(
-                isBalanceVisible ? formatDouble(coinsGroup.totalAmount) : '****',
+                isBalanceVisible ? formatCrypto(coinsGroup.totalAmount) : '****',
                 style: context.theme.appTextThemes.body
                     .copyWith(color: context.theme.appColors.primaryText),
               ),

--- a/lib/app/features/wallets/views/pages/coins_flow/network_list/network_item.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/network_list/network_item.dart
@@ -8,6 +8,7 @@ import 'package:ion/app/features/wallets/model/coin_in_wallet_data.f.dart';
 import 'package:ion/app/features/wallets/model/network_data.f.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/user_preferences_selectors.r.dart';
 import 'package:ion/app/features/wallets/views/components/coin_icon_with_network.dart';
+import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
 
 class NetworkItem extends ConsumerWidget {
@@ -49,7 +50,7 @@ class NetworkItem extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           Text(
-            isBalanceVisible ? formatDouble(coinInWallet.amount) : '****',
+            isBalanceVisible ? formatCrypto(coinInWallet.amount) : '****',
             style: context.theme.appTextThemes.body
                 .copyWith(color: context.theme.appColors.primaryText),
           ),

--- a/lib/app/features/wallets/views/utils/crypto_formatter.dart
+++ b/lib/app/features/wallets/views/utils/crypto_formatter.dart
@@ -9,8 +9,11 @@ String formatCrypto(double value, [String? currency]) {
     // For values 1-9.99: max 6 decimals, min 2 decimals
     // Handle truncation for cases like 1.1234567 -> 1.123456 and 2.0000001 -> 2.00
     _ when value >= 1 => _formatWithSmartTruncation(value, maxDecimals: 6, minDecimals: 2),
-    // For values < 1: max 6 decimals, min 2 decimals, but handle very small numbers
+    // For values < 1e-6: specific format as 0.0(n)d
+    // - n is number of zeros after decimal point
+    // - d is first non-zero digit
     _ when value < 1e-6 => _formatVerySmallNumber(value),
+    // For values < 1: max 6 decimals, min 2 decimals
     _ => _formatWithSmartTruncation(value, maxDecimals: 6, minDecimals: 2),
   };
 

--- a/lib/app/features/wallets/views/utils/crypto_formatter.dart
+++ b/lib/app/features/wallets/views/utils/crypto_formatter.dart
@@ -3,9 +3,92 @@
 import 'package:ion/app/utils/num.dart';
 
 String formatCrypto(double value, [String? currency]) {
-  final formatted = formatDouble(value, maximumFractionDigits: 10);
+  final formatted = switch (value) {
+    0.0 => formatDouble(value),
+    _ when value >= 10 => _formatWithSmartTruncation(value, maxDecimals: 2, minDecimals: 2),
+    // For values 1-9.99: max 6 decimals, min 2 decimals
+    // Handle truncation for cases like 1.1234567 -> 1.123456 and 2.0000001 -> 2.00
+    _ when value >= 1 => _formatWithSmartTruncation(value, maxDecimals: 6, minDecimals: 2),
+    // For values < 1: max 6 decimals, min 2 decimals, but handle very small numbers
+    _ when value < 1e-6 => _formatVerySmallNumber(value),
+    _ => _formatWithSmartTruncation(value, maxDecimals: 6, minDecimals: 2),
+  };
 
   if (currency != null) return '$formatted $currency';
 
   return formatted;
+}
+
+String _formatWithSmartTruncation(
+  double value, {
+  required int maxDecimals,
+  required int minDecimals,
+}) {
+  final stringValue = value.toString();
+
+  if (!stringValue.contains('.')) {
+    // It's an integer, just format with minimum decimals
+    return formatDouble(
+      value,
+      maximumFractionDigits: maxDecimals,
+      minimumFractionDigits: minDecimals,
+    );
+  }
+
+  final parts = stringValue.split('.');
+  final integerPart = parts[0];
+  var decimalPart = parts[1];
+
+  // Truncate decimal part to maxDecimals if it's longer
+  if (decimalPart.length > maxDecimals) {
+    decimalPart = decimalPart.substring(0, maxDecimals);
+  }
+
+  // Pad with zeros to meet minimum decimals requirement
+  final buffer = StringBuffer(decimalPart);
+  while (buffer.length < minDecimals) {
+    buffer.write('0');
+  }
+  decimalPart = buffer.toString();
+
+  // Remove trailing zeros beyond minimum decimals
+  while (decimalPart.length > minDecimals && decimalPart.endsWith('0')) {
+    decimalPart = decimalPart.substring(0, decimalPart.length - 1);
+  }
+
+  final reconstructed = double.parse('$integerPart.$decimalPart');
+
+  // Use formatDouble to get proper thousands separators
+  return formatDouble(
+    reconstructed,
+    maximumFractionDigits: maxDecimals,
+    minimumFractionDigits: minDecimals,
+  );
+}
+
+String _formatVerySmallNumber(double value) {
+  // Convert to string with high precision and remove trailing zeros
+  final stringValue = value.toStringAsFixed(20).replaceAll(RegExp(r'0+$'), '');
+
+  if (!stringValue.contains('.')) {
+    return formatDouble(value);
+  }
+
+  final parts = stringValue.split('.');
+  final decimalPart = parts[1];
+
+  // Count consecutive zeros after decimal point
+  var zeroCount = 0;
+  for (var i = 0; i < decimalPart.length; i++) {
+    if (decimalPart[i] == '0') {
+      zeroCount++;
+    } else {
+      // Found the first non-zero digit
+      final firstSignificantDigit = decimalPart[i];
+      return '0.0($zeroCount)$firstSignificantDigit';
+    }
+  }
+
+  // Fallback to regular formatting if no non-zero digits found
+  return formatDouble(0);
 }

--- a/test/app/features/wallets/utils/crypto_formatter_test.dart
+++ b/test/app/features/wallets/utils/crypto_formatter_test.dart
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
+
+import '../../../../test_utils.dart';
+
+void main() {
+  group('formatCrypto', () {
+    group('zero values', () {
+      test('formats zero as 0.00', () {
+        expect(formatCrypto(0), '0.00');
+      });
+    });
+
+    group('values >= 10 (maximum 2 decimal places, minimum 2)', () {
+      parameterizedGroup('large values formatting', [
+        (value: 11.0, expected: '11.00'),
+        (value: 100.0, expected: '100.00'),
+        (value: 100.5, expected: '100.50'),
+        (value: 100.55, expected: '100.55'),
+        (value: 1000.0, expected: '1,000.00'),
+        (value: 1000.12, expected: '1,000.12'),
+        (value: 1000.123, expected: '1,000.12'),
+        (value: 1234567.89, expected: '1,234,567.89'),
+        (value: 1234567.999, expected: '1,234,568.99'),
+        (value: 50.0, expected: '50.00'),
+        (value: 99.99, expected: '99.99'),
+        (value: 10.1, expected: '10.10'),
+        (value: 999.999, expected: '1,000.00'),
+      ], (t) {
+        test('formatCrypto(${t.value}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value), t.expected);
+        });
+      });
+    });
+
+    group('values >= 1 and < 10 (maximum 6 decimal places)', () {
+      parameterizedGroup('medium values formatting', [
+        (value: 1.0, expected: '1.00'),
+        (value: 1.5, expected: '1.50'),
+        (value: 1.12, expected: '1.12'),
+        (value: 1.123456, expected: '1.123456'),
+        (value: 1.1234567, expected: '1.123456'),
+        (value: 9.0, expected: '9.00'),
+        (value: 9.99, expected: '9.99'),
+        (value: 9.999999, expected: '9.999999'),
+        (value: 5.123, expected: '5.123'),
+        (value: 2.000001, expected: '2.000001'),
+        (value: 2.0000001, expected: '2.00'),
+        (value: 3.1415926, expected: '3.141592'),
+      ], (t) {
+        test('formatCrypto(${t.value}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value), t.expected);
+        });
+      });
+    });
+
+    group('values < 1 (maximum 6 decimal places)', () {
+      parameterizedGroup('small values formatting', [
+        (value: 0.1, expected: '0.10'),
+        (value: 0.12, expected: '0.12'),
+        (value: 0.123, expected: '0.123'),
+        (value: 0.1234, expected: '0.1234'),
+        (value: 0.12345, expected: '0.12345'),
+        (value: 0.123456, expected: '0.123456'),
+        (value: 0.1234567, expected: '0.123456'),
+        (value: 0.001, expected: '0.001'),
+        (value: 0.0001, expected: '0.0001'),
+        (value: 0.00001, expected: '0.00001'),
+        (value: 0.000001, expected: '0.000001'),
+        (value: 0.0000001, expected: '0.00'),
+        (value: 0.999999, expected: '0.999999'),
+        (value: 0.5, expected: '0.50'),
+      ], (t) {
+        test('formatCrypto(${t.value}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value), t.expected);
+        });
+      });
+    });
+
+    group('with currency symbol', () {
+      parameterizedGroup('currency formatting', [
+        (value: 0.0, currency: 'BTC', expected: '0.00 BTC'),
+        (value: 1.5, currency: 'ETH', expected: '1.50 ETH'),
+        (value: 1000.12, currency: 'USD', expected: '1,000.12 USD'),
+        (value: 0.00001, currency: 'SATS', expected: '0.00001 SATS'),
+        (value: 0.0000119, currency: 'SATS', expected: '0.000011 SATS'),
+        (value: 11.0, currency: 'DOGE', expected: '11.00 DOGE'),
+        (value: 11.099999999, currency: 'DOGE', expected: '11.09 DOGE'),
+        (value: 0.123456, currency: 'ADA', expected: '0.123456 ADA'),
+      ], (t) {
+        test('formatCrypto(${t.value}, ${t.currency}) returns ${t.expected}', () {
+          expect(formatCrypto(t.value, t.currency), t.expected);
+        });
+      });
+
+      test('null currency returns value without suffix', () {
+        expect(formatCrypto(1.5), '1.50');
+      });
+    });
+
+    group('boundary values', () {
+      test('handles values exactly at boundaries', () {
+        expect(formatCrypto(1), '1.00');
+        expect(formatCrypto(10), '10.00');
+        expect(formatCrypto(0.999999), '0.999999');
+        expect(formatCrypto(0.9999999), '0.999999');
+        expect(formatCrypto(10.000001), '10.00');
+      });
+    });
+
+    group('edge cases', () {
+      test('handles very small numbers correctly', () {
+        expect(formatCrypto(1e-7), '0.00');
+        expect(formatCrypto(1e-6), '0.000001');
+        expect(formatCrypto(1.23e-6), '0.000001');
+      });
+    });
+  });
+}

--- a/test/app/features/wallets/utils/crypto_formatter_test.dart
+++ b/test/app/features/wallets/utils/crypto_formatter_test.dart
@@ -23,11 +23,11 @@ void main() {
         (value: 1000.12, expected: '1,000.12'),
         (value: 1000.123, expected: '1,000.12'),
         (value: 1234567.89, expected: '1,234,567.89'),
-        (value: 1234567.999, expected: '1,234,568.99'),
+        (value: 1234567.999, expected: '1,234,567.99'),
         (value: 50.0, expected: '50.00'),
         (value: 99.99, expected: '99.99'),
         (value: 10.1, expected: '10.10'),
-        (value: 999.999, expected: '1,000.00'),
+        (value: 999.999, expected: '999.99'),
       ], (t) {
         test('formatCrypto(${t.value}) returns ${t.expected}', () {
           expect(formatCrypto(t.value), t.expected);
@@ -69,7 +69,7 @@ void main() {
         (value: 0.0001, expected: '0.0001'),
         (value: 0.00001, expected: '0.00001'),
         (value: 0.000001, expected: '0.000001'),
-        (value: 0.0000001, expected: '0.00'),
+        (value: 0.0000001, expected: '0.0(6)1'),
         (value: 0.999999, expected: '0.999999'),
         (value: 0.5, expected: '0.50'),
       ], (t) {
@@ -112,9 +112,17 @@ void main() {
 
     group('edge cases', () {
       test('handles very small numbers correctly', () {
-        expect(formatCrypto(1e-7), '0.00');
+        expect(formatCrypto(1e-7), '0.0(6)1');
         expect(formatCrypto(1e-6), '0.000001');
         expect(formatCrypto(1.23e-6), '0.000001');
+      });
+
+      test('handles very small numbers with scientific notation format', () {
+        expect(formatCrypto(0.00000001), '0.0(7)1');
+        expect(formatCrypto(0.00000012), '0.0(6)1');
+        expect(formatCrypto(0.00000123), '0.000001');
+        expect(formatCrypto(0.000000456), '0.0(6)4');
+        expect(formatCrypto(0.0000000789), '0.0(7)7');
       });
     });
   });


### PR DESCRIPTION
## Description
Apply advanced rules to crypto formatting.

## Additional Notes
Rules:
**0 < value < 0.000001 (10 * (10^-7))** => display the value in the next way `0.0(n)d`, where
n - number of zeros after the dot
d - first non-zero value
**0.000001 < value < 10** => display max 6 decimal digits + integer part 
**value > 10** => display only 2 decimal digits + full integer part

## Task ID
ION-2515

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<img width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-22 at 17 10 37" src="https://github.com/user-attachments/assets/876f65c9-d341-4376-b199-24fdadf3d009" />

