### PR TITLE
fix: prevent go_router stack refresh on every app resume to keep pop callback working

### DIFF
--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -16,6 +18,7 @@ import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/router/components/sheet_content/main_modal_item.dart';
 import 'package:ion/app/router/components/sheet_content/sheet_content.dart';
+import 'package:ion/app/router/model/main_modal_list_item.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion/app/services/media_service/banuba_service.r.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
@@ -44,101 +47,138 @@ class FeedMainModalPage extends ConsumerWidget {
             itemCount: feedTypeValues.length,
             itemBuilder: (BuildContext context, int index) {
               final type = feedTypeValues[index];
-
-              if (type == FeedType.story) {
-                return PermissionAwareWidget(
-                  permissionType: Permission.camera,
-                  requestId: 'story_record',
-                  builder: (_, onPressed) => MainModalItem(
-                    item: type,
-                    onTap: onPressed,
-                    index: index,
-                  ),
-                  onGranted: () => StoryRecordRoute().push<void>(context),
-                  requestDialog: const PermissionRequestSheet(
-                    permission: Permission.camera,
-                  ),
-                  settingsDialog: SettingsRedirectSheet.fromType(context, Permission.camera),
-                );
-              } else if (type == FeedType.video) {
-                return PermissionAwareWidget(
-                  permissionType: Permission.photos,
-                  onGranted: () async {
-                    Future<void> showMediaPickerAndCreatePost() async {
-                      final result = await showSimpleBottomSheet<List<MediaFile>>(
-                        context: context,
-                        child: const MediaPickerPage(
-                          maxSelection: 1,
-                          isBottomSheet: true,
-                          type: MediaPickerType.video,
-                        ),
-                      );
-
-                      if (result != null && result.isNotEmpty && context.mounted) {
-                        final editedMedia = await ref.read(
-                          editMediaProvider(
-                            result[0],
-                            maxVideoDuration: VideoConstants.feedVideoMaxDuration,
-                          ).future,
-                        );
-                        if (!context.mounted || editedMedia == null) return;
-                        final editingResult = await CreateVideoRoute(
-                              videoPath: editedMedia.path,
-                              videoThumbPath: editedMedia.thumb,
-                              mimeType: result[0].mimeType ?? '',
-                            ).push<bool>(context) ??
-                            false;
-
-                        if (editingResult && context.mounted) {
-                          WidgetsBinding.instance.addPostFrameCallback((_) {
-                            if (context.mounted) {
-                              context.pop();
-                            }
-                          });
-                        }
-                      }
-                    }
-
-                    await showMediaPickerAndCreatePost();
-                  },
-                  requestDialog: const PermissionRequestSheet(permission: Permission.photos),
-                  settingsDialog: SettingsRedirectSheet.fromType(context, Permission.photos),
-                  builder: (_, onPressed) => MainModalItem(
-                    item: type,
-                    onTap: onPressed,
-                    index: index,
-                  ),
-                );
+              switch (type) {
+                case FeedType.post:
+                  return _SharePostButton(type: type, index: index);
+                case FeedType.story:
+                  return _ShareStoryButton(type: type, index: index);
+                case FeedType.video:
+                  return _ShareVideoButton(type: type, index: index);
+                case FeedType.article:
+                  return _ShareArticleButton(type: type, index: index);
               }
-
-              return MainModalItem(
-                item: type,
-                onTap: () async {
-                  final createFlowRouteLocation = _getCreateFlowRouteLocation(type);
-                  final result = await context.push<bool>(createFlowRouteLocation);
-
-                  if ((result ?? false) && context.mounted) {
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (context.mounted) {
-                        context.pop();
-                      }
-                    });
-                  }
-                },
-                index: index,
-              );
             },
           ),
         ],
       ),
     );
   }
+}
 
