### PR TITLE
feat: Use v5 and v7 as conversation identifiers

### DIFF
--- a/lib/app/features/chat/community/models/entities/community_definition_data.f.dart
+++ b/lib/app/features/chat/community/models/entities/community_definition_data.f.dart
@@ -11,13 +11,14 @@ import 'package:ion/app/features/chat/community/models/entities/tags/community_v
 import 'package:ion/app/features/chat/community/models/entities/tags/conversation_identifier.f.dart';
 import 'package:ion/app/features/chat/community/models/entities/tags/description_tag.f.dart';
 import 'package:ion/app/features/chat/community/models/entities/tags/name_tag.f.dart';
+import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
 import 'package:ion/app/features/ion_connect/ion_connect.dart';
 import 'package:ion/app/features/ion_connect/model/event_serializable.dart';
 import 'package:ion/app/features/ion_connect/model/event_setting.f.dart';
 import 'package:ion/app/features/ion_connect/model/ion_connect_entity.dart';
 import 'package:ion/app/features/ion_connect/model/media_attachment.dart';
 import 'package:ion/app/features/ion_connect/model/replaceable_event_identifier.f.dart';
-import 'package:ion/app/services/uuid/uuid.dart';
+import 'package:ion/app/services/uuid/generate_conversation_id.dart';
 
 part 'community_definition_data.f.freezed.dart';
 
