### PR TITLE
feat: user chat privacy

### DIFF
--- a/lib/app/features/chat/e2ee/providers/encrypted_deletion_request_handler.r.dart
+++ b/lib/app/features/chat/e2ee/providers/encrypted_deletion_request_handler.r.dart
@@ -69,6 +69,7 @@ class EncryptedDeletionRequestHandler extends GlobalSubscriptionEncryptedEventMe
         .toList();
 
     if (deleteConversationIds.isNotEmpty) {
+      await eventMessageDao.add(rumor);
       await conversationDao.removeConversations(
         deleteRequest: rumor,
         conversationIds: deleteConversationIds,

--- a/lib/app/features/chat/model/database/chat_database.m.dart
+++ b/lib/app/features/chat/model/database/chat_database.m.dart
@@ -21,6 +21,7 @@ import 'package:ion/app/features/feed/data/models/entities/generic_repost.f.dart
 import 'package:ion/app/features/ion_connect/database/converters/event_reference_converter.d.dart';
 import 'package:ion/app/features/ion_connect/database/converters/event_tags_converter.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
+import 'package:ion/app/features/ion_connect/model/deletion_request.f.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 

--- a/lib/app/features/chat/model/database/dao/conversation_dao.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_dao.dart
@@ -243,6 +243,59 @@ class ConversationDao extends DatabaseAccessor<ChatDatabase> with _$Conversation
     return [];
   }
 
+  Future<bool> checkAnotherUserDeletedConversation({
+    required String masterPubkey,
+    required String conversationId,
+  }) async {
+    // Check if conversation is already marked as deleted in conversationTable
+    final conversation = await (select(conversationTable)
+          ..where((t) => t.id.equals(conversationId))
+          ..where((t) => t.isDeleted.equals(true)))
+        .getSingleOrNull();
+
+    if (conversation != null) {
+      return true;
+    }
+
+    // Check for kind 5 (deletion request) events from the specified masterPubkey
+    final kind5Events = await (select(eventMessageTable)
+          ..where((t) => t.kind.equals(5))
+          ..where((t) => t.masterPubkey.equals(masterPubkey)))
+        .get();
+
+    for (final event in kind5Events) {
+      final eventMessage = event.toEventMessage();
+      // Assuming deletion request events have tags in the format [['h', conversationId], ...]
+      final hasConversationTag = eventMessage.tags.any(
+        (tag) =>
+            tag.isNotEmpty &&
+            tag[0] == ConversationIdentifier.tagName &&
+            tag.length > 1 &&
+            tag[1] == conversationId,
+      );
+      if (hasConversationTag) {
+        // Check if there are newer messages for this conversation
+        final latestMessage = await (select(eventMessageTable).join([
+          innerJoin(
+            conversationMessageTable,
+            conversationMessageTable.messageEventReference
+                .equalsExp(eventMessageTable.eventReference),
+          ),
+        ])
+              ..where(conversationMessageTable.conversationId.equals(conversationId))
+              ..where(eventMessageTable.createdAt.isBiggerThanValue(eventMessage.createdAt))
+              ..limit(1))
+            .getSingleOrNull();
+
+        if (latestMessage == null) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
   Future<void> removeConversations({
     required EventMessage deleteRequest,
     required List<String> conversationIds,

--- a/lib/app/features/chat/model/database/dao/event_message_dao.dart
+++ b/lib/app/features/chat/model/database/dao/event_message_dao.dart
@@ -20,6 +20,8 @@ class EventMessageDao extends DatabaseAccessor<ChatDatabase> with _$EventMessage
   Future<void> add(EventMessage event) async {
     final EventReference eventReference;
     switch (event.kind) {
+      case DeletionRequestEntity.kind:
+        eventReference = DeletionRequestEntity.fromEventMessage(event).toEventReference();
       case GenericRepostEntity.kind:
         eventReference = GenericRepostEntity.fromEventMessage(event).toEventReference();
       case ReplaceablePrivateDirectMessageEntity.kind:

--- a/lib/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart
+++ b/lib/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart
@@ -9,5 +9,10 @@ part 'exist_chat_conversation_id_provider.r.g.dart';
 @riverpod
 Future<String?> existChatConversationId(Ref ref, List<String> participantsMasterPubkeys) async {
   final sortedMasterPubkeys = List<String>.from(participantsMasterPubkeys)..sort();
-  return ref.watch(conversationDaoProvider).getExistOneToOneConversationId(sortedMasterPubkeys);
+  return ref.watch(conversationDaoProvider).getExistingConversationId(sortedMasterPubkeys);
+}
+
+@riverpod
+Future<bool> checkIfConversationExists(Ref ref, String conversationId) async {
+  return ref.watch(conversationDaoProvider).checkIfConversationExists(conversationId);
 }

--- a/lib/app/features/chat/providers/user_chat_privacy_provider.r.dart
+++ b/lib/app/features/chat/providers/user_chat_privacy_provider.r.dart
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: ice License 1.0
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/user/providers/follow_list_provider.r.dart';
+import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'user_chat_privacy_provider.r.g.dart';
+
+@riverpod
+Future<bool> canSendMessage(Ref ref, String masterPubkey) async {
+  final currentUserIsFollowed = isCurrentUserFollowed(ref, masterPubkey, cache: false);
+
+  final userPrivacySettings = await ref.watch(
+    userMetadataProvider(masterPubkey, cache: false).future,
+  );
+  final everyoneCanSend = userPrivacySettings?.data.whoCanMessageYou == null;
+
+  return everyoneCanSend || currentUserIsFollowed;
+}

--- a/lib/app/features/chat/providers/user_chat_privacy_provider.r.dart
+++ b/lib/app/features/chat/providers/user_chat_privacy_provider.r.dart
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
+import 'package:ion/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart';
 import 'package:ion/app/features/user/providers/follow_list_provider.r.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -9,12 +11,31 @@ part 'user_chat_privacy_provider.r.g.dart';
 
 @riverpod
 Future<bool> canSendMessage(Ref ref, String masterPubkey, {bool cache = true}) async {
-  final currentUserIsFollowed = isCurrentUserFollowed(ref, masterPubkey, cache: cache);
+  // 1. Check if the current user is followed by the target user
+  final isFollowed = isCurrentUserFollowed(ref, masterPubkey, cache: cache);
+  if (isFollowed) return true;
 
-  final userPrivacySettings = await ref.watch(
+  // 2. Fetch user privacy settings
+  final userMetadata = await ref.watch(
     userMetadataProvider(masterPubkey, cache: cache).future,
   );
-  final everyoneCanSend = userPrivacySettings?.data.whoCanMessageYou == null;
+  final whoCanMessage = userMetadata?.data.whoCanMessageYou;
 
-  return everyoneCanSend || currentUserIsFollowed;
+  // If privacy setting allows everyone or is unset, allow messaging
+  if (whoCanMessage == null) return true;
+
+  // 3. Check if a conversation already exists
+  final conversationId = await ref.read(
+    existChatConversationIdProvider(masterPubkey).future,
+  );
+
+  if (conversationId == null) return false;
+
+  // 4. Check if the conversation was deleted by the other user
+  final isDeleted = await ref.watch(conversationDaoProvider).checkAnotherUserDeletedConversation(
+        masterPubkey: masterPubkey,
+        conversationId: conversationId,
+      );
+
+  return !isDeleted;
 }

--- a/lib/app/features/chat/providers/user_chat_privacy_provider.r.dart
+++ b/lib/app/features/chat/providers/user_chat_privacy_provider.r.dart
@@ -8,11 +8,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'user_chat_privacy_provider.r.g.dart';
 
 @riverpod
-Future<bool> canSendMessage(Ref ref, String masterPubkey) async {
-  final currentUserIsFollowed = isCurrentUserFollowed(ref, masterPubkey, cache: false);
+Future<bool> canSendMessage(Ref ref, String masterPubkey, {bool cache = true}) async {
+  final currentUserIsFollowed = isCurrentUserFollowed(ref, masterPubkey, cache: cache);
 
   final userPrivacySettings = await ref.watch(
-    userMetadataProvider(masterPubkey, cache: false).future,
+    userMetadataProvider(masterPubkey, cache: cache).future,
   );
   final everyoneCanSend = userPrivacySettings?.data.whoCanMessageYou == null;
 

--- a/lib/app/features/chat/views/components/chat_privacy_tooltip.dart
+++ b/lib/app/features/chat/views/components/chat_privacy_tooltip.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:flutter/material.dart';
 import 'package:ion/app/extensions/extensions.dart';
 

--- a/lib/app/features/chat/views/components/chat_privacy_tooltip.dart
+++ b/lib/app/features/chat/views/components/chat_privacy_tooltip.dart
@@ -26,7 +26,7 @@ class ChatPrivacyTooltip extends StatelessWidget {
         borderRadius: BorderRadius.circular(16.0.s),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.08),
+            color: context.theme.appColors.primaryText.withValues(alpha: 0.08),
             blurRadius: 16.0.s,
           ),
         ],

--- a/lib/app/features/chat/views/components/chat_privacy_tooltip.dart
+++ b/lib/app/features/chat/views/components/chat_privacy_tooltip.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:ion/app/extensions/extensions.dart';
+
+class ChatPrivacyTooltip extends StatelessWidget {
+  const ChatPrivacyTooltip({
+    required this.canSendMessage,
+    required this.child,
+    super.key,
+  });
+
+  final Widget child;
+  final bool canSendMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      triggerMode: canSendMessage ? TooltipTriggerMode.manual : TooltipTriggerMode.tap,
+      textStyle: context.theme.appTextThemes.body2.copyWith(
+        color: context.theme.appColors.secondaryText,
+      ),
+      padding: EdgeInsets.symmetric(horizontal: 16.0.s, vertical: 11.0.s),
+      decoration: BoxDecoration(
+        color: context.theme.appColors.onPrimaryAccent,
+        borderRadius: BorderRadius.circular(16.0.s),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 16.0.s,
+          ),
+        ],
+      ),
+      constraints: BoxConstraints(
+        maxWidth: 300.0.s,
+        maxHeight: 76.0.s,
+      ),
+      message: context.i18n.chat_privacy_cant_send_message,
+      child: Opacity(opacity: canSendMessage ? 1.0 : 0.3, child: child),
+    );
+  }
+}

--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
@@ -37,6 +37,8 @@ class SharedStoryMessage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final currentUserMasterPubkey = ref.watch(currentPubkeySelectorProvider);
+
     final isMe = ref.watch(isCurrentUserSelectorProvider(replyEventMessage.masterPubkey));
 
     final storyEntityData = useMemoized(
@@ -62,14 +64,16 @@ class SharedStoryMessage extends HookConsumerWidget {
       () => (storyMedia.mediaType == MediaType.video ? storyMedia.thumb : storyMedia.url) ?? '',
     );
 
-    final storyExpired = useMemoized(
-      () => switch (storyEntity) {
-        final ModifiablePostEntity post =>
-          post.data.expiration!.value.toDateTime.isBefore(DateTime.now()),
-        final PostEntity post => post.data.expiration!.value.toDateTime.isBefore(DateTime.now()),
-        _ => true,
-      },
-    );
+    final storyExpired = storyEntity.masterPubkey != currentUserMasterPubkey &&
+        useMemoized(
+          () => switch (storyEntity) {
+            final ModifiablePostEntity post => post.data.expiration!.value.toDateTime
+                .isBefore(DateTime.now().add(const Duration(days: 3))),
+            final PostEntity post => post.data.expiration!.value.toDateTime
+                .isBefore(DateTime.now().add(const Duration(days: 3))),
+            _ => true,
+          },
+        );
 
     final storyDeleted = useMemoized(
       () => switch (storyEntity) {

--- a/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
+++ b/lib/app/features/chat/views/components/message_items/message_types/post_message/shared_story_message.dart
@@ -67,10 +67,10 @@ class SharedStoryMessage extends HookConsumerWidget {
     final storyExpired = storyEntity.masterPubkey != currentUserMasterPubkey &&
         useMemoized(
           () => switch (storyEntity) {
-            final ModifiablePostEntity post => post.data.expiration!.value.toDateTime
-                .isBefore(DateTime.now().add(const Duration(days: 3))),
-            final PostEntity post => post.data.expiration!.value.toDateTime
-                .isBefore(DateTime.now().add(const Duration(days: 3))),
+            final ModifiablePostEntity post =>
+              post.data.expiration!.value.toDateTime.isBefore(DateTime.now()),
+            final PostEntity post =>
+              post.data.expiration!.value.toDateTime.isBefore(DateTime.now()),
             _ => true,
           },
         );

--- a/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
+++ b/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
@@ -37,6 +37,7 @@ class NewChatModal extends HookConsumerWidget {
     return SheetContent(
       topPadding: 0,
       body: UserPickerSheet(
+        controlPrivacy: true,
         navigationBar: NavigationAppBar.modal(
           showBackButton: false,
           title: Text(context.i18n.new_chat_modal_title),

--- a/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
+++ b/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
@@ -38,6 +38,7 @@ class NewChatModal extends HookConsumerWidget {
       topPadding: 0,
       body: UserPickerSheet(
         controlPrivacy: true,
+        expirationDuration: const Duration(minutes: 2),
         navigationBar: NavigationAppBar.modal(
           showBackButton: false,
           title: Text(context.i18n.new_chat_modal_title),

--- a/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
+++ b/lib/app/features/chat/views/pages/new_chat_modal/new_chat_modal.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/button/button.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
+import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/core/providers/feature_flags_provider.r.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart';
@@ -34,11 +35,16 @@ class NewChatModal extends HookConsumerWidget {
     final hideCommunity =
         ref.watch(featureFlagsProvider.notifier).get(ChatFeatureFlag.hideCommunity);
 
+    final env = ref.read(envProvider.notifier);
+    final expirationDuration = Duration(
+      minutes: env.get<int>(EnvVariable.CHAT_PRIVACY_CACHE_MINUTES),
+    );
+
     return SheetContent(
       topPadding: 0,
       body: UserPickerSheet(
         controlPrivacy: true,
-        expirationDuration: const Duration(minutes: 2),
+        expirationDuration: expirationDuration,
         navigationBar: NavigationAppBar.modal(
           showBackButton: false,
           title: Text(context.i18n.new_chat_modal_title),

--- a/lib/app/features/chat/views/pages/share_via_message_modal/share_via_message_modal.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/share_via_message_modal.dart
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/chat/views/pages/share_via_message_modal/components/share_options.dart';
 import 'package:ion/app/features/chat/views/pages/share_via_message_modal/components/share_send_button.dart';
+import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart';
 import 'package:ion/app/hooks/use_selected_state.dart';
@@ -13,7 +14,7 @@ import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.
 import 'package:ion/app/router/components/navigation_app_bar/navigation_close_button.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
 
-class ShareViaMessageModal extends HookWidget {
+class ShareViaMessageModal extends HookConsumerWidget {
   const ShareViaMessageModal({
     required this.eventReference,
     super.key,
@@ -22,8 +23,16 @@ class ShareViaMessageModal extends HookWidget {
   final EventReference eventReference;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
     final (selectedPubkeys, togglePubkeySelection) = useSelectedState<String>();
+
+    final env = ref.read(envProvider.notifier);
+    final expirationDuration = Duration(
+      minutes: env.get<int>(EnvVariable.CHAT_PRIVACY_CACHE_MINUTES),
+    );
 
     return SheetContent(
       body: Column(
@@ -33,7 +42,7 @@ class ShareViaMessageModal extends HookWidget {
               selectable: true,
               controlPrivacy: true,
               selectedPubkeys: selectedPubkeys,
-              expirationDuration: const Duration(minutes: 2),
+              expirationDuration: expirationDuration,
               navigationBar: NavigationAppBar.modal(
                 title: Text(context.i18n.feed_share_via),
                 actions: const [NavigationCloseButton()],

--- a/lib/app/features/chat/views/pages/share_via_message_modal/share_via_message_modal.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/share_via_message_modal.dart
@@ -31,6 +31,7 @@ class ShareViaMessageModal extends HookWidget {
           Flexible(
             child: UserPickerSheet(
               selectable: true,
+              controlPrivacy: true,
               selectedPubkeys: selectedPubkeys,
               navigationBar: NavigationAppBar.modal(
                 title: Text(context.i18n.feed_share_via),

--- a/lib/app/features/chat/views/pages/share_via_message_modal/share_via_message_modal.dart
+++ b/lib/app/features/chat/views/pages/share_via_message_modal/share_via_message_modal.dart
@@ -33,6 +33,7 @@ class ShareViaMessageModal extends HookWidget {
               selectable: true,
               controlPrivacy: true,
               selectedPubkeys: selectedPubkeys,
+              expirationDuration: const Duration(minutes: 2),
               navigationBar: NavigationAppBar.modal(
                 title: Text(context.i18n.feed_share_via),
                 actions: const [NavigationCloseButton()],

--- a/lib/app/features/core/providers/env_provider.r.dart
+++ b/lib/app/features/core/providers/env_provider.r.dart
@@ -16,6 +16,7 @@ enum EnvVariable {
   STORY_EXPIRATION_HOURS,
   EDIT_POST_ALLOWED_MINUTES,
   USER_METADATA_SYNC_MINUTES,
+  CHAT_PRIVACY_CACHE_MINUTES,
   EDIT_MESSAGE_ALLOWED_MINUTES,
   COMMUNITY_CREATION_CACHE_MINUTES,
   COMMUNITY_MEMBERS_COUNT_CACHE_MINUTES,
@@ -53,6 +54,8 @@ class Env extends _$Env {
         const int.fromEnvironment('STORY_EXPIRATION_HOURS') as T,
       EnvVariable.USER_METADATA_SYNC_MINUTES =>
         const int.fromEnvironment('USER_METADATA_SYNC_MINUTES') as T,
+      EnvVariable.CHAT_PRIVACY_CACHE_MINUTES =>
+        const int.fromEnvironment('CHAT_PRIVACY_CACHE_MINUTES') as T,
       EnvVariable.EDIT_POST_ALLOWED_MINUTES =>
         const int.fromEnvironment('EDIT_POST_ALLOWED_MINUTES') as T,
       EnvVariable.EDIT_MESSAGE_ALLOWED_MINUTES =>

--- a/lib/app/features/feed/stories/views/pages/story_preview_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_preview_page.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:ion/app/components/list_item/list_item.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
 import 'package:ion/app/components/separated/separator.dart';
@@ -13,7 +12,6 @@ import 'package:ion/app/features/core/model/media_type.dart';
 import 'package:ion/app/features/feed/create_post/model/create_post_option.dart';
 import 'package:ion/app/features/feed/create_post/providers/create_post_notifier.m.dart';
 import 'package:ion/app/features/feed/data/models/entities/event_count_result_data.f.dart';
-import 'package:ion/app/features/feed/data/models/who_can_reply_settings_option.f.dart';
 import 'package:ion/app/features/feed/providers/selected_interests_notifier.r.dart';
 import 'package:ion/app/features/feed/providers/selected_who_can_reply_option_provider.r.dart';
 import 'package:ion/app/features/feed/stories/providers/current_user_story_provider.r.dart';
@@ -23,15 +21,12 @@ import 'package:ion/app/features/feed/stories/views/components/story_preview/act
 import 'package:ion/app/features/feed/stories/views/components/story_preview/media/post_screenshot_preview.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_preview/media/story_image_preview.dart';
 import 'package:ion/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart';
-import 'package:ion/app/features/feed/views/pages/who_can_reply_settings_modal/who_can_reply_settings_modal.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.r.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
-import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion/app/services/compressors/image_compressor.r.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
-import 'package:ion/generated/assets.gen.dart';
 
 class StoryPreviewPage extends HookConsumerWidget {
   const StoryPreviewPage({
@@ -91,28 +86,6 @@ class StoryPreviewPage extends HookConsumerWidget {
                       },
                     ),
                     SizedBox(height: 8.0.s),
-                    ListItem(
-                      title: Text(
-                        whoCanReply.getTitle(context),
-                        style: context.theme.appTextThemes.caption.copyWith(
-                          color: context.theme.appColors.primaryAccent,
-                        ),
-                      ),
-                      contentPadding: EdgeInsets.zero,
-                      backgroundColor: context.theme.appColors.secondaryBackground,
-                      leading: whoCanReply.getIcon(context),
-                      trailing: Assets.svg.iconArrowRight.icon(
-                        color: context.theme.appColors.primaryAccent,
-                        size: 16.s,
-                      ),
-                      constraints: BoxConstraints(minHeight: 40.0.s),
-                      onTap: () => showSimpleBottomSheet<void>(
-                        context: context,
-                        child: WhoCanReplySettingsModal(
-                          title: context.i18n.who_can_reply_settings_title_story,
-                        ),
-                      ),
-                    ),
                     Padding(
                       padding: EdgeInsets.symmetric(vertical: 7.s),
                       child: const HorizontalSeparator(),

--- a/lib/app/features/ion_connect/model/deletion_request.f.dart
+++ b/lib/app/features/ion_connect/model/deletion_request.f.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:async';
-import 'dart:developer' as Logger;
 
 import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -13,6 +12,7 @@ import 'package:ion/app/features/ion_connect/model/deletable_event.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/event_serializable.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
+import 'package:ion/app/services/logger/logger.dart';
 
 part 'deletion_request.f.freezed.dart';
 

--- a/lib/app/features/ion_connect/model/deletion_request.f.dart
+++ b/lib/app/features/ion_connect/model/deletion_request.f.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'dart:async';
+import 'dart:developer' as Logger;
 
 import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -34,11 +35,15 @@ class DeletionRequestEntity with IonConnectEntity, ImmutableEntity, _$DeletionRe
       throw IncorrectEventKindException(eventMessage.id, kind: kind);
     }
 
+    if (eventMessage.sig == null) {
+      Logger.log('Event message ${eventMessage.id} does not have a signature');
+    }
+
     return DeletionRequestEntity(
       id: eventMessage.id,
       pubkey: eventMessage.pubkey,
       masterPubkey: eventMessage.masterPubkey,
-      signature: eventMessage.sig!,
+      signature: eventMessage.sig ?? '',
       createdAt: eventMessage.createdAt,
       data: DeletionRequest.fromEventMessage(eventMessage),
     );

--- a/lib/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart
+++ b/lib/app/features/ion_connect/providers/ion_connect_entity_provider.r.dart
@@ -267,6 +267,7 @@ class IonConnectEntitiesManager extends _$IonConnectEntitiesManager {
     String? search,
     bool cache = true,
     bool network = true,
+    Duration? expirationDuration,
   }) async {
     final cachedResults = <IonConnectEntity>[];
     final networkResults = <IonConnectEntity>[];
@@ -277,7 +278,10 @@ class IonConnectEntitiesManager extends _$IonConnectEntitiesManager {
             .map(
               (eventReference) => ref.read(
                 ionConnectCacheProvider.select(
-                  cacheSelector(CacheableEntity.cacheKeyBuilder(eventReference: eventReference)),
+                  cacheSelector(
+                    CacheableEntity.cacheKeyBuilder(eventReference: eventReference),
+                    expirationDuration: expirationDuration,
+                  ),
                 ),
               ),
             )

--- a/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_all/chat_advanced_search_all.dart
+++ b/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_all/chat_advanced_search_all.dart
@@ -10,6 +10,7 @@ import 'package:ion/app/components/scroll_view/load_more_builder.dart';
 import 'package:ion/app/components/scroll_view/pull_to_refresh_builder.dart';
 import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/search/model/chat_search_result_item.f.dart';
 import 'package:ion/app/features/search/providers/chat_search/chat_local_user_search_provider.r.dart';
 import 'package:ion/app/features/search/providers/chat_search/chat_messages_search_provider.r.dart';
@@ -26,10 +27,15 @@ class ChatAdvancedSearchAll extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
+    final env = ref.read(envProvider.notifier);
+    final expirationDuration = Duration(
+      minutes: env.get<int>(EnvVariable.CHAT_PRIVACY_CACHE_MINUTES),
+    );
+
     final remoteUserSearch = ref.watch(
       searchUsersProvider(
         query: query,
-        expirationDuration: const Duration(minutes: 2),
+        expirationDuration: expirationDuration,
       ),
     );
     final localUserSearch = ref.watch(chatLocalUserSearchProvider(query));
@@ -93,7 +99,7 @@ class ChatAdvancedSearchAll extends HookConsumerWidget {
               .read(
                 searchUsersProvider(
                   query: query,
-                  expirationDuration: const Duration(minutes: 2),
+                  expirationDuration: expirationDuration,
                 ).notifier,
               )
               .refresh(),
@@ -106,8 +112,7 @@ class ChatAdvancedSearchAll extends HookConsumerWidget {
         slivers: slivers,
         onLoadMore: ref
             .read(
-              searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2))
-                  .notifier,
+              searchUsersProvider(query: query, expirationDuration: expirationDuration).notifier,
             )
             .loadMore,
         hasMore: remoteUserSearch.valueOrNull?.hasMore ?? false,

--- a/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_all/chat_advanced_search_all.dart
+++ b/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_all/chat_advanced_search_all.dart
@@ -26,7 +26,12 @@ class ChatAdvancedSearchAll extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
-    final remoteUserSearch = ref.watch(searchUsersProvider(query: query));
+    final remoteUserSearch = ref.watch(
+      searchUsersProvider(
+        query: query,
+        expirationDuration: const Duration(minutes: 2),
+      ),
+    );
     final localUserSearch = ref.watch(chatLocalUserSearchProvider(query));
     final localMessageSearch = ref.watch(chatMessagesSearchProvider(query));
 
@@ -83,14 +88,28 @@ class ChatAdvancedSearchAll extends HookConsumerWidget {
           ),
       ],
       onRefresh: () async {
-        unawaited(ref.read(searchUsersProvider(query: query).notifier).refresh());
+        unawaited(
+          ref
+              .read(
+                searchUsersProvider(
+                  query: query,
+                  expirationDuration: const Duration(minutes: 2),
+                ).notifier,
+              )
+              .refresh(),
+        );
         ref
           ..invalidate(chatLocalUserSearchProvider(query))
           ..invalidate(chatMessagesSearchProvider(query));
       },
       builder: (context, slivers) => LoadMoreBuilder(
         slivers: slivers,
-        onLoadMore: ref.read(searchUsersProvider(query: query).notifier).loadMore,
+        onLoadMore: ref
+            .read(
+              searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2))
+                  .notifier,
+            )
+            .loadMore,
         hasMore: remoteUserSearch.valueOrNull?.hasMore ?? false,
       ),
     );

--- a/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_people/chat_advanced_search_people.dart
+++ b/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_people/chat_advanced_search_people.dart
@@ -25,7 +25,8 @@ class ChatAdvancedSearchPeople extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
-    final remoteUserSearch = ref.watch(searchUsersProvider(query: query));
+    final remoteUserSearch = ref
+        .watch(searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2)));
     final localUserSearch = ref.watch(chatLocalUserSearchProvider(query));
 
     final hasMore = remoteUserSearch.valueOrNull?.hasMore ?? true;
@@ -78,12 +79,24 @@ class ChatAdvancedSearchPeople extends HookConsumerWidget {
           ),
       ],
       onRefresh: () async {
-        unawaited(ref.read(searchUsersProvider(query: query).notifier).refresh());
+        unawaited(
+          ref
+              .read(
+                searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2))
+                    .notifier,
+              )
+              .refresh(),
+        );
         ref.invalidate(chatLocalUserSearchProvider(query));
       },
       builder: (context, slivers) => LoadMoreBuilder(
         slivers: slivers,
-        onLoadMore: ref.read(searchUsersProvider(query: query).notifier).loadMore,
+        onLoadMore: ref
+            .read(
+              searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2))
+                  .notifier,
+            )
+            .loadMore,
         hasMore: remoteUserSearch.valueOrNull?.hasMore ?? false,
       ),
     );

--- a/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_people/chat_advanced_search_people.dart
+++ b/lib/app/features/search/views/pages/chat/chat_advanced_search_page/components/chat_advanced_search_people/chat_advanced_search_people.dart
@@ -10,6 +10,7 @@ import 'package:ion/app/components/scroll_view/load_more_builder.dart';
 import 'package:ion/app/components/scroll_view/pull_to_refresh_builder.dart';
 import 'package:ion/app/components/separated/separator.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/search/model/chat_search_result_item.f.dart';
 import 'package:ion/app/features/search/providers/chat_search/chat_local_user_search_provider.r.dart';
 import 'package:ion/app/features/search/views/pages/chat/components/chat_no_results_found.dart';
@@ -25,8 +26,13 @@ class ChatAdvancedSearchPeople extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
-    final remoteUserSearch = ref
-        .watch(searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2)));
+    final env = ref.read(envProvider.notifier);
+    final expirationDuration = Duration(
+      minutes: env.get<int>(EnvVariable.CHAT_PRIVACY_CACHE_MINUTES),
+    );
+
+    final remoteUserSearch =
+        ref.watch(searchUsersProvider(query: query, expirationDuration: expirationDuration));
     final localUserSearch = ref.watch(chatLocalUserSearchProvider(query));
 
     final hasMore = remoteUserSearch.valueOrNull?.hasMore ?? true;
@@ -82,8 +88,7 @@ class ChatAdvancedSearchPeople extends HookConsumerWidget {
         unawaited(
           ref
               .read(
-                searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2))
-                    .notifier,
+                searchUsersProvider(query: query, expirationDuration: expirationDuration).notifier,
               )
               .refresh(),
         );
@@ -93,8 +98,7 @@ class ChatAdvancedSearchPeople extends HookConsumerWidget {
         slivers: slivers,
         onLoadMore: ref
             .read(
-              searchUsersProvider(query: query, expirationDuration: const Duration(minutes: 2))
-                  .notifier,
+              searchUsersProvider(query: query, expirationDuration: expirationDuration).notifier,
             )
             .loadMore,
         hasMore: remoteUserSearch.valueOrNull?.hasMore ?? false,

--- a/lib/app/features/search/views/pages/chat/chat_quick_search_page/chat_quick_search_page.dart
+++ b/lib/app/features/search/views/pages/chat/chat_quick_search_page/chat_quick_search_page.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_top_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/core/model/feature_flags.dart';
+import 'package:ion/app/features/core/providers/env_provider.r.dart';
 import 'package:ion/app/features/core/providers/feature_flags_provider.r.dart';
 import 'package:ion/app/features/search/model/chat_search_result_item.f.dart';
 import 'package:ion/app/features/search/providers/chat_search/chat_local_user_search_provider.r.dart';
@@ -34,8 +35,13 @@ class ChatQuickSearchPage extends HookConsumerWidget {
     final hideCommunity =
         ref.watch(featureFlagsProvider.notifier).get(ChatFeatureFlag.hideCommunity);
 
+    final env = ref.read(envProvider.notifier);
+    final expirationDuration = Duration(
+      minutes: env.get<int>(EnvVariable.CHAT_PRIVACY_CACHE_MINUTES),
+    );
+
     final remoteUserSearch = ref.watch(
-      searchUsersProvider(query: debouncedQuery, expirationDuration: const Duration(minutes: 2)),
+      searchUsersProvider(query: debouncedQuery, expirationDuration: expirationDuration),
     );
     final localUserSearch = ref.watch(chatLocalUserSearchProvider(debouncedQuery));
 

--- a/lib/app/features/search/views/pages/chat/chat_quick_search_page/chat_quick_search_page.dart
+++ b/lib/app/features/search/views/pages/chat/chat_quick_search_page/chat_quick_search_page.dart
@@ -34,7 +34,9 @@ class ChatQuickSearchPage extends HookConsumerWidget {
     final hideCommunity =
         ref.watch(featureFlagsProvider.notifier).get(ChatFeatureFlag.hideCommunity);
 
-    final remoteUserSearch = ref.watch(searchUsersProvider(query: debouncedQuery));
+    final remoteUserSearch = ref.watch(
+      searchUsersProvider(query: debouncedQuery, expirationDuration: const Duration(minutes: 2)),
+    );
     final localUserSearch = ref.watch(chatLocalUserSearchProvider(debouncedQuery));
 
     final isLoading = remoteUserSearch.isLoading || localUserSearch.isLoading;

--- a/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
+++ b/lib/app/features/search/views/pages/chat/components/chat_search_results_list_item.dart
@@ -6,6 +6,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/list_item/badges_user_list_item.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/providers/user_chat_privacy_provider.r.dart';
+import 'package:ion/app/features/chat/views/components/chat_privacy_tooltip.dart';
 import 'package:ion/app/features/search/model/chat_search_result_item.f.dart';
 import 'package:ion/app/features/search/providers/chat_search/chat_search_history_provider.m.dart';
 import 'package:ion/app/router/app_routes.gr.dart';
@@ -25,51 +27,60 @@ class ChatSearchResultListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userMetadata = item.userMetadata;
+    final canSendMessage =
+        ref.watch(canSendMessageProvider(userMetadata.masterPubkey)).valueOrNull ?? false;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: () {
-        ref
-            .read(chatSearchHistoryProvider.notifier)
-            .addUserIdToTheHistory(userMetadata.masterPubkey);
-        context.pushReplacement(
-          ConversationRoute(receiverMasterPubkey: item.userMetadata.masterPubkey).location,
-        );
-      },
-      child: BadgesUserListItem(
-        contentPadding:
-            EdgeInsets.symmetric(vertical: 8.0.s, horizontal: ScreenSideOffset.defaultSmallMargin),
-        pubkey: userMetadata.masterPubkey,
-        title: Padding(
-          padding: EdgeInsetsDirectional.only(bottom: 2.38.s),
-          child: Text(
-            userMetadata.data.displayName,
-            style: context.theme.appTextThemes.subtitle3.copyWith(
-              color: context.theme.appColors.primaryText,
+      onTap: canSendMessage
+          ? () {
+              ref
+                  .read(chatSearchHistoryProvider.notifier)
+                  .addUserIdToTheHistory(userMetadata.masterPubkey);
+              context.pushReplacement(
+                ConversationRoute(receiverMasterPubkey: item.userMetadata.masterPubkey).location,
+              );
+            }
+          : null,
+      child: ChatPrivacyTooltip(
+        canSendMessage: canSendMessage,
+        child: BadgesUserListItem(
+          contentPadding: EdgeInsets.symmetric(
+            vertical: 8.0.s,
+            horizontal: ScreenSideOffset.defaultSmallMargin,
+          ),
+          pubkey: userMetadata.masterPubkey,
+          title: Padding(
+            padding: EdgeInsetsDirectional.only(bottom: 2.38.s),
+            child: Text(
+              userMetadata.data.displayName,
+              style: context.theme.appTextThemes.subtitle3.copyWith(
+                color: context.theme.appColors.primaryText,
+              ),
             ),
           ),
-        ),
-        constraints: BoxConstraints(minHeight: 48.0.s),
-        subtitle: item.lastMessageContent.isNotEmpty && showLastMessage
-            ? Text(
-                item.lastMessageContent!,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: context.theme.appTextThemes.body2.copyWith(
-                  color: context.theme.appColors.onTertararyBackground,
+          constraints: BoxConstraints(minHeight: 48.0.s),
+          subtitle: item.lastMessageContent.isNotEmpty && showLastMessage
+              ? Text(
+                  item.lastMessageContent!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.theme.appTextThemes.body2.copyWith(
+                    color: context.theme.appColors.onTertararyBackground,
+                  ),
+                )
+              : Text(
+                  prefixUsername(username: userMetadata.data.name, context: context),
+                  style: context.theme.appTextThemes.body2.copyWith(
+                    color: context.theme.appColors.onTertararyBackground,
+                  ),
                 ),
-              )
-            : Text(
-                prefixUsername(username: userMetadata.data.name, context: context),
-                style: context.theme.appTextThemes.body2.copyWith(
-                  color: context.theme.appColors.onTertararyBackground,
-                ),
-              ),
-        avatarSize: 48.0.s,
-        leadingPadding: EdgeInsetsDirectional.only(end: 12.0.s),
-        trailing: Assets.svg.iconArrowRight.icon(
-          size: 24.0.s,
-          color: context.theme.appColors.tertararyText,
+          avatarSize: 48.0.s,
+          leadingPadding: EdgeInsetsDirectional.only(end: 12.0.s),
+          trailing: Assets.svg.iconArrowRight.icon(
+            size: 24.0.s,
+            color: context.theme.appColors.tertararyText,
+          ),
         ),
       ),
     );

--- a/lib/app/features/settings/model/privacy_options.dart
+++ b/lib/app/features/settings/model/privacy_options.dart
@@ -32,13 +32,11 @@ enum WalletAddressPrivacyOption implements SelectableOption {
 
 enum UserVisibilityPrivacyOption implements SelectableOption {
   everyone,
-  followedPeople,
-  friends;
+  followedPeople;
 
   static UserVisibilityPrivacyOption fromWhoCanSetting(WhoCanSetting? setting) => switch (setting) {
         WhoCanSetting.everyone => UserVisibilityPrivacyOption.everyone,
         WhoCanSetting.follows => UserVisibilityPrivacyOption.followedPeople,
-        WhoCanSetting.friends => UserVisibilityPrivacyOption.friends,
         null => UserVisibilityPrivacyOption.everyone,
       };
 
@@ -48,8 +46,6 @@ enum UserVisibilityPrivacyOption implements SelectableOption {
           context.i18n.privacy_option_user_visibility_for_everyone,
         UserVisibilityPrivacyOption.followedPeople =>
           context.i18n.privacy_option_user_visibility_for_followed_people,
-        UserVisibilityPrivacyOption.friends =>
-          context.i18n.privacy_option_user_visibility_for_friends,
       };
 
   @override
@@ -57,7 +53,6 @@ enum UserVisibilityPrivacyOption implements SelectableOption {
     final icon = switch (this) {
       UserVisibilityPrivacyOption.everyone => Assets.svg.iconPostEveryone,
       UserVisibilityPrivacyOption.followedPeople => Assets.svg.iconSearchFollow,
-      UserVisibilityPrivacyOption.friends => Assets.svg.iconSearchGroups,
     };
 
     return icon.icon(color: context.theme.appColors.primaryAccent);
@@ -66,6 +61,5 @@ enum UserVisibilityPrivacyOption implements SelectableOption {
   WhoCanSetting? toWhoCanSetting() => switch (this) {
         UserVisibilityPrivacyOption.everyone => null,
         UserVisibilityPrivacyOption.followedPeople => WhoCanSetting.follows,
-        UserVisibilityPrivacyOption.friends => WhoCanSetting.friends,
       };
 }

--- a/lib/app/features/settings/views/privacy_settings_modal.dart
+++ b/lib/app/features/settings/views/privacy_settings_modal.dart
@@ -32,8 +32,6 @@ class PrivacySettingsModal extends ConsumerWidget {
     final walletPrivacy = WalletAddressPrivacyOption.fromWalletsMap(metadata.data.wallets);
     final messagingPrivacy =
         UserVisibilityPrivacyOption.fromWhoCanSetting(metadata.data.whoCanMessageYou);
-    final invitingPrivacy =
-        UserVisibilityPrivacyOption.fromWhoCanSetting(metadata.data.whoCanInviteYouToGroups);
 
     return SheetContent(
       body: SingleChildScrollView(
@@ -69,13 +67,6 @@ class PrivacySettingsModal extends ConsumerWidget {
                       onSelected: (option) =>
                           _onMessagingPrivacyOptionSelected(ref, metadata, option),
                     ),
-                    SelectableOptionsGroup(
-                      title: context.i18n.privacy_group_who_can_invite_you_title,
-                      selected: [invitingPrivacy],
-                      options: UserVisibilityPrivacyOption.values,
-                      onSelected: (option) =>
-                          _onInvitingPrivacyOptionSelected(ref, metadata, option),
-                    ),
                   ],
                 ),
               ),
@@ -92,16 +83,6 @@ class PrivacySettingsModal extends ConsumerWidget {
     UserVisibilityPrivacyOption option,
   ) {
     final updatedMetadata = metadata.data.copyWith(whoCanMessageYou: option.toWhoCanSetting());
-    ref.read(updateUserMetadataNotifierProvider.notifier).publish(updatedMetadata);
-  }
-
-  void _onInvitingPrivacyOptionSelected(
-    WidgetRef ref,
-    UserMetadataEntity metadata,
-    UserVisibilityPrivacyOption option,
-  ) {
-    final updatedMetadata =
-        metadata.data.copyWith(whoCanInviteYouToGroups: option.toWhoCanSetting());
     ref.read(updateUserMetadataNotifierProvider.notifier).publish(updatedMetadata);
   }
 }

--- a/lib/app/features/user/model/user_metadata.f.dart
+++ b/lib/app/features/user/model/user_metadata.f.dart
@@ -201,8 +201,7 @@ class UserDataEventMessageContent {
 
 enum WhoCanSetting {
   everyone,
-  follows,
-  friends;
+  follows;
 
   static WhoCanSetting? fromString(String? value) => value == null
       ? null

--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -35,34 +35,36 @@ class ProfileActions extends ConsumerWidget {
         ref.watch(userMetadataProvider(pubkey).select((state) => state.value?.data.wallets));
     final hasPrivateWallets = walletsState == null;
     final following = ref.watch(isCurrentUserFollowingSelectorProvider(pubkey));
-    final canSendMessage = ref.watch(canSendMessageProvider(pubkey)).valueOrNull ?? false;
+    final canSendMessage =
+        ref.watch(canSendMessageProvider(pubkey, cache: false)).valueOrNull ?? false;
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         FollowUserButton(pubkey: pubkey),
-        if (!hasPrivateWallets) ...[
+        if (!hasPrivateWallets && canSendMessage) ...[
           SizedBox(width: 8.0.s),
           ProfileAction(
             onPressed: () async {
               final needToEnable2FA =
                   await PaymentSelectionProfileRoute(pubkey: pubkey).push<bool>(context);
-              if (needToEnable2FA != null && needToEnable2FA == true && context.mounted) {
+              if (needToEnable2FA != null && needToEnable2FA && context.mounted) {
                 await SecureAccountModalRoute().push<void>(context);
               }
             },
             assetName: Assets.svg.iconProfileTips,
           ),
         ],
-        SizedBox(width: 8.0.s),
-        if (canSendMessage)
+        if (canSendMessage) ...[
+          SizedBox(width: 8.0.s),
           ProfileAction(
             onPressed: () {
               ConversationRoute(receiverMasterPubkey: pubkey).push<void>(context);
             },
             assetName: Assets.svg.iconChatOff,
           ),
-        SizedBox(width: 8.0.s),
+          SizedBox(width: 8.0.s),
+        ],
         if (following)
           ProfileAction(
             onPressed: () {

--- a/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
+++ b/lib/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_actions.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/providers/user_chat_privacy_provider.r.dart';
 import 'package:ion/app/features/components/user/follow_user_button/follow_user_button.dart';
 import 'package:ion/app/features/user/model/user_notifications_type.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/profile_details/profile_actions/profile_action.dart';
@@ -34,13 +35,12 @@ class ProfileActions extends ConsumerWidget {
         ref.watch(userMetadataProvider(pubkey).select((state) => state.value?.data.wallets));
     final hasPrivateWallets = walletsState == null;
     final following = ref.watch(isCurrentUserFollowingSelectorProvider(pubkey));
+    final canSendMessage = ref.watch(canSendMessageProvider(pubkey)).valueOrNull ?? false;
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        FollowUserButton(
-          pubkey: pubkey,
-        ),
+        FollowUserButton(pubkey: pubkey),
         if (!hasPrivateWallets) ...[
           SizedBox(width: 8.0.s),
           ProfileAction(
@@ -55,12 +55,13 @@ class ProfileActions extends ConsumerWidget {
           ),
         ],
         SizedBox(width: 8.0.s),
-        ProfileAction(
-          onPressed: () {
-            ConversationRoute(receiverMasterPubkey: pubkey).push<void>(context);
-          },
-          assetName: Assets.svg.iconChatOff,
-        ),
+        if (canSendMessage)
+          ProfileAction(
+            onPressed: () {
+              ConversationRoute(receiverMasterPubkey: pubkey).push<void>(context);
+            },
+            assetName: Assets.svg.iconChatOff,
+          ),
         SizedBox(width: 8.0.s),
         if (following)
           ProfileAction(

--- a/lib/app/features/user/pages/user_picker_sheet/components/following_users.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/following_users.dart
@@ -15,14 +15,14 @@ class FollowingUsers extends ConsumerWidget {
     required this.onUserSelected,
     this.selectedPubkeys = const [],
     this.selectable = false,
-    this.controlPrivacy = false,
+    this.controlChatPrivacy = false,
     super.key,
   });
 
   final void Function(UserMetadataEntity user) onUserSelected;
   final List<String> selectedPubkeys;
   final bool selectable;
-  final bool controlPrivacy;
+  final bool controlChatPrivacy;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -36,16 +36,16 @@ class FollowingUsers extends ConsumerWidget {
         return SliverList.builder(
           itemBuilder: (context, index) {
             final masterPubkey = pubkeys.elementAt(index);
-            final canSendMessage = controlPrivacy &&
+            final canSendMessage = controlChatPrivacy &&
                 (ref.watch(canSendMessageProvider(masterPubkey)).valueOrNull ?? false);
 
             return SelectableUserListItem(
+              selectable: selectable,
               pubkey: pubkeys[index],
               masterPubkey: pubkeys[index],
               onUserSelected: onUserSelected,
               selectedPubkeys: selectedPubkeys,
-              selectable: selectable,
-              canSendMessage: controlPrivacy && canSendMessage,
+              canSendMessage: canSendMessage,
             );
           },
           itemCount: pubkeys.length,

--- a/lib/app/features/user/pages/user_picker_sheet/components/following_users.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/following_users.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/providers/user_chat_privacy_provider.r.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/pages/user_picker_sheet/components/selectable_user_list_item.dart';
 import 'package:ion/app/features/user/providers/follow_list_provider.r.dart';
@@ -14,12 +15,14 @@ class FollowingUsers extends ConsumerWidget {
     required this.onUserSelected,
     this.selectedPubkeys = const [],
     this.selectable = false,
+    this.controlPrivacy = false,
     super.key,
   });
 
   final void Function(UserMetadataEntity user) onUserSelected;
   final List<String> selectedPubkeys;
   final bool selectable;
+  final bool controlPrivacy;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -32,12 +35,17 @@ class FollowingUsers extends ConsumerWidget {
 
         return SliverList.builder(
           itemBuilder: (context, index) {
+            final masterPubkey = pubkeys.elementAt(index);
+            final canSendMessage = controlPrivacy &&
+                (ref.watch(canSendMessageProvider(masterPubkey)).valueOrNull ?? false);
+
             return SelectableUserListItem(
               pubkey: pubkeys[index],
               masterPubkey: pubkeys[index],
               onUserSelected: onUserSelected,
               selectedPubkeys: selectedPubkeys,
               selectable: selectable,
+              canSendMessage: controlPrivacy && canSendMessage,
             );
           },
           itemCount: pubkeys.length,

--- a/lib/app/features/user/pages/user_picker_sheet/components/searched_users.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/searched_users.dart
@@ -14,7 +14,7 @@ class SearchedUsers extends ConsumerWidget {
     required this.users,
     required this.onUserSelected,
     this.selectable = false,
-    this.controlPrivacy = false,
+    this.controlChatPrivacy = false,
     this.selectedPubkeys = const [],
     super.key,
   });
@@ -22,7 +22,7 @@ class SearchedUsers extends ConsumerWidget {
   final List<UserMetadataEntity>? users;
   final void Function(UserMetadataEntity user) onUserSelected;
   final bool selectable;
-  final bool controlPrivacy;
+  final bool controlChatPrivacy;
   final List<String> selectedPubkeys;
 
   @override
@@ -44,7 +44,7 @@ class SearchedUsers extends ConsumerWidget {
       itemCount: searchedUsers.length,
       itemBuilder: (BuildContext context, int index) {
         final user = searchedUsers.elementAt(index);
-        final canSendMessage = controlPrivacy &&
+        final canSendMessage = controlChatPrivacy &&
             (ref.watch(canSendMessageProvider(user.masterPubkey)).valueOrNull ?? false);
 
         return SelectableUserListItem(

--- a/lib/app/features/user/pages/user_picker_sheet/components/searched_users.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/searched_users.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/list_items_loading_state/list_items_loading_state.dart';
 import 'package:ion/app/components/nothing_is_found/nothing_is_found.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/providers/user_chat_privacy_provider.r.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/pages/user_picker_sheet/components/selectable_user_list_item.dart';
 
@@ -13,6 +14,7 @@ class SearchedUsers extends ConsumerWidget {
     required this.users,
     required this.onUserSelected,
     this.selectable = false,
+    this.controlPrivacy = false,
     this.selectedPubkeys = const [],
     super.key,
   });
@@ -20,6 +22,7 @@ class SearchedUsers extends ConsumerWidget {
   final List<UserMetadataEntity>? users;
   final void Function(UserMetadataEntity user) onUserSelected;
   final bool selectable;
+  final bool controlPrivacy;
   final List<String> selectedPubkeys;
 
   @override
@@ -41,12 +44,16 @@ class SearchedUsers extends ConsumerWidget {
       itemCount: searchedUsers.length,
       itemBuilder: (BuildContext context, int index) {
         final user = searchedUsers.elementAt(index);
+        final canSendMessage = controlPrivacy &&
+            (ref.watch(canSendMessageProvider(user.masterPubkey)).valueOrNull ?? false);
+
         return SelectableUserListItem(
           pubkey: user.pubkey,
+          selectable: selectable,
+          canSendMessage: canSendMessage,
           masterPubkey: user.masterPubkey,
           onUserSelected: onUserSelected,
           selectedPubkeys: selectedPubkeys,
-          selectable: selectable,
         );
       },
     );

--- a/lib/app/features/user/pages/user_picker_sheet/components/selectable_user_list_item.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/components/selectable_user_list_item.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/list_item/badges_user_list_item.dart';
 import 'package:ion/app/components/screen_offset/screen_side_offset.dart';
 import 'package:ion/app/extensions/extensions.dart';
+import 'package:ion/app/features/chat/views/components/chat_privacy_tooltip.dart';
 import 'package:ion/app/features/user/model/user_metadata.f.dart';
 import 'package:ion/app/features/user/providers/user_metadata_provider.r.dart';
 import 'package:ion/app/utils/username.dart';
@@ -18,6 +19,7 @@ class SelectableUserListItem extends ConsumerWidget {
     super.key,
     this.selectedPubkeys = const [],
     this.selectable = false,
+    this.canSendMessage = true,
   });
 
   final String pubkey;
@@ -25,6 +27,7 @@ class SelectableUserListItem extends ConsumerWidget {
   final void Function(UserMetadataEntity user) onUserSelected;
   final List<String> selectedPubkeys;
   final bool selectable;
+  final bool canSendMessage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -36,24 +39,27 @@ class SelectableUserListItem extends ConsumerWidget {
 
     final isSelected = selectedPubkeys.contains(masterPubkey) || (selectedPubkeys.contains(pubkey));
 
-    return BadgesUserListItem(
-      onTap: () => onUserSelected(userMetadataResult),
-      title: Text(userMetadataResult.data.displayName),
-      subtitle: Text(prefixUsername(username: userMetadataResult.data.name, context: context)),
-      pubkey: masterPubkey,
-      contentPadding: EdgeInsets.symmetric(
-        vertical: 8.0.s,
-        horizontal: ScreenSideOffset.defaultSmallMargin,
+    return ChatPrivacyTooltip(
+      canSendMessage: canSendMessage,
+      child: BadgesUserListItem(
+        onTap: canSendMessage ? () => onUserSelected(userMetadataResult) : null,
+        title: Text(userMetadataResult.data.displayName),
+        subtitle: Text(prefixUsername(username: userMetadataResult.data.name, context: context)),
+        pubkey: masterPubkey,
+        contentPadding: EdgeInsets.symmetric(
+          vertical: 8.0.s,
+          horizontal: ScreenSideOffset.defaultSmallMargin,
+        ),
+        trailing: selectable && canSendMessage
+            ? isSelected
+                ? Assets.svg.iconBlockCheckboxOnblue.icon(
+                    color: context.theme.appColors.success,
+                  )
+                : Assets.svg.iconBlockCheckboxOff.icon(
+                    color: context.theme.appColors.onTerararyFill,
+                  )
+            : null,
       ),
-      trailing: selectable
-          ? isSelected
-              ? Assets.svg.iconBlockCheckboxOnblue.icon(
-                  color: context.theme.appColors.success,
-                )
-              : Assets.svg.iconBlockCheckboxOff.icon(
-                  color: context.theme.appColors.onTerararyFill,
-                )
-          : null,
     );
   }
 }

--- a/lib/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart
@@ -23,12 +23,14 @@ class UserPickerSheet extends HookConsumerWidget {
     this.controlPrivacy = false,
     this.header,
     this.footer,
+    this.expirationDuration,
   });
 
   final NavigationAppBar navigationBar;
   final List<String> selectedPubkeys;
   final bool selectable;
   final bool controlPrivacy;
+  final Duration? expirationDuration;
   final void Function(UserMetadataEntity user) onUserSelected;
 
   final Widget? header;
@@ -39,7 +41,12 @@ class UserPickerSheet extends HookConsumerWidget {
     final searchQuery = ref.watch(searchUsersQueryProvider);
     final debouncedQuery = useDebounced(searchQuery, const Duration(milliseconds: 300)) ?? '';
 
-    final searchResults = ref.watch(searchUsersProvider(query: debouncedQuery));
+    final searchResults = ref.watch(
+      searchUsersProvider(
+        query: debouncedQuery,
+        expirationDuration: expirationDuration,
+      ),
+    );
 
     return LoadMoreBuilder(
       slivers: [
@@ -78,7 +85,7 @@ class UserPickerSheet extends HookConsumerWidget {
         else
           SearchedUsers(
             selectable: selectable,
-            controlPrivacy: controlPrivacy,
+            controlChatPrivacy: controlPrivacy,
             onUserSelected: onUserSelected,
             selectedPubkeys: selectedPubkeys,
             users: searchResults.valueOrNull?.users,

--- a/lib/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart
@@ -20,6 +20,7 @@ class UserPickerSheet extends HookConsumerWidget {
     super.key,
     this.selectedPubkeys = const [],
     this.selectable = false,
+    this.controlPrivacy = false,
     this.header,
     this.footer,
   });
@@ -27,6 +28,7 @@ class UserPickerSheet extends HookConsumerWidget {
   final NavigationAppBar navigationBar;
   final List<String> selectedPubkeys;
   final bool selectable;
+  final bool controlPrivacy;
   final void Function(UserMetadataEntity user) onUserSelected;
 
   final Widget? header;
@@ -68,16 +70,18 @@ class UserPickerSheet extends HookConsumerWidget {
         if (header != null) header!,
         if (debouncedQuery.isEmpty)
           FollowingUsers(
-            onUserSelected: onUserSelected,
-            selectedPubkeys: selectedPubkeys,
             selectable: selectable,
+            onUserSelected: onUserSelected,
+            controlPrivacy: controlPrivacy,
+            selectedPubkeys: selectedPubkeys,
           )
         else
           SearchedUsers(
-            users: searchResults.valueOrNull?.users,
+            selectable: selectable,
+            controlPrivacy: controlPrivacy,
             onUserSelected: onUserSelected,
             selectedPubkeys: selectedPubkeys,
-            selectable: selectable,
+            users: searchResults.valueOrNull?.users,
           ),
         SliverToBoxAdapter(child: SizedBox(height: 8.0.s)),
         if (footer != null) footer!,

--- a/lib/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart
+++ b/lib/app/features/user/pages/user_picker_sheet/user_picker_sheet.dart
@@ -79,7 +79,7 @@ class UserPickerSheet extends HookConsumerWidget {
           FollowingUsers(
             selectable: selectable,
             onUserSelected: onUserSelected,
-            controlPrivacy: controlPrivacy,
+            controlChatPrivacy: controlPrivacy,
             selectedPubkeys: selectedPubkeys,
           )
         else

--- a/lib/app/features/user/providers/follow_list_provider.r.dart
+++ b/lib/app/features/user/providers/follow_list_provider.r.dart
@@ -49,10 +49,10 @@ bool isCurrentUserFollowingSelector(Ref ref, String pubkey) {
 }
 
 @riverpod
-bool isCurrentUserFollowed(Ref ref, String pubkey) {
+bool isCurrentUserFollowed(Ref ref, String pubkey, {bool cache = true}) {
   final currentPubkey = ref.watch(currentPubkeySelectorProvider);
   return ref.watch(
-    followListProvider(pubkey).select(
+    followListProvider(pubkey, cache: cache).select(
       (state) =>
           state.valueOrNull?.data.list.any((followee) => followee.pubkey == currentPubkey) ?? false,
     ),

--- a/lib/app/features/user/providers/paginated_users_metadata_provider.r.dart
+++ b/lib/app/features/user/providers/paginated_users_metadata_provider.r.dart
@@ -37,7 +37,10 @@ class PaginatedUsersMetadata extends _$PaginatedUsersMetadata {
   int _offset = 0;
 
   @override
-  Future<PaginatedUsersMetadataData> build(UserRelaysInfoFetcher fetcher) async {
+  Future<PaginatedUsersMetadataData> build(
+    UserRelaysInfoFetcher fetcher, {
+    Duration? expirationDuration,
+  }) async {
     _fetcher = fetcher;
     if (!_initialized) {
       await _init();
@@ -69,6 +72,7 @@ class PaginatedUsersMetadata extends _$PaginatedUsersMetadata {
       final masterPubkeys = userRelaysInfo.map((e) => e.masterPubKey).toSet();
       final usersMetadataWithDependencies =
           await ref.read(ionConnectEntitiesManagerProvider.notifier).fetch(
+                expirationDuration: expirationDuration,
                 eventReferences: masterPubkeys
                     .map(
                       (masterPubkey) => ReplaceableEventReference(

--- a/lib/app/features/user/providers/search_users_provider.r.dart
+++ b/lib/app/features/user/providers/search_users_provider.r.dart
@@ -14,10 +14,12 @@ class SearchUsers extends _$SearchUsers {
   @override
   FutureOr<({List<UserMetadataEntity>? users, bool hasMore})?> build({
     required String query,
+    Duration? expirationDuration,
   }) async {
     final masterPubkey = ref.watch(currentPubkeySelectorProvider);
-    final paginatedUsersMetadataData =
-        await ref.watch(paginatedUsersMetadataProvider(_fetcher).future);
+    final paginatedUsersMetadataData = await ref.watch(
+      paginatedUsersMetadataProvider(_fetcher, expirationDuration: expirationDuration).future,
+    );
     final blockedUsersMasterPubkeys = ref
             .watch(currentUserBlockListNotifierProvider)
             .valueOrNull
@@ -38,11 +40,17 @@ class SearchUsers extends _$SearchUsers {
   }
 
   Future<void> loadMore() async {
-    return ref.read(paginatedUsersMetadataProvider(_fetcher).notifier).loadMore();
+    return ref
+        .read(
+          paginatedUsersMetadataProvider(_fetcher, expirationDuration: expirationDuration).notifier,
+        )
+        .loadMore();
   }
 
   Future<void> refresh() async {
-    return ref.invalidate(paginatedUsersMetadataProvider(_fetcher));
+    return ref.invalidate(
+      paginatedUsersMetadataProvider(_fetcher, expirationDuration: expirationDuration),
+    );
   }
 
   Future<List<UserRelaysInfo>> _fetcher(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -325,7 +325,7 @@
   "privacy_option_wallet_public": "Public",
   "privacy_option_wallet_private": "Private",
   "privacy_option_user_visibility_for_everyone": "Everyone",
-  "privacy_option_user_visibility_for_followed_people": "People I follow",
+  "privacy_option_user_visibility_for_followed_people": "Accounts I follow",
   "privacy_option_user_visibility_for_friends": "Friends",
   "push_notification_device_permission": "Device permission",
   "push_notification_social_group_title": "Social",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -729,6 +729,7 @@
   "chat_message_delete_modal_description_single": "Are you sure you want to delete this message?",
   "chat_search_empty": "Search here for users, chats, groups, and channels...",
   "chat_search_no_community_empty": "Search here for users, chats...",
+  "chat_privacy_cant_send_message": "You can't message this user due to their privacy settings - they only allow messages from accounts they follow",
   "chat_money_request_title": "Money requested",
   "chat_money_received_title": "Money received",
   "chat_money_sent_title": "Money sent",


### PR DESCRIPTION
## Description
1. Create canSendMessage verification provider which decides if current user can send message to target user:
a. If target user follows current user (allow)
b. Check target user kind 0 who_can_message_you field settings (allow only if target  account follows current user or everyone can send message (default))
c. Allow send message even if target user don’t follow current user but conversation between two users already existed
d. Do not allow if target user changed his privacy settings and 
deleted conversation for both users

2. Reuse it in next conversation entrance points:
a. Share story to target user (make inactive in search with tooltip)
b. Reply or react to target user story 
c. Share feed post to target user (make inactive in search with tooltip)
d. Start conversation or send money request from target user profile (hide buttons)
e. Send or request funds from wallet (make inactive in search with tooltip)
f. Search for target user in the chat search as profile or existing conversations  (make inactive in search with tooltip)

3. Remove user story privacy settings (who can reply to your story) as it is conflicting with chat privacy settings

4. Set user metadata cache TTL related to the chat entrance points equal to 2 minutes

## Task ID
ION-3298

## Type of Change
- [x] New feature
- [x] Refactoring


## Screenshots (if applicable)
<img width="420" height="913" alt="image" src="https://github.com/user-attachments/assets/8404593d-d8db-426a-9389-b57e352a9d4b" />
