### PR TITLE
fix: update text field content when editing message

### DIFF
--- a/lib/app/features/chat/views/components/chat_input_bar/chat_input_bar.dart
+++ b/lib/app/features/chat/views/components/chat_input_bar/chat_input_bar.dart
@@ -93,12 +93,25 @@ class ChatInputBar extends HookConsumerWidget {
 
     useEffect(
       () {
-        if (editMessage != null || repliedMessage != null) {
+        if (repliedMessage != null) {
           textFieldFocusNode.requestFocus();
         }
         return null;
       },
-      [editMessage, repliedMessage],
+      [repliedMessage],
+    );
+
+    useEffect(
+      () {
+        if (editMessage != null) {
+          textFieldFocusNode.requestFocus();
+          textFieldController.text = editMessage.contentDescription;
+        } else {
+          textFieldController.clear();
+        }
+        return null;
+      },
+      [editMessage],
     );
 
     useEffect(


### PR DESCRIPTION
## Description
This PR fixes an issue where the text field wasn’t correctl populated when entering edit mode for a message. 

## Additional Notes
N/A

## Task ID
3401

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)


https://github.com/user-attachments/assets/5b97fc65-4615-4ca3-ab89-304fdad830e6

