### PR TITLE
fix: add "usd amount" to Send Coins form

### DIFF
--- a/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
+++ b/lib/app/features/wallets/views/pages/coins_flow/send_coins/components/send_coins_form.dart
@@ -62,6 +62,8 @@ class SendCoinsForm extends HookConsumerWidget {
 
     final amount = coin?.amount ?? 0.0;
     final amountController = useTextEditingController();
+    final usdAmount =
+        (parseAmount(amountController.text) ?? 0) * (coin?.selectedOption?.coin.priceUSD ?? 0);
 
     useOnInit(() => amountController.text = amount == 0.0 ? '' : formatCrypto(amount), []);
 
@@ -175,6 +177,7 @@ class SendCoinsForm extends HookConsumerWidget {
                         controller: amountController,
                         maxValue: coin?.selectedOption?.amount ?? 0,
                         coinAbbreviation: coin?.coinsGroup.abbreviation ?? '',
+                        balanceUSD: usdAmount,
                         errorText:
                             exceedsMaxAmount ? locale.wallet_coin_amount_insufficient_funds : null,
                       ),


### PR DESCRIPTION
## Description
Previously the Send Coins form didn't have a USD amount next to the amount field. This PR makes it visible.

## Task ID
ION-3335

## Type of Change
- [x] Bug fix

## Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/529557a0-a626-49b7-bced-103d11bfef1c" />
