### PR TITLE
fix: remove image precache from the CoinsGroupItem

### DIFF
--- a/lib/app/features/wallets/views/components/coins_list/coin_item.dart
+++ b/lib/app/features/wallets/views/components/coins_list/coin_item.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ion/app/components/coins/coin_icon.dart';
 import 'package:ion/app/components/list_item/list_item.dart';
@@ -10,10 +9,8 @@ import 'package:ion/app/extensions/extensions.dart';
 import 'package:ion/app/features/wallets/model/coins_group.f.dart';
 import 'package:ion/app/features/wallets/providers/wallet_user_preferences/user_preferences_selectors.r.dart';
 import 'package:ion/app/features/wallets/views/components/coins_list/unseen_transaction_indicator.dart';
-import 'package:ion/app/features/wallets/views/pages/coins_flow/coin_details/providers/network_selector_notifier.r.dart';
 import 'package:ion/app/features/wallets/views/utils/crypto_formatter.dart';
 import 'package:ion/app/utils/num.dart';
-import 'package:ion/app/utils/precache_pictures.dart';
 import 'package:ion/generated/assets.gen.dart';
 
 class CoinsGroupItem extends HookConsumerWidget {
@@ -31,19 +28,6 @@ class CoinsGroupItem extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isBalanceVisible = ref.watch(isBalanceVisibleSelectorProvider);
-
-    final icons = ref.read(networkSelectorNotifierProvider(symbolGroup: coinsGroup.symbolGroup));
-
-    useEffect(
-      () {
-        if (icons != null) {
-          precachePictures(icons.items.map((item) => item.image));
-        }
-
-        return null;
-      },
-      [icons],
-    );
 
     return ListItem(
       key: Key(coinsGroup.symbolGroup),


### PR DESCRIPTION
## Description
`CoinsGroupItem` is used on different pages, like `Receive coins`, `Send coins` modals, etc. These pages have a search. For example, a user would paste the word "ice" in the search and see 100 different coins with the word "ice" in the name, symbol, or something else.

Because of the line
`ref.read(networkSelectorNotifierProvider(symbolGroup: coinsGroup.symbolGroup));`
for each of these 100 coins
`ref.watch(syncedCoinsBySymbolGroupProvider(symbolGroup));`
would be triggered, which would result in the mobile client making hundreds (or thousands) of requests in one session.

## Task ID
ION-3460

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore
