### PR TITLE
fix: prevent story video from stretching to fit screen

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/viewers/video_story_viewer.dart
@@ -45,18 +45,25 @@ class VideoStoryViewer extends HookConsumerWidget {
       onCompleted: onVideoCompleted,
     );
 
-    Widget videoPlayer = VideoPlayer(videoController);
-
     final aspect = videoController.value.aspectRatio;
     final isHorizontal = aspect > 1.0;
     if (isHorizontal) {
-      videoPlayer = Center(
+      return Center(
         child: AspectRatio(
           aspectRatio: aspect,
-          child: videoPlayer,
+          child: VideoPlayer(videoController),
         ),
       );
     }
-    return videoPlayer;
+    return SizedBox.expand(
+      child: FittedBox(
+        fit: BoxFit.cover,
+        child: SizedBox(
+          width: videoController.value.size.width,
+          height: videoController.value.size.height,
+          child: VideoPlayer(videoController),
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where story videos were stretched to fill the screen.

## Additional Notes
N/A

## Task ID
3376

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/39c46b99-306d-49b1-b3ec-d695a6d1b2e0


