### PR TITLE
fix: routing issue when user cancels sharing a post

### DIFF
--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -76,8 +76,12 @@ class _SharePostButton extends HookConsumerWidget {
       item: type,
       onTap: () async {
         await CreatePostRoute().push<void>(context);
-        if (context.mounted) {
-          context.pop();
+        if (context.mounted && context.canPop()) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              context.pop();
+            }
+          });
         }
       },
       index: index,

--- a/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
+++ b/lib/app/features/feed/views/pages/feed_main_modal/feed_main_modal_page.dart
@@ -131,42 +131,51 @@ class _ShareVideoButton extends HookConsumerWidget {
       permissionType: Permission.photos,
       onGranted: () async {
         Future<void> showMediaPickerAndCreatePost() async {
-          final result = await showSimpleBottomSheet<List<MediaFile>>(
+          await showSimpleBottomSheet<List<MediaFile>>(
             context: context,
-            child: const MediaPickerPage(
+            child: MediaPickerPage(
               maxSelection: 1,
               isBottomSheet: true,
               type: MediaPickerType.video,
-            ),
-          );
+              onSelectCallback: (result) async {
+                if (context.mounted) {
+                  if (result.isNotEmpty) {
+                    final editedMedia = await ref.read(
+                      editMediaProvider(
+                        result[0],
+                        maxVideoDuration: VideoConstants.feedVideoMaxDuration,
+                      ).future,
+                    );
+                    if (!context.mounted) return;
+                    if (editedMedia == null) {
+                      return;
+                    } else {
+                      final finishEditing = await CreateVideoRoute(
+                        videoPath: editedMedia.path,
+                        videoThumbPath: editedMedia.thumb,
+                        mimeType: result[0].mimeType ?? '',
+                      ).push<bool?>(context);
 
-          if (context.mounted) {
-            if (result != null && result.isNotEmpty) {
-              final editedMedia = await ref.read(
-                editMediaProvider(
-                  result[0],
-                  maxVideoDuration: VideoConstants.feedVideoMaxDuration,
-                ).future,
-              );
-              if (!context.mounted) return;
-              if (editedMedia == null) {
-                context.pop();
-              } else {
-                await CreateVideoRoute(
-                  videoPath: editedMedia.path,
-                  videoThumbPath: editedMedia.thumb,
-                  mimeType: result[0].mimeType ?? '',
-                ).push<void>(context);
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (context.mounted) {
+                      if (finishEditing.falseOrValue) {
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (context.mounted) {
+                            context.pop();
+                          }
+                        });
+                      }
+                    }
+                  } else {
                     context.pop();
                   }
-                });
-              }
-            } else {
+                }
+              },
+            ),
+          );
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
               context.pop();
             }
-          }
+          });
         }
 
         await showMediaPickerAndCreatePost();

--- a/lib/app/features/gallery/views/pages/media_picker_page.dart
+++ b/lib/app/features/gallery/views/pages/media_picker_page.dart
@@ -22,12 +22,13 @@ import 'package:ion/app/services/media_service/media_service.m.dart';
 class MediaPickerPage extends HookConsumerWidget {
   const MediaPickerPage({
     required this.maxSelection,
+    super.key,
     this.type = MediaPickerType.common,
     this.title,
     this.isBottomSheet = false,
     this.maxVideoDurationInSeconds,
     this.showCameraCell = true,
-    super.key,
+    this.onSelectCallback,
   });
 
   final int maxSelection;
@@ -36,6 +37,7 @@ class MediaPickerPage extends HookConsumerWidget {
   final bool isBottomSheet;
   final int? maxVideoDurationInSeconds;
   final bool showCameraCell;
+  final void Function(List<MediaFile> media)? onSelectCallback;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -52,11 +54,16 @@ class MediaPickerPage extends HookConsumerWidget {
       if (maxSelection == 1 && value.selectedMedia.isNotEmpty == true) {
         // this is need to avoid this callback running too early, before the previous screen
         // is closed
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (context.mounted) {
-            Navigator.of(context).pop(value.selectedMedia);
-          }
-        });
+        if (onSelectCallback == null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              Navigator.of(context).pop(value.selectedMedia);
+            }
+          });
+        } else {
+          onSelectCallback!(value.selectedMedia);
+          ref.invalidate(mediaSelectionNotifierProvider);
+        }
       }
     });
 


### PR DESCRIPTION
## Description
Fixes a routing issue that occurred when the user entered content in the share modal but then canceled. The app now correctly closes the modal and stays on the current tab without unintended navigation.

## Additional Notes
- keep media picker open after canceling banuba edit

## Task ID
3322-3439

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)

https://github.com/user-attachments/assets/41a5728c-e6c8-4a50-8bff-4884bd03403e


