### PR TITLE
fix: enable followed and unfollowed state for follow button in story viewer

### DIFF
--- a/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
+++ b/lib/app/features/feed/stories/views/components/story_viewer/components/header/story_context_menu.dart
@@ -14,6 +14,7 @@ import 'package:ion/app/features/feed/stories/providers/story_pause_provider.r.d
 import 'package:ion/app/features/feed/views/pages/entity_delete_confirmation_modal/entity_delete_confirmation_modal.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/header/context_menu_item.dart';
 import 'package:ion/app/features/user/pages/profile_page/components/header/context_menu_item_divider.dart';
+import 'package:ion/app/features/user/providers/follow_list_provider.r.dart';
 import 'package:ion/app/features/user/providers/report_notifier.m.dart';
 import 'package:ion/app/router/utils/show_simple_bottom_sheet.dart';
 import 'package:ion/generated/assets.gen.dart';
@@ -161,6 +162,7 @@ class _OtherUserMenuItems extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final i18n = context.i18n;
     final isMuted = ref.watch(globalMuteNotifierProvider);
+    final following = ref.watch(isCurrentUserFollowingSelectorProvider(pubkey));
 
     ref.displayErrors(reportNotifierProvider);
 
@@ -187,14 +189,20 @@ class _OtherUserMenuItems extends ConsumerWidget {
         ),
         const ContextMenuItemDivider(),
         ContextMenuItem(
-          label: i18n.button_unfollow,
-          iconAsset: Assets.svg.iconCategoriesUnflow,
+          label: following ? context.i18n.button_unfollow : context.i18n.button_follow,
+          iconAsset: following ? Assets.svg.iconCategoriesUnflow : Assets.svg.iconSearchFollow,
           onPressed: () {
             onClose();
-            showSimpleBottomSheet<void>(
-              context: context,
-              child: UnfollowUserModal(pubkey: pubkey),
-            );
+            if (following) {
+              showSimpleBottomSheet<void>(
+                context: context,
+                child: UnfollowUserModal(
+                  pubkey: pubkey,
+                ),
+              );
+            } else {
+              ref.read(followListManagerProvider.notifier).toggleFollow(pubkey);
+            }
           },
         ),
       ],


### PR DESCRIPTION
## Description
This PR fixes an issue where follow button on story viewer could only be used for unfollowing. It was updated to support both following and unfollowing.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
<!-- Add corresponding task ID here. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
