### PR TITLE
fix: feed and profile main modal navigation routing fixes

### DIFF
--- a/lib/app/features/feed/create_article/views/pages/article_form_modal/article_form_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/article_form_modal/article_form_modal.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/back_hardware_button_interceptor/back_hardware_button_interceptor.dart';
 import 'package:ion/app/components/button/button.dart';
@@ -101,13 +102,19 @@ class ArticleFormModal extends HookConsumerWidget {
                   backgroundColor: context.theme.appColors.secondaryBackground,
                   borderColor: context.theme.appColors.secondaryBackground,
                   disabled: !articleState.isButtonEnabled,
-                  onPressed: () {
+                  onPressed: () async {
                     articleState.onNext();
                     if (modifiedEvent != null) {
                       final eventEncoded = modifiedEvent!.encode();
-                      EditArticlePreviewRoute(modifiedEvent: eventEncoded).push<void>(context);
+                      await EditArticlePreviewRoute(modifiedEvent: eventEncoded)
+                          .push<void>(context);
                     } else {
-                      ArticlePreviewRoute().push<void>(context);
+                      await ArticlePreviewRoute().push<void>(context);
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (context.mounted) {
+                          context.pop();
+                        }
+                      });
                     }
                   },
                 ),

--- a/lib/app/features/feed/create_article/views/pages/article_preview_modal/article_preview_modal.dart
+++ b/lib/app/features/feed/create_article/views/pages/article_preview_modal/article_preview_modal.dart
@@ -147,8 +147,7 @@ class ArticlePreviewModal extends HookConsumerWidget {
                       }
 
                       if (!ref.read(createArticleProvider(type)).hasError && ref.context.mounted) {
-                        final state = GoRouterState.of(ref.context);
-                        ref.context.go(state.currentTab.baseRouteLocation);
+                        context.pop();
                       }
                     },
                     label: Text(context.i18n.button_publish),

--- a/lib/app/features/feed/stories/views/pages/story_preview_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_preview_page.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
 import 'package:ion/app/components/screen_offset/screen_bottom_offset.dart';
@@ -23,7 +24,6 @@ import 'package:ion/app/features/feed/stories/views/components/story_preview/med
 import 'package:ion/app/features/feed/stories/views/components/story_preview/media/story_video_preview.dart';
 import 'package:ion/app/features/ion_connect/model/event_reference.f.dart';
 import 'package:ion/app/features/ion_connect/providers/ion_connect_cache.r.dart';
-import 'package:ion/app/router/app_routes.gr.dart';
 import 'package:ion/app/router/components/navigation_app_bar/navigation_app_bar.dart';
 import 'package:ion/app/services/compressors/image_compressor.r.dart';
 import 'package:ion/app/services/media_service/media_service.m.dart';
@@ -54,7 +54,7 @@ class StoryPreviewPage extends HookConsumerWidget {
         createPostNotifierProvider(CreatePostOption.story),
         (_) {
           if (context.mounted) {
-            FeedRoute().go(context);
+            context.pop(true);
           }
         },
       );

--- a/lib/app/features/feed/stories/views/pages/story_record_page.dart
+++ b/lib/app/features/feed/stories/views/pages/story_record_page.dart
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:ion/app/components/progress_bar/centered_loading_indicator.dart';
@@ -113,7 +114,15 @@ class StoryRecordPage extends HookConsumerWidget {
               );
 
           if (edited != null && edited != file.path && context.mounted) {
-            await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<void>(context);
+            final shouldPop =
+                await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<bool?>(context);
+            if (shouldPop.falseOrValue) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (context.mounted) {
+                  context.pop();
+                }
+              });
+            }
           }
           await ref.read(cameraControllerNotifierProvider.notifier).resumeCamera();
         } else if (mediaType == MediaType.image) {
@@ -145,7 +154,15 @@ class StoryRecordPage extends HookConsumerWidget {
             .editExternalPhoto(file.path, resumeCamera: false);
 
         if (edited != null && edited != file.path && context.mounted) {
-          await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<void>(context);
+          final shouldPop =
+              await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<bool?>(context);
+          if (shouldPop.falseOrValue) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (context.mounted) {
+                context.pop();
+              }
+            });
+          }
         }
         await ref.read(cameraControllerNotifierProvider.notifier).resumeCamera();
       },
