### PR TITLE
fix: cancel global subscription on background and reinitialize on resume to prevent event loss

### DIFF
--- a/lib/app/features/ion_connect/providers/global_subscription.r.dart
+++ b/lib/app/features/ion_connect/providers/global_subscription.r.dart
@@ -56,7 +56,6 @@ class GlobalSubscription {
   static const List<int> _encryptedEventKinds = [IonConnectGiftWrapEntity.kind];
 
   void init() {
-    print('CUSTOM LOG - init');
     final now = DateTime.now().microsecondsSinceEpoch;
     final regularLatestEventTimestamp = latestEventTimestampService.get(EventType.regular);
 

--- a/lib/app/features/ion_connect/providers/global_subscription.r.dart
+++ b/lib/app/features/ion_connect/providers/global_subscription.r.dart
@@ -2,11 +2,13 @@
 
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/exceptions/exceptions.dart';
 import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/auth/providers/auth_provider.m.dart';
 import 'package:ion/app/features/auth/providers/delegation_complete_provider.r.dart';
+import 'package:ion/app/features/core/providers/app_lifecycle_provider.r.dart';
 import 'package:ion/app/features/feed/data/models/entities/generic_repost.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/modifiable_post_data.f.dart';
 import 'package:ion/app/features/feed/data/models/entities/reaction_data.f.dart';
@@ -54,6 +56,7 @@ class GlobalSubscription {
   static const List<int> _encryptedEventKinds = [IonConnectGiftWrapEntity.kind];
 
   void init() {
+    print('CUSTOM LOG - init');
     final now = DateTime.now().microsecondsSinceEpoch;
     final regularLatestEventTimestamp = latestEventTimestampService.get(EventType.regular);
 
@@ -157,22 +160,33 @@ class GlobalSubscription {
 
 @riverpod
 class GlobalSubscriptionNotifier extends _$GlobalSubscriptionNotifier {
+  StreamSubscription<EventMessage>? _subscription;
+
   @override
-  void build() {}
+  void build() {
+    ref.onDispose(() {
+      _subscription?.cancel();
+    });
+  }
 
   void subscribe(
     RequestMessage requestMessage, {
     required void Function(EventMessage) onEvent,
   }) {
     final stream = ref.watch(ionConnectEventsSubscriptionProvider(requestMessage));
-    final subscription = stream.listen(onEvent);
-    ref.onDispose(subscription.cancel);
+    _subscription = stream.listen(onEvent);
   }
 }
 
 @riverpod
 GlobalSubscription? globalSubscription(Ref ref) {
   keepAliveWhenAuthenticated(ref);
+
+  final appState = ref.watch(appLifecycleProvider);
+
+  if (appState != AppLifecycleState.resumed) {
+    return null;
+  }
 
   final currentUserMasterPubkey = ref.watch(currentPubkeySelectorProvider);
   final devicePubkey = ref.watch(currentUserIonConnectEventSignerProvider).valueOrNull?.publicKey;


### PR DESCRIPTION
## Description
This PR enhances global subscription handling by:
	•	Cancelling the active event stream subscription when the app moves to the background.
	•	Reinitializing the subscription when the app returns to the foreground (AppLifecycleState.resumed).
	•	Preventing potential event loss caused by OS-level network restrictions during background state.

## Additional Notes
N/A

## Task ID
part of 3243

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
