### PR TITLE
chore: generate and inject whole tld list

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,7 @@ analyzer:
     - lib/**.g.dart
     - lib/**.freezed.dart
     - build/**
+    - scripts/**
     - lib/generated/**
 
   errors:

--- a/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
+++ b/lib/app/features/auth/views/pages/sign_up_passkey/sign_up_passkey_form.dart
@@ -52,6 +52,7 @@ class SignUpPasskeyForm extends HookConsumerWidget {
                   ),
             onPressed: () {
               if (formKey.value.currentState!.validate()) {
+                FocusScope.of(context).unfocus();
                 guardPasskeyDialog(
                   ref.context,
                   (child) => RiverpodVerifyIdentityRequestBuilder(

--- a/lib/app/services/text_parser/model/text_matcher.dart
+++ b/lib/app/services/text_parser/model/text_matcher.dart
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import 'package:ion/generated/tlds_group.dart';
+
 sealed class TextMatcher {
   const TextMatcher();
 
@@ -32,12 +34,12 @@ class UrlMatcher extends TextMatcher {
       ')'
       r'(?:[^@\s]+@)?' // optional auth
       r'(?:(?:(?!-)[A-Za-z0-9-]+(?<!-)\.)+' // labels with dots
-      '(?:com|net|org|info|biz|gov|edu|mil|int|arpa|io|ai|app|dev|xyz|online|site|tech|blog|store|news|shop|club|us|uk|ca|de|fr|cn|jp|ru|br|in|au|es|it|nl|se|no|fi|dk|be|ch|at|pl|cz|sk|pt|gr|tr|kr|sg|hk|tw|mx|ar|za)' // explicit TLD list
+      '$tldGroup'
       '|(?!-)[A-Za-z0-9-]{2,}(?<!-))' // or fallback host (like localhost)
       '|'
       // bare domain with explicit TLD only
       r'(?:[A-Za-z0-9-]+\.)+' // labels with dots
-      '(?:com|net|org|info|biz|gov|edu|mil|int|arpa|io|ai|app|dev|xyz|online|site|tech|blog|store|news|shop|club|us|uk|ca|de|fr|cn|jp|ru|br|in|au|es|it|nl|se|no|fi|dk|be|ch|at|pl|cz|sk|pt|gr|tr|kr|sg|hk|tw|mx|ar|za)' // explicit TLD list
+      '$tldGroup'
       ')'
       r'(?::\d{2,5})?' // optional port
       r'(?:\/[^\s!?.,;:]*[A-Za-z0-9\/])?' // optional path

--- a/scripts/generate_code.sh
+++ b/scripts/generate_code.sh
@@ -8,3 +8,4 @@ source "$(dirname "$0")/utils.sh"
 # https://pub.dev/packages/widgetbook
 use_asdf dart run build_runner clean
 use_asdf dart run build_runner build --delete-conflicting-outputs
+use_asdf dart run scripts/generate_tld_regex.dart

--- a/scripts/generate_tld_regex.dart
+++ b/scripts/generate_tld_regex.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  // Download the official IANA TLD list
+  const tldUrl = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt';
+  final httpClient = HttpClient();
+  final request = await httpClient.getUrl(Uri.parse(tldUrl));
+  final response = await request.close();
+  if (response.statusCode != HttpStatus.ok) {
+    stderr.writeln('ERROR: Failed to download TLD list (HTTP ${response.statusCode})');
+    exit(1);
+  }
+  final rawLines = await response.transform(utf8.decoder).transform(const LineSplitter()).toList();
+
+  // 1) Read, trim, drop empty/comment lines
+  final tlds = rawLines
+      .map((l) => l.trim().toLowerCase())
+      .where((l) => l.isNotEmpty && !l.startsWith('#'))
+      .toList();
+
+  if (tlds.isEmpty) {
+    stderr.writeln('ERROR: No TLDs found.');
+    exit(2);
+  }
+
+  // 2) Build the regex group
+  final group = '(?:' + tlds.join('|') + ')';
+
+  // 3) Write a complete Dart source file
+  const outputPath = 'lib/generated/tlds_group.dart';
+  final outFile = File(outputPath);
+  // Ensure the target directory exists
+  outFile.parent.createSync(recursive: true);
+  final content =
+      '''
+// GENERATED — do not edit by hand.
+const String tldGroup = '$group';
+''';
+  outFile.writeAsStringSync(content);
+  print('Wrote generated TLD group to $outputPath');
+  httpClient.close(force: true);
+  exit(0);
+}

--- a/test/services/text_parser/text_parser_test.dart
+++ b/test/services/text_parser/text_parser_test.dart
@@ -69,10 +69,10 @@ void main() {
     });
 
     test('should not parse as URLs any text with dot', () {
-      final results = parser.parse('Some dummy text.To test links.to test links');
+      final results = parser.parse('Some dummy text.To test links.asd test links');
 
       expect(results.length, equals(1));
-      expect(results[0].text, equals('Some dummy text.To test links.to test links'));
+      expect(results[0].text, equals('Some dummy text.To test links.asd test links'));
     });
 
     test('should parse www-prefixed URLs correctly', () {
@@ -130,6 +130,17 @@ void main() {
       expect(results[2].text, equals('.no questions'));
 
       expect(results.length, 3);
+    });
+
+    test('should parse URLs with dots in domain correctly', () {
+      final results = parser.parse('Visit https://ion.onelink.me/f1Pi/4yqm2bwx');
+
+      expect(results.length, equals(2));
+      expect(results[0].text, equals('Visit '));
+      expect(results[1].text, equals('https://ion.onelink.me/f1Pi/4yqm2bwx'));
+      expect(results[1].matcher, isA<UrlMatcher>());
+
+      expect(results.length, 2);
     });
 
     test('should parse mixed content correctly', () {


### PR DESCRIPTION
## Description
- generate lib/generated/tlds_group.dart with list of all TLDs downloaded from latest https://data.iana.org/TLD/tlds-alpha-by-domain.txt;
- unfocus sign up passkey form before verify identity pop up to get rid of flickering;


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Chore

## Screenshots

https://github.com/user-attachments/assets/f857bf3f-adb9-4ff6-88f7-11e275758595

 (if applicable)