@@ -82,7 +83,7 @@ class CommunityDefinitionData with _$CommunityDefinitionData implements EventSer
     required List<String> moderators,
     required List<String> admins,
   }) {
-    final uuid = generateUuid();
+    final uuid = generateConversationId(conversationType: ConversationType.community);
     return CommunityDefinitionData(
       uuid: uuid,
       id: uuid,

--- a/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.r.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.r.dart
@@ -52,7 +52,6 @@ class SendE2eeChatMessageService {
   SendE2eeChatMessageService(this.ref);
 
   final Ref ref;
-
   Future<EventMessage> sendMessage({
     required String content,
     required String conversationId,
@@ -386,19 +385,6 @@ class SendE2eeChatMessageService {
       failedParticipantsMasterPubkeys:
           failedParticipantsMasterPubkeys.isNotEmpty ? failedParticipantsMasterPubkeys : null,
     );
-  }
-
-  String generateConversationId({
-    required String receiverPubkey,
-  }) {
-    final currentPubkey = ref.read(currentPubkeySelectorProvider);
-
-    if (currentPubkey == null) {
-      throw UserMasterPubkeyNotFoundException();
-    }
-
-    final sorted = [receiverPubkey, currentPubkey]..sort();
-    return sorted.join();
   }
 
   Future<List<String>> _generateCacheKeys(List<MediaFile> mediaFiles) async {

--- a/lib/app/features/chat/e2ee/providers/send_chat_message_service.r.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message_service.r.dart
@@ -17,8 +17,15 @@ Future<SendChatMessageService> sendChatMessageService(Ref ref) async {
   return SendChatMessageService(
     currentUserMasterPubkey: ref.watch(currentPubkeySelectorProvider),
     sendChatMessageService: ref.watch(sendE2eeChatMessageServiceProvider),
-    getExistingConversationId: (String pubkey) =>
-        ref.read(existChatConversationIdProvider(pubkey).future),
+    getExistingConversationId: (String masterPubkey) {
+      final currentUserMasterPubkey = ref.read(currentPubkeySelectorProvider);
+      if (currentUserMasterPubkey == null) {
+        throw UserMasterPubkeyNotFoundException();
+      }
+      final participantsMasterPubkeys = [masterPubkey, currentUserMasterPubkey];
+
+      return ref.read(existChatConversationIdProvider(participantsMasterPubkeys).future);
+    },
   );
 }
 

--- a/lib/app/features/chat/e2ee/providers/send_chat_message_service.r.dart
+++ b/lib/app/features/chat/e2ee/providers/send_chat_message_service.r.dart
@@ -4,8 +4,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/chat/e2ee/providers/send_chat_message/send_e2ee_chat_message_service.r.dart';
+import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
 import 'package:ion/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
+import 'package:ion/app/services/uuid/generate_conversation_id.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'send_chat_message_service.r.g.dart';
@@ -47,8 +49,9 @@ class SendChatMessageService {
     final existingConversationId = await getExistingConversationId(receiverPubkey);
 
     final conversationId = existingConversationId ??
-        sendChatMessageService.generateConversationId(
-          receiverPubkey: receiverPubkey,
+        generateConversationId(
+          conversationType: ConversationType.oneToOne,
+          receiverMasterPubkeys: [receiverPubkey, currentPubkey],
         );
 
     await sendChatMessageService.sendMessage(

--- a/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
+++ b/lib/app/features/chat/e2ee/views/pages/one_to_one_messages_page.dart
@@ -51,10 +51,15 @@ class OneToOneMessagesPage extends HookConsumerWidget {
           throw UserMasterPubkeyNotFoundException();
         }
 
-        final existingConversationId =
-            await ref.read(existChatConversationIdProvider(receiverMasterPubkey).future);
+        final participantsMasterPubkeys = [
+          receiverMasterPubkey,
+          currentUserMasterPubkey,
+        ];
 
-        print('Existing conversation ID: $existingConversationId');
+        final existingConversationId = await ref.read(
+          existChatConversationIdProvider(participantsMasterPubkeys).future,
+        );
+
         conversationId.value = existingConversationId ??
             generateConversationId(
               conversationType: ConversationType.oneToOne,

--- a/lib/app/features/chat/model/database/dao/conversation_dao.dart
+++ b/lib/app/features/chat/model/database/dao/conversation_dao.dart
@@ -154,7 +154,7 @@ class ConversationDao extends DatabaseAccessor<ChatDatabase> with _$Conversation
   /// Get the id of the conversation with the given receiver master pubkey
   /// Only searches for non-deleted conversations of type [ConversationType.oneToOne]
   ///
-  Future<String?> getExistOneToOneConversationId(String receiverMasterPubkey) async {
+  Future<String?> getExistOneToOneConversationId(List<String> participantsMasterPubkeys) async {
     final query = select(conversationTable).join([
       innerJoin(
         conversationMessageTable,
@@ -167,7 +167,7 @@ class ConversationDao extends DatabaseAccessor<ChatDatabase> with _$Conversation
     ])
       ..where(conversationTable.type.equals(ConversationType.oneToOne.index))
       ..where(conversationTable.isDeleted.equals(false))
-      ..where(eventMessageTable.masterPubkey.equals(receiverMasterPubkey))
+      ..where(conversationMessageTable.conversationId.equals(participantsMasterPubkeys.join()))
       ..where(
         eventMessageTable.kind.equals(ReplaceablePrivateDirectMessageEntity.kind),
       )

--- a/lib/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart
+++ b/lib/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart
@@ -9,7 +9,5 @@ part 'exist_chat_conversation_id_provider.r.g.dart';
 @riverpod
 Future<String?> existChatConversationId(Ref ref, List<String> participantsMasterPubkeys) async {
   final sortedMasterPubkeys = List<String>.from(participantsMasterPubkeys)..sort();
-  return ref
-      .watch(conversationDaoProvider)
-      .getExistOneToOneConversationId(sortedMasterPubkeys);
+  return ref.watch(conversationDaoProvider).getExistOneToOneConversationId(sortedMasterPubkeys);
 }

--- a/lib/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart
+++ b/lib/app/features/chat/providers/exist_chat_conversation_id_provider.r.dart
@@ -7,6 +7,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'exist_chat_conversation_id_provider.r.g.dart';
 
 @riverpod
-Future<String?> existChatConversationId(Ref ref, String receiverMasterPubKey) async {
-  return ref.watch(conversationDaoProvider).getExistOneToOneConversationId(receiverMasterPubKey);
+Future<String?> existChatConversationId(Ref ref, List<String> participantsMasterPubkeys) async {
+  final sortedMasterPubkeys = List<String>.from(participantsMasterPubkeys)..sort();
+  return ref
+      .watch(conversationDaoProvider)
+      .getExistOneToOneConversationId(sortedMasterPubkeys);
 }

--- a/lib/app/features/chat/providers/share_feed_item_to_chat_provider.r.dart
+++ b/lib/app/features/chat/providers/share_feed_item_to_chat_provider.r.dart
@@ -23,6 +23,7 @@ import 'package:ion/app/features/ion_connect/model/quoted_event.f.dart';
 import 'package:ion/app/features/ion_connect/model/related_pubkey.f.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_event_signer_provider.r.dart';
 import 'package:ion/app/features/user_profile/providers/user_profile_sync_provider.r.dart';
+import 'package:ion/app/services/uuid/generate_conversation_id.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'share_feed_item_to_chat_provider.r.g.dart';
@@ -142,8 +143,17 @@ class ShareFeedItemToChat extends _$ShareFeedItemToChat {
     final existingConversationId =
         await ref.read(existChatConversationIdProvider(masterPubkey).future);
 
+    final currentUserMasterPubkey = ref.watch(currentPubkeySelectorProvider);
+
+    if (currentUserMasterPubkey == null) {
+      throw UserMasterPubkeyNotFoundException();
+    }
+
     final conversationId = existingConversationId ??
-        sendChatMessageService.generateConversationId(receiverPubkey: masterPubkey);
+        generateConversationId(
+          conversationType: ConversationType.oneToOne,
+          receiverMasterPubkeys: [masterPubkey, currentUserMasterPubkey],
+        );
 
     final tags = [
       MasterPubkeyTag(value: currentUserMasterPubkey).toTag(),

--- a/lib/app/features/chat/providers/share_feed_item_to_chat_provider.r.dart
+++ b/lib/app/features/chat/providers/share_feed_item_to_chat_provider.r.dart
@@ -140,14 +140,16 @@ class ShareFeedItemToChat extends _$ShareFeedItemToChat {
     required EventMessage feedItemEventMessage,
     required SendE2eeChatMessageService sendChatMessageService,
   }) async {
-    final existingConversationId =
-        await ref.read(existChatConversationIdProvider(masterPubkey).future);
-
     final currentUserMasterPubkey = ref.watch(currentPubkeySelectorProvider);
 
     if (currentUserMasterPubkey == null) {
       throw UserMasterPubkeyNotFoundException();
     }
+
+    final participantsMasterPubkeys = [masterPubkey, currentUserMasterPubkey];
+
+    final existingConversationId =
+        await ref.read(existChatConversationIdProvider(participantsMasterPubkeys).future);
 
     final conversationId = existingConversationId ??
         generateConversationId(
@@ -180,8 +182,6 @@ class ShareFeedItemToChat extends _$ShareFeedItemToChat {
       createdAt: feedItemEventMessage.createdAt,
       sig: null,
     );
-
-    final participantsMasterPubkeys = [masterPubkey, currentUserMasterPubkey];
 
     final conversationPubkeysNotifier = ref.read(conversationPubkeysProvider.notifier);
 

--- a/lib/app/features/feed/stories/providers/story_reply_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_reply_provider.r.dart
@@ -20,6 +20,7 @@ import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/model/quoted_event.f.dart';
 import 'package:ion/app/features/ion_connect/model/related_pubkey.f.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_event_signer_provider.r.dart';
+import 'package:ion/app/services/uuid/generate_conversation_id.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'story_reply_provider.r.g.dart';
@@ -48,14 +49,13 @@ class StoryReply extends _$StoryReply {
         throw UserMasterPubkeyNotFoundException();
       }
 
-      final sendChatMessageService = ref.read(sendE2eeChatMessageServiceProvider);
-
       final existingConversationId =
           await ref.read(existChatConversationIdProvider(story.masterPubkey).future);
 
       final conversationId = existingConversationId ??
-          sendChatMessageService.generateConversationId(
-            receiverPubkey: story.masterPubkey,
+          generateConversationId(
+            conversationType: ConversationType.oneToOne,
+            receiverMasterPubkeys: [story.masterPubkey, currentUserMasterPubkey],
           );
 
       final storyEventMessage = await story.toEventMessage(story.data);

--- a/lib/app/features/feed/stories/providers/story_reply_provider.r.dart
+++ b/lib/app/features/feed/stories/providers/story_reply_provider.r.dart
@@ -49,8 +49,13 @@ class StoryReply extends _$StoryReply {
         throw UserMasterPubkeyNotFoundException();
       }
 
+      final participantsMasterPubkeys = [
+        story.masterPubkey,
+        currentUserMasterPubkey,
+      ];
+
       final existingConversationId =
-          await ref.read(existChatConversationIdProvider(story.masterPubkey).future);
+          await ref.read(existChatConversationIdProvider(participantsMasterPubkeys).future);
 
       final conversationId = existingConversationId ??
           generateConversationId(
@@ -86,11 +91,6 @@ class StoryReply extends _$StoryReply {
         createdAt: storyEventMessage.createdAt,
         sig: null,
       );
-
-      final participantsMasterPubkeys = [
-        story.masterPubkey,
-        currentUserMasterPubkey,
-      ];
 
       final conversationPubkeysNotifier = ref.read(conversationPubkeysProvider.notifier);
 

--- a/lib/app/services/uuid/generate_conversation_id.dart
+++ b/lib/app/services/uuid/generate_conversation_id.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: ice License 1.0
+
 import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
 import 'package:uuid/uuid.dart';
 

--- a/lib/app/services/uuid/generate_conversation_id.dart
+++ b/lib/app/services/uuid/generate_conversation_id.dart
@@ -10,13 +10,11 @@ String generateConversationId({
   final sorted = List<String>.from(receiverMasterPubkeys)..sort();
 
   // For one-to-one conversations, we use v5 UUID to ensure the same conversation ID for the same participants.
-  if (conversationType == ConversationType.oneToOne) {
-    return const Uuid().v5(Namespace.nil.value, sorted.join());
-  } else if (conversationType == ConversationType.group) {
-    return const Uuid().v7();
-  } else if (conversationType == ConversationType.community) {
-    return const Uuid().v7();
-  } else {
-    throw UnsupportedError('Unsupported conversation type: $conversationType');
+  switch (conversationType) {
+    case ConversationType.oneToOne:
+      return const Uuid().v5(Namespace.nil.value, sorted.join());
+    case ConversationType.group:
+    case ConversationType.community:
+      return const Uuid().v7();
   }
 }

--- a/lib/app/services/uuid/generate_conversation_id.dart
+++ b/lib/app/services/uuid/generate_conversation_id.dart
@@ -1,0 +1,20 @@
+import 'package:ion/app/features/chat/model/database/chat_database.m.dart';
+import 'package:uuid/uuid.dart';
+
+String generateConversationId({
+  required ConversationType conversationType,
+  List<String> receiverMasterPubkeys = const [],
+}) {
+  final sorted = List<String>.from(receiverMasterPubkeys)..sort();
+
+  // For one-to-one conversations, we use v5 UUID to ensure the same conversation ID for the same participants.
+  if (conversationType == ConversationType.oneToOne) {
+    return const Uuid().v5(Namespace.nil.value, sorted.join());
+  } else if (conversationType == ConversationType.group) {
+    return const Uuid().v7();
+  } else if (conversationType == ConversationType.community) {
+    return const Uuid().v7();
+  } else {
+    throw UnsupportedError('Unsupported conversation type: $conversationType');
+  }
+}


### PR DESCRIPTION
## Description
 - Replaces current approach for one-to-one conversations to use UUID v5 which produces same id for same participants
 - Makes generation method isolated from `ref`
 - Fixes bug when only author send messages and existing conversation Id can't be found

## Task ID
?

## Type of Change
- [x] Refactoring