-  String _getCreateFlowRouteLocation(FeedType type) {
-    return switch (type) {
-      FeedType.post => CreatePostRoute().location,
-      FeedType.article => CreateArticleRoute().location,
-      _ => throw UnimplementedError(),
-    };
+class _SharePostButton extends HookConsumerWidget {
+  const _SharePostButton({required this.type, required this.index});
+  final MainModalListItem type;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return MainModalItem(
+      item: type,
+      onTap: () => CreatePostRoute().go(context),
+      index: index,
+    );
+  }
+}
+
+class _ShareStoryButton extends HookConsumerWidget {
+  const _ShareStoryButton({required this.type, required this.index});
+  final MainModalListItem type;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PermissionAwareWidget(
+      permissionType: Permission.camera,
+      requestId: 'story_record',
+      builder: (_, onPressed) => MainModalItem(
+        item: type,
+        onTap: onPressed,
+        index: index,
+      ),
+      onGranted: () async {
+        await StoryRecordRoute().push<void>(context);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (context.mounted) {
+            context.pop();
+          }
+        });
+      },
+      requestDialog: const PermissionRequestSheet(
+        permission: Permission.camera,
+      ),
+      settingsDialog: SettingsRedirectSheet.fromType(context, Permission.camera),
+    );
+  }
+}
+
+class _ShareVideoButton extends HookConsumerWidget {
+  const _ShareVideoButton({required this.type, required this.index});
+  final MainModalListItem type;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PermissionAwareWidget(
+      permissionType: Permission.photos,
+      onGranted: () async {
+        Future<void> showMediaPickerAndCreatePost() async {
+          final result = await showSimpleBottomSheet<List<MediaFile>>(
+            context: context,
+            child: const MediaPickerPage(
+              maxSelection: 1,
+              isBottomSheet: true,
+              type: MediaPickerType.video,
+            ),
+          );
+
+          if (context.mounted) {
+            if (result != null && result.isNotEmpty) {
+              final editedMedia = await ref.read(
+                editMediaProvider(
+                  result[0],
+                  maxVideoDuration: VideoConstants.feedVideoMaxDuration,
+                ).future,
+              );
+              if (!context.mounted) return;
+              if (editedMedia == null) {
+                context.pop();
+              } else {
+                CreateVideoRoute(
+                  videoPath: editedMedia.path,
+                  videoThumbPath: editedMedia.thumb,
+                  mimeType: result[0].mimeType ?? '',
+                ).go(context);
+              }
+            } else {
+              context.pop();
+            }
+          }
+        }
+
+        await showMediaPickerAndCreatePost();
+      },
+      requestDialog: const PermissionRequestSheet(permission: Permission.photos),
+      settingsDialog: SettingsRedirectSheet.fromType(context, Permission.photos),
+      builder: (_, onPressed) => MainModalItem(
+        item: type,
+        onTap: onPressed,
+        index: index,
+      ),
+    );
+  }
+}
+
+class _ShareArticleButton extends HookConsumerWidget {
+  const _ShareArticleButton({required this.type, required this.index});
+  final MainModalListItem type;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return MainModalItem(
+      item: type,
+      onTap: () => CreateArticleRoute().go(context),
+      index: index,
+    );
   }
 }

--- a/lib/app/features/force_update/providers/force_update_provider.r.dart
+++ b/lib/app/features/force_update/providers/force_update_provider.r.dart
@@ -23,14 +23,17 @@ class ForceUpdate extends _$ForceUpdate {
       appLifecycleProvider,
       (previous, next) async {
         if (next == AppLifecycleState.resumed) {
-          state = AsyncData(await _isForceUpdateRequired());
+          final isForceUpdateRequired = await _checkIsForceUpdateRequired();
+          if (state.valueOrNull != isForceUpdateRequired) {
+            state = AsyncData(isForceUpdateRequired);
+          }
         }
       },
     );
-    return _isForceUpdateRequired();
+    return _checkIsForceUpdateRequired();
   }
 
-  Future<bool> _isForceUpdateRequired() async {
+  Future<bool> _checkIsForceUpdateRequired() async {
     try {
       final repository = await ref.read(configRepositoryProvider.future);
 


### PR DESCRIPTION
## Description

This PR fixes an issue where navigation callbacks (like pop results) would break after the app was resumed, due to unnecessary GoRouter stack refreshes.

- The GoRouter configuration uses refreshListenable: AppRouterNotifier(ref) to watch several providers for changes.
- In AppRouterNotifier, we listen to providers like forceUpdateProvider, authProvider, and others, triggering notifyListeners() on updates.
- forceUpdateProvider always set a new state when the app switched to resumed, even if nothing changed.
- This caused GoRouter to refresh the whole navigation stack every time the app was resumed, breaking pop callbacks.
- The fix avoids unnecessary state changes in forceUpdateProvider on app resume, so navigation callbacks now work as expected.

## Additional Notes
- Hide the main feed modal when the user cancels publishing.

## Task ID
3322

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
