### PR TITLE
fix: update camera dependencies to fix front camera mirroring issue

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -301,18 +301,18 @@ packages:
     dependency: "direct main"
     description:
       name: camera
-      sha256: "413d2b34fe28496c35c69ede5b232fb9dd5ca2c3a4cb606b14efc1c7546cc8cb"
+      sha256: d6ec2cbdbe2fa8f5e0d07d8c06368fe4effa985a4a5ddade9cc58a8cd849557d
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.11.2"
   camera_android_camerax:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: camera_android_camerax
-      sha256: ea7e40bd63afb8f55058e48ec529ce96562be9d08393f79631a06f781161fd0d
+      sha256: "4b6c1bef4270c39df96402c4d62f2348c3bb2bbaefd0883b9dbd58f426306ad0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.19"
   camera_avfoundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   btc_address_validate_swan: ^1.2.1
   cached_network_image: ^3.4.1
   cached_video_player_plus: ^4.0.1
-  camera: ^0.11.0+2
+  camera: ^0.11.2
+  camera_android_camerax: ^0.6.19
   charcode: ^1.4.0
   collection: ^1.18.0
   convert: ^3.1.2


### PR DESCRIPTION
## Description
This PR updates the following dependencies to their latest versions to fix the reversed (mirrored) front camera preview:

- `camera`
- `camera_android_camerax`
## Additional Notes

> Related Flutter issue: https://github.com/flutter/flutter/issues/156974
> Fix implemented in:  https://github.com/flutter/flutter/pull/170600

## Task ID
3422

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
