### PR TITLE
fix: exclude unreachable relays after ranking

### DIFF
--- a/lib/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart
+++ b/lib/app/features/core/providers/ion_connect_media_url_fallback_provider.r.dart
@@ -27,7 +27,7 @@ class IONConnectMediaUrlFallback extends _$IONConnectMediaUrlFallback {
     // TODO: the fallback relays should be taken from the user with `authorPubkey` relays, so userRelayProvider(authorPubkey)
     // + if the fallback doesn't work we need to take the relays from the identity and persist those
     final userRelays = await ref.read(rankedCurrentUserRelaysProvider.future);
-    if (userRelays == null) {
+    if (userRelays.isEmpty) {
       return null;
     }
 

--- a/lib/app/features/ion_connect/providers/relays/relay_picker_provider.r.dart
+++ b/lib/app/features/ion_connect/providers/relays/relay_picker_provider.r.dart
@@ -138,7 +138,7 @@ class RelayPicker extends _$RelayPicker {
 
   Future<List<UserRelay>> _getCurrentUserRankedRelays() async {
     final relays = await ref.read(rankedCurrentUserRelaysProvider.future);
-    if (relays == null || relays.isEmpty) {
+    if (relays.isEmpty) {
       throw UserRelaysNotFoundException();
     }
     return relays;

--- a/lib/app/features/ion_connect/utils/file_storage_utils.dart
+++ b/lib/app/features/ion_connect/utils/file_storage_utils.dart
@@ -38,7 +38,7 @@ Future<String> getFileStorageApiUrl(
   CancelToken? cancelToken,
 }) async {
   final userRelays = await ref.read(rankedCurrentUserRelaysProvider.future);
-  if (userRelays == null || userRelays.isEmpty) {
+  if (userRelays.isEmpty) {
     throw UserRelaysNotFoundException();
   }
   final relayUrl = userRelays.first.url;


### PR DESCRIPTION
## Description
This PR excludes unreachable relays from the list of ranked and relevant relays.

## Additional Notes
<!-- Add any extra context or relevant information here. -->

## Task ID
3463

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore

## Screenshots (if applicable)
<!-- Include screenshots to demonstrate any UI changes. -->
<!-- <img width="180" alt="image" src="image_url_here"> -->