@@ -167,7 +184,15 @@ class StoryRecordPage extends HookConsumerWidget {
           );
 
       if (edited != null && edited != file.path && context.mounted) {
-        await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<void>(context);
+        final shouldPop =
+            await StoryPreviewRoute(path: edited, mimeType: file.mimeType).push<bool?>(context);
+        if (shouldPop.falseOrValue) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              context.pop();
+            }
+          });
+        }
       }
       await ref.read(cameraControllerNotifierProvider.notifier).resumeCamera();
     } else if (mediaType == MediaType.image) {

--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -74,7 +74,12 @@ class _SharePostButton extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return MainModalItem(
       item: type,
-      onTap: () => CreatePostRoute().go(context),
+      onTap: () async {
+        await CreatePostRoute().push<void>(context);
+        if (context.mounted) {
+          context.pop();
+        }
+      },
       index: index,
     );
   }
@@ -143,11 +148,16 @@ class _ShareVideoButton extends HookConsumerWidget {
               if (editedMedia == null) {
                 context.pop();
               } else {
-                CreateVideoRoute(
+                await CreateVideoRoute(
                   videoPath: editedMedia.path,
                   videoThumbPath: editedMedia.thumb,
                   mimeType: result[0].mimeType ?? '',
-                ).go(context);
+                ).push<void>(context);
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (context.mounted) {
+                    context.pop();
+                  }
+                });
               }
             } else {
               context.pop();
@@ -177,7 +187,14 @@ class _ShareArticleButton extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return MainModalItem(
       item: type,
-      onTap: () => CreateArticleRoute().go(context),
+      onTap: () async {
+        await CreateArticleRoute().push<void>(context);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (context.mounted) {
+            context.pop();
+          }
+        });
+      },
       index: index,
     );
   }

--- a/lib/app/router/app_routes.gr.dart
+++ b/lib/app/router/app_routes.gr.dart
@@ -222,6 +222,7 @@ final transitionObserver = NavigationSheetTransitionObserver();
           path: '/profile',
           routes: [
             ...ProfileRoutes.routes,
+            TypedGoRoute<ProfileMainModalRoute>(path: 'main-modal'),
           ],
         ),
       ],
@@ -314,6 +315,14 @@ class IntroRoute extends BaseRouteData with _$IntroRoute {
 
 class FeedMainModalRoute extends BaseRouteData with _$FeedMainModalRoute {
   FeedMainModalRoute()
+      : super(
+          child: const FeedMainModalPage(),
+          type: IceRouteType.mainModalSheet,
+        );
+}
+
+class ProfileMainModalRoute extends BaseRouteData with _$ProfileMainModalRoute {
+  ProfileMainModalRoute()
       : super(
           child: const FeedMainModalPage(),
           type: IceRouteType.mainModalSheet,

--- a/lib/app/router/feed_routes.dart
+++ b/lib/app/router/feed_routes.dart
@@ -21,6 +21,8 @@ class FeedRoutes {
     TypedGoRoute<ArticlesFromAuthorRoute>(path: 'articles/author/:pubkey'),
     TypedGoRoute<FeedSimpleSearchRoute>(path: 'feed-simple-search'),
     TypedGoRoute<FeedAdvancedSearchRoute>(path: 'feed-advanced-search'),
+    TypedGoRoute<StoryRecordRoute>(path: 'story-record-fullstack'),
+    TypedGoRoute<StoryPreviewRoute>(path: 'story-preview-fullstack/:path'),
     TypedShellRoute<ModalShellRouteData>(
       routes: [
         TypedGoRoute<FeedVisibleArticleCategoriesRoute>(path: 'feed-visible-article-categories'),
@@ -363,12 +365,10 @@ class FeedSearchFiltersRoute extends BaseRouteData with _$FeedSearchFiltersRoute
         );
 }
 
-@TypedGoRoute<StoryRecordRoute>(path: '/story-record')
 class StoryRecordRoute extends BaseRouteData with _$StoryRecordRoute {
   StoryRecordRoute() : super(child: const StoryRecordPage());
 }
 
-@TypedGoRoute<StoryPreviewRoute>(path: '/story-preview/:path')
 class StoryPreviewRoute extends BaseRouteData with _$StoryPreviewRoute {
   StoryPreviewRoute({
     required this.path,

--- a/lib/app/router/main_tabs/components/tab_item.dart
+++ b/lib/app/router/main_tabs/components/tab_item.dart
@@ -51,9 +51,10 @@ enum TabItem {
       };
 
   String get mainModalLocation => switch (this) {
-        TabItem.feed || TabItem.profile => FeedMainModalRoute().location,
+        TabItem.feed => FeedMainModalRoute().location,
         TabItem.chat => ChatMainModalRoute().location,
         TabItem.wallet => WalletMainModalRoute().location,
+        TabItem.profile => ProfileMainModalRoute().location,
         TabItem.main => '/',
       };
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where:
	•	When the user shares content from the Profile tab, the app incorrectly switches to the Feed tab.
	•	The Feed main modal remains open after sharing, even though the user did not explicitly open it.


## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3322

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
